### PR TITLE
[RNDPOSTGRES-69] fix tiny CLI issues

### DIFF
--- a/cmd/stroppy/commands/config/config_new.go
+++ b/cmd/stroppy/commands/config/config_new.go
@@ -34,7 +34,7 @@ var NewConfigCmd = &cobra.Command{ //nolint: gochecknoglobals
 		if err != nil {
 			return err
 		}
-		configName, err := cmd.Flags().GetString(configFlagName)
+		configName, err := cmd.Flags().GetString(configNewNameFlagName)
 		if err != nil {
 			return err
 		}
@@ -92,6 +92,4 @@ func init() { //nolint: gochecknoinits // allow in cmd
 		configNewFormatFlagName,
 		"output config format, json or yaml",
 	)
-
-	NewConfigCmd.PersistentFlags().Lookup(configNewFormatFlagName).NoOptDefVal = config.FormatJSON.String()
 }

--- a/cmd/stroppy/commands/config/config_new.go
+++ b/cmd/stroppy/commands/config/config_new.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -17,10 +18,11 @@ import (
 const (
 	configNewWorkdirFlagName = "workdir"
 	configNewFormatFlagName  = "format"
+	configNewNameFlagName    = "name"
 )
 
 var NewConfigCmd = &cobra.Command{ //nolint: gochecknoglobals
-	Use:   "new --output <output>",
+	Use:   fmt.Sprintf("new --%s <dirpath>", configNewWorkdirFlagName),
 	Short: "Generate default stroppy config",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -32,10 +34,14 @@ var NewConfigCmd = &cobra.Command{ //nolint: gochecknoglobals
 		if err != nil {
 			return err
 		}
+		configName, err := cmd.Flags().GetString(configFlagName)
+		if err != nil {
+			return err
+		}
 
 		example := config.NewExampleConfig()
 
-		runConfStr, err := MarshalConfig(example, format.FormatConfigName(DefaultConfigName))
+		runConfStr, err := MarshalConfig(example, format.FormatConfigName(configName))
 		if err != nil {
 			return err
 		}
@@ -46,7 +52,7 @@ var NewConfigCmd = &cobra.Command{ //nolint: gochecknoglobals
 		}
 
 		err = os.WriteFile(
-			path.Join(output, format.FormatConfigName(DefaultConfigName)),
+			path.Join(output, format.FormatConfigName(configName)),
 			runConfStr,
 			common.FileMode,
 		)
@@ -56,7 +62,7 @@ var NewConfigCmd = &cobra.Command{ //nolint: gochecknoglobals
 
 		logger.Global().WithOptions(zap.WithCaller(false)).Info("Config generated! Happy benchmarking!", zap.String(
 			"config_path",
-			path.Join(output, format.FormatConfigName(DefaultConfigName)),
+			path.Join(output, format.FormatConfigName(configName)),
 		))
 
 		return nil
@@ -70,6 +76,11 @@ func init() { //nolint: gochecknoinits // allow in cmd
 		configNewWorkdirFlagName,
 		DefaultWorkdirPath,
 		"work directory",
+	)
+	NewConfigCmd.PersistentFlags().String(
+		configNewNameFlagName,
+		DefaultConfigName,
+		"name of the config file",
 	)
 	NewConfigCmd.PersistentFlags().Var(
 		enumflag.New(

--- a/cmd/stroppy/commands/config/config_validate.go
+++ b/cmd/stroppy/commands/config/config_validate.go
@@ -77,9 +77,4 @@ func init() { //nolint: gochecknoinits // allow in cmd
 		false,
 		"set version in config to current version",
 	)
-
-	err := validateCmd.MarkPersistentFlagRequired(configFlagName)
-	if err != nil {
-		panic(err)
-	}
 }

--- a/cmd/stroppy/commands/gen/new.go
+++ b/cmd/stroppy/commands/gen/new.go
@@ -140,6 +140,4 @@ func init() { //nolint: gochecknoinits // allow in cmd
 		false,
 		"generate dev environment, includes package.json, Makefile.dev and ts requirements",
 	)
-
-	Cmd.PersistentFlags().Lookup(configNewFormatFlagName).NoOptDefVal = config.FormatJSON.String()
 }

--- a/cmd/stroppy/commands/gen/new.go
+++ b/cmd/stroppy/commands/gen/new.go
@@ -1,9 +1,11 @@
 package gen
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
@@ -84,17 +86,27 @@ k6 script template, ts requirements and Makefile for run.
 			return fmt.Errorf("failed to get self binary path: %w", err) //nolint: err113
 		}
 
+		pathToWriteItself := path.Join(output, "stroppy")
+		absTo, errTo := filepath.Abs(filepath.Clean(pathToWriteItself))
+		absFrom, errFrom := filepath.Abs(filepath.Clean(execPath))
+		if err = cmp.Or(errTo, errFrom); err != nil {
+			return err
+		}
+		if absTo == absFrom {
+			return nil // executable already in correct place
+		}
+
 		execBin, err := os.ReadFile(execPath)
 		if err != nil {
 			return fmt.Errorf("failed to read self binary file: %w", err) //nolint: err113
 		}
 
-		err = os.WriteFile(path.Join(output, "stroppy"), execBin, common.FileMode)
+		err = os.WriteFile(pathToWriteItself, execBin, common.FileMode)
 		if err != nil {
 			return fmt.Errorf("failed to write self binary file: %w", err)
 		}
 
-		err = os.Chmod(path.Join(output, "stroppy"), common.FolderMode)
+		err = os.Chmod(pathToWriteItself, common.FolderMode)
 		if err != nil {
 			return fmt.Errorf("failed to chmod self binary file: %w", err)
 		}


### PR DESCRIPTION
# Pull Request

## Description of Changes
1. Improved `stroppy config new`:
   - Usage information now matches actual behavior.  
   - Added the `--name` flag to specify the configuration file name.  
   - Previously ignored `--format` option is now fully supported: both `json` and `yaml` formats work correctly.  

2. Updated `stroppy config validate`:
   - The `--config` flag is no longer required since Stroppy assumes the current working directory by default.  

3. Fixed `./stroppy new`:
   - It no longer overwrites the existing `./stroppy` binary.  

4. Updated `stroppy new`:
   - Previously ignored `--format` option is now fully supported: both `json` and `yaml` formats work correctly.  

## Motivation and Context
These changes improve the user experience by making Stroppy more consistent and less frustrating to use.


## How Has This Been Tested?
Commands was tested manually.

## Type of Changes
- [x] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [ ] Refactoring
- [ ] Other

## Checklist
- [ ] I have read the CONTRIBUTING.md
- [x] I have checked build and tests
- [x] I have updated documentation if needed