### PR TITLE
xk6 process start refactors

### DIFF
--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -1,7 +1,15 @@
 package xk6
 
 import (
+	"context"
+	"os"
+
+	"github.com/stroppy-io/stroppy/pkg/common/logger"
+	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto"
+	"github.com/stroppy-io/stroppy/pkg/common/unit_queue"
+	"github.com/stroppy-io/stroppy/pkg/driver"
 	"go.k6.io/k6/js/modules"
+	"go.uber.org/zap"
 )
 
 // RootModule global object, runs with k6 process
@@ -14,5 +22,45 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance { //nolin
 var _ modules.Module = new(RootModule)
 
 func init() { //nolint:gochecknoinits // allow for xk6
+	lg := logger.NewFromEnv().
+		Named(pluginLoggerName).
+		WithOptions(zap.AddCallerSkip(1))
+
+	runContextBytes, ok := os.LookupEnv("context")
+	if !ok {
+		lg.Fatal("no context provided, fatal error")
+	}
+
+	runContext, err := Serialized[*stroppy.StepContext](runContextBytes).Unmarshal()
+	if err != nil {
+		lg.Fatal("can't deserialize step context", zap.Error(err))
+	}
+
+	lg.Debug("xk6 module init", zap.Uint64("seed", runContext.GetConfig().GetSeed()))
+
+	processCtx := context.Background()
+
+	drv := driver.Dispatch(lg, runContext.GetConfig().GetDriver())
+
+	err = drv.Initialize(processCtx, runContext)
+	if err != nil {
+		lg.Fatal("driver isn't initialized", zap.Error(err))
+	}
+
+	// TODO: solve limits and buffers with k6 scenario config from runContext.GetExecutor().GetK6().GetScenario().GetExecutor()
+	queue := unit_queue.NewQueue(drv.GenerateNextUnit, 0, 1)
+	for _, u := range runContext.GetWorkload().GetUnits() {
+		queue.PrepareGenerator(u.GetDescriptor_(), 1, uint(u.GetCount()))
+	}
+
+	queue.StartGeneration(processCtx)
+
+	runPtr = newRuntimeContext(
+		drv,
+		lg,
+		runContext,
+		queue,
+	)
+
 	modules.Register("k6/x/stroppy", new(RootModule))
 }

--- a/internal/runner/k6.go
+++ b/internal/runner/k6.go
@@ -23,10 +23,8 @@ import (
 func runK6Binary(
 	_ context.Context,
 	lg *zap.Logger,
-	workdir string,
-	binaryPath string,
-	args []string,
-	envs []string,
+	workdir, binaryPath string,
+	args, envs []string,
 ) error {
 	binExec := exec.Cmd{
 		Env:  envs,
@@ -140,11 +138,12 @@ func RunStepInK6(
 
 // k6ArgsOtelExport setups k6 OpenTelemetry exporter.
 // Docs: https://grafana.com/docs/k6/latest/results-output/real-time/opentelemetry/#opentelemetry
+//
+//nolint:nonamedreturns // an unnamed returns are confusing and trigers other linter
 func k6ArgsOtelExport(
 	runContext *stroppy.StepContext,
-	baseArgs []string,
-	envs []string,
-) ([]string, []string) {
+	baseArgs, envs []string,
+) (argsOut, envsOut []string) {
 	export := runContext.GetExporter().GetOtlpExport()
 	if export == nil {
 		return baseArgs, envs

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -80,6 +80,12 @@ func SetLoggerEnv(level zapcore.Level, mod LogMod) {
 	os.Setenv(envLogLevel, strings.ToLower(level.String()))
 	os.Setenv(envLogMod, strings.ToLower(string(mod)))
 }
+func PrepareLoggerEnvs(level zapcore.Level, mod LogMod) []string {
+	return []string{
+		envLogLevel + "=" + strings.ToLower(level.String()),
+		envLogMod + "=" + strings.ToLower(string(mod)),
+	}
+}
 
 func NewFromEnv(opts ...zap.Option) *zap.Logger {
 	cfg := &Config{

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -80,6 +80,7 @@ func SetLoggerEnv(level zapcore.Level, mod LogMod) {
 	os.Setenv(envLogLevel, strings.ToLower(level.String()))
 	os.Setenv(envLogMod, strings.ToLower(string(mod)))
 }
+
 func PrepareLoggerEnvs(level zapcore.Level, mod LogMod) []string {
 	return []string{
 		envLogLevel + "=" + strings.ToLower(level.String()),


### PR DESCRIPTION
# Pull Request

## Description of Changes
1) Previously environment variables been passed to the k6 sub-process by setting it to parent stroppy-cli process and inheritance.
    Now they passed directly to a sub-process.
2) xk6 module setup was implemented by passing context string to js-script and then to the module with `setup(context)` in the process of the first VU.
    Now stroppy sets proper environment variable for k6 process and k6 module gets the context directly at module initialization stage (before any VU).

## Motivation and Context
Simplification of code base.

## How Has This Been Tested?
Manually.

## Type of Changes
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [x] Refactoring
- [ ] Other

## Checklist
- [ ] I have read the CONTRIBUTING.md
- [x] I have checked build and tests
- [ ] I have updated documentation if needed