### PR TITLE
[RNDPOSTGRES-60] Partial configuration environments support

### DIFF
--- a/cmd/stroppy/commands/root.go
+++ b/cmd/stroppy/commands/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stroppy-io/stroppy/cmd/stroppy/commands/config"
 	"github.com/stroppy-io/stroppy/cmd/stroppy/commands/gen"
 	"github.com/stroppy-io/stroppy/cmd/stroppy/commands/run"
+	int_config "github.com/stroppy-io/stroppy/internal/config"
 	"github.com/stroppy-io/stroppy/internal/version"
 )
 
@@ -32,6 +33,20 @@ var versionCmd = &cobra.Command{ //nolint: gochecknoglobals
 	},
 }
 
+var envsCmd = &cobra.Command{ //nolint: gochecknoglobals
+	Use:   "envs",
+	Short: "Print envs to override config",
+	Long:  ``,
+	Run: func(_ *cobra.Command, _ []string) {
+		log := logger.Global().WithOptions(zap.WithCaller(false))
+		names := int_config.ValidEnvsNames()
+
+		for _, name := range names {
+			log.Info(name)
+		}
+	},
+}
+
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
@@ -45,6 +60,7 @@ func init() { //nolint: gochecknoinits // allow in cmd
 	rootCmd.SetVersionTemplate(`{{with .Name}}{{printf "%s " .}}{{end}}{{printf "%s" .Version}}`)
 
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(envsCmd)
 	rootCmd.AddCommand(config.TopLevelCommand)
 	rootCmd.AddCommand(run.Cmd)
 	rootCmd.AddCommand(gen.Cmd)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.3
 require (
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	github.com/stroppy-io/stroppy-core v0.0.1
 	github.com/thediveo/enumflag v0.10.1
 	go.uber.org/zap v1.27.0
@@ -13,6 +14,7 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
@@ -25,6 +27,7 @@ require (
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.38.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
@@ -34,4 +37,5 @@ require (
 	golang.org/x/text v0.26.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a // indirect
 	google.golang.org/grpc v1.74.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,11 @@ func LoadAndValidateConfig(runConfigPath string, validatePaths bool) (*Config, e
 		return nil, fmt.Errorf("failed to load run config: %w", err)
 	}
 
+	err = updateConfigWithDirectEnvs(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to override config with envs: %w", err)
+	}
+
 	err = config.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate run config: %w", err)

--- a/internal/config/read_envs.go
+++ b/internal/config/read_envs.go
@@ -1,0 +1,185 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/stroppy-io/stroppy-core/pkg/logger"
+	stroppy "github.com/stroppy-io/stroppy-core/pkg/proto"
+)
+
+type visitorInFunc func(
+	msg protoreflect.Message,
+	field protoreflect.FieldDescriptor,
+	value protoreflect.Value,
+)
+type visitorOutFunc func(
+	msg protoreflect.Message,
+	field protoreflect.FieldDescriptor,
+	value protoreflect.Value,
+)
+
+var ErrUnsupportedFieldKind = errors.New("unsupported field kind")
+
+func traverseMessage(
+	msg protoreflect.Message,
+	inFunc visitorInFunc,
+	outFunc visitorOutFunc,
+) {
+	md := msg.Descriptor()
+
+	fields := md.Fields()
+	for i := range fields.Len() {
+		field := fields.Get(i)
+
+		value := msg.Get(field)
+		// TODO: add support for List[Message], Map, probably Enums
+		if (field.Kind() == protoreflect.MessageKind && !(field.IsList() || field.IsMap())) ||
+			field.Kind() != protoreflect.MessageKind && !field.IsMap() {
+			inFunc(msg, field, value)
+
+			if field.Kind() == protoreflect.MessageKind {
+				traverseMessage(value.Message(), inFunc, outFunc)
+			}
+
+			outFunc(msg, field, value)
+		}
+	}
+}
+
+func updateConfigWithDirectEnvs(config *stroppy.Config) error {
+	var errTotal error
+
+	log := logger.Global().WithOptions(zap.WithCaller(false))
+
+	confPath := []string{"CONFIG"}
+
+	traverseMessage(config.ProtoReflect(),
+		func(msg protoreflect.Message, field protoreflect.FieldDescriptor, value protoreflect.Value) {
+			confPath = append(confPath, field.TextName())
+			// TODO: add support for lists of premitives at least
+			if field.Kind() != protoreflect.MessageKind && !field.IsList() {
+				envName := strings.Join(confPath, "__")
+				envName = strings.ToUpper(envName)
+
+				if newValueString, exists := os.LookupEnv(envName); exists {
+					log.Debug("Config overridden",
+						zap.String("env", envName),
+						zap.String("old_value", value.String()),
+						zap.String("new_value", newValueString),
+					)
+
+					newValue, err := convertStringToProtoValue(newValueString, field.Kind())
+					if err != nil {
+						errTotal = errors.Join(errTotal, fmt.Errorf(`env "%s" value "%s" is invalid: %w`, envName, newValueString, err))
+
+						return
+					}
+
+					msg.Set(field, newValue)
+				}
+			}
+		},
+		func(_ protoreflect.Message, _ protoreflect.FieldDescriptor, _ protoreflect.Value) {
+			confPath = confPath[:len(confPath)-1]
+		})
+
+	return errTotal
+}
+
+func ValidEnvsNames() []string {
+	config := protoNew[*stroppy.Config]()
+
+	var envs []string
+	// TODO: deduplicate algorithm here and in updateConfigWithDirectEnvs somehow
+	confPath := []string{"CONFIG"}
+
+	traverseMessage(config.ProtoReflect(),
+		func(_ protoreflect.Message, field protoreflect.FieldDescriptor, _ protoreflect.Value) {
+			confPath = append(confPath, field.TextName())
+			// TODO: add support for lists of premitives at least
+			if field.Kind() != protoreflect.MessageKind && !field.IsList() {
+				envName := strings.Join(confPath, "__")
+				envName = strings.ToUpper(envName)
+				envs = append(envs, envName)
+			}
+		},
+		func(_ protoreflect.Message, _ protoreflect.FieldDescriptor, _ protoreflect.Value) {
+			confPath = confPath[:len(confPath)-1]
+		})
+
+	return envs
+}
+
+func convertStringToProtoValue(value string, kind protoreflect.Kind) (protoreflect.Value, error) {
+	switch kind {
+	case protoreflect.StringKind:
+		return protoreflect.ValueOfString(value), nil
+
+	case protoreflect.BoolKind:
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return protoreflect.Value{}, err
+		}
+
+		return protoreflect.ValueOfBool(b), nil
+
+	case protoreflect.Int32Kind:
+		i, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return protoreflect.Value{}, err
+		}
+
+		return protoreflect.ValueOfInt32(int32(i)), nil
+
+	case protoreflect.Int64Kind:
+		i, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return protoreflect.Value{}, err
+		}
+
+		return protoreflect.ValueOfInt64(i), nil
+
+	case protoreflect.Uint32Kind:
+		i, err := strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return protoreflect.Value{}, err
+		}
+
+		return protoreflect.ValueOfUint32(uint32(i)), nil
+
+	case protoreflect.Uint64Kind:
+		i, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return protoreflect.Value{}, err
+		}
+
+		return protoreflect.ValueOfUint64(i), nil
+
+	case protoreflect.FloatKind:
+		f, err := strconv.ParseFloat(value, 32)
+		if err != nil {
+			return protoreflect.Value{}, err
+		}
+
+		return protoreflect.ValueOfFloat32(float32(f)), nil
+
+	case protoreflect.DoubleKind:
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return protoreflect.Value{}, err
+		}
+
+		return protoreflect.ValueOfFloat64(f), nil
+
+	default:
+		return protoreflect.Value{},
+			fmt.Errorf("%w: %s", ErrUnsupportedFieldKind, kind)
+	}
+}

--- a/internal/config/read_envs_test.go
+++ b/internal/config/read_envs_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestMutateConfigByEnvs(t *testing.T) {
+	testVersion := "123.0.0"
+	testPath := "./path/to/stroppy-postgres"
+
+	t.Setenv("CONFIG__VERSION", testVersion)
+	t.Setenv("CONFIG__RUN__DRIVER__DRIVER_PLUGIN_PATH", testPath)
+
+	cfg := NewExampleConfig()
+
+	updateConfigWithDirectEnvs(cfg)
+
+	require.Equal(t, cfg.Version, testVersion)
+	require.Equal(t, cfg.Run.Driver.DriverPluginPath, testPath)
+}
+
+func Example_updateConfigWithDirectEnvs() { //nolint: testableexamples // not reproduceble
+	cfg := NewExampleConfig()
+
+	var names []string
+
+	traverseMessage(cfg.ProtoReflect(),
+		func(msg protoreflect.Message, field protoreflect.FieldDescriptor, value protoreflect.Value) {
+			names = append(names, field.JSONName())
+
+			if field.Kind() != protoreflect.MessageKind {
+				var isListStr string
+				if field.IsList() {
+					isListStr = "[]"
+				}
+
+				fmt.Printf("%v :: %s%s :: %s \n", names, isListStr, field.Kind().String(), value.String())
+
+				if field.Kind() == protoreflect.StringKind && !field.IsList() {
+					msg.Set(field, protoreflect.ValueOfString("Mutated value"))
+				}
+			}
+		},
+		func(_ protoreflect.Message, _ protoreflect.FieldDescriptor, _ protoreflect.Value) {
+			names = names[:len(names)-1]
+		})
+
+	traverseMessage(cfg.ProtoReflect(),
+		func(_ protoreflect.Message, field protoreflect.FieldDescriptor, value protoreflect.Value) {
+			names = append(names, field.JSONName())
+
+			if field.Kind() != protoreflect.MessageKind {
+				var isListStr string
+				if field.IsList() {
+					isListStr = "[]"
+				}
+
+				fmt.Printf("%v :: %s%s :: %s \n", names, isListStr, field.Kind().String(), value.String())
+			}
+		},
+		func(_ protoreflect.Message, _ protoreflect.FieldDescriptor, _ protoreflect.Value) {
+			names = names[:len(names)-1]
+		})
+}


### PR DESCRIPTION
# Pull Request

## Description of Changes
Added new step to config loading.
After reading configuration from json/yaml file, Stroppy will check some environment variables.
Full list of supported envs available by `stroppy envs` subcommand.

```
CONFIG__VERSION
CONFIG__RUN__RUN_ID
CONFIG__RUN__SEED
CONFIG__RUN__DRIVER__DRIVER_PLUGIN_PATH
CONFIG__RUN__DRIVER__URL
CONFIG__RUN__GO_EXECUTOR__GO_MAX_PROC
CONFIG__RUN__GO_EXECUTOR__CANCEL_ON_ERROR
CONFIG__RUN__K6_EXECUTOR__K6_BINARY_PATH
CONFIG__RUN__K6_EXECUTOR__K6_SCRIPT_PATH
CONFIG__RUN__K6_EXECUTOR__K6_SETUP_TIMEOUT__SECONDS
CONFIG__RUN__K6_EXECUTOR__K6_SETUP_TIMEOUT__NANOS
CONFIG__RUN__K6_EXECUTOR__K6_VUS
CONFIG__RUN__K6_EXECUTOR__K6_MAX_VUS
CONFIG__RUN__K6_EXECUTOR__K6_RATE
CONFIG__RUN__K6_EXECUTOR__K6_DURATION__SECONDS
CONFIG__RUN__K6_EXECUTOR__K6_DURATION__NANOS
CONFIG__RUN__K6_EXECUTOR__OTLP_EXPORT__OTLP_GRPC_ENDPOINT
CONFIG__RUN__K6_EXECUTOR__OTLP_EXPORT__OTLP_METRICS_PREFIX
CONFIG__RUN__LOGGER__LOG_LEVEL
CONFIG__RUN__LOGGER__LOG_MODE
CONFIG__BENCHMARK__NAME
```

Now supported only configuration field accessible directly (without nested Lists or Maps).

## Motivation and Context
For example if config file baked into dockerfile, now it's possible to override some params. 

## How Has This Been Tested?
Config loading is already stable.
For config values overriding `strpoppy/internal/config/read_envs_test.go` tests written.

## Type of Changes
- [ ] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [ ] Refactoring
- [ ] Other

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] I have checked build and tests
- [ ] I have updated documentation if needed 