### PR TITLE
[RNDSTROPPY-88]: query rows values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,14 @@ Four variants available via `Generation.Rule.kind` in the proto:
 
 Generator factory entry point: `NewValueGeneratorByRule` in `pkg/common/generate/value.go`.
 
+### Go Exploration
+
+- Use `go doc` to quickly inspect interfaces, structs, and function signatures. Examples:
+  - `go doc github.com/jackc/pgx/v5.Rows` — show the pgx Rows interface
+  - `go doc github.com/pashagolub/pgxmock/v4 NewPool` — show pgxmock constructor
+  - `go doc ./pkg/driver Rows` — show a local interface
+- Prefer `go doc` over searching source files for type/interface definitions — it's faster and gives clean output.
+
 ### Build System
 
 - `make build` - Builds k6 with xk6air extension via xk6

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ revision: # Recreate git tag with version tag=<semver>
 ## Local K6 fast tests
 ##
 
-.PHONY: run-simple-test run-tpcb-test run-tpcc-test run-tpcds-test .rm-dev
+.PHONY: run-simple-test run-tpcb-test run-tpcc-test run-tpcds-test run-sqlapi-test .rm-dev
 
 WORKDIR=dev
 
@@ -298,6 +298,9 @@ run-tpcc-test: .rm-dev
 run-tpcds-test: .rm-dev
 	./build/stroppy gen --workdir $(WORKDIR) --preset=tpcds
 	cd $(WORKDIR) && ./stroppy run tpcds.ts tpcds-scale-1.sql
+
+run-sqlapi-test: # Run SQL API integration tests
+	./build/stroppy run workloads/tests/sqlapi_test.ts
 
 ##
 ## TypeScript Development

--- a/cmd/xk6air/driver_wrapper.go
+++ b/cmd/xk6air/driver_wrapper.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
 	"github.com/stroppy-io/stroppy/pkg/driver"
+	"github.com/stroppy-io/stroppy/pkg/driver/stats"
 	"go.k6.io/k6/js/modules"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -45,28 +46,28 @@ func (d *DriverWrapper) configure() {
 	})
 }
 
-func (d *DriverWrapper) RunQuery(sql string, args map[string]any) any {
+func (d *DriverWrapper) RunQuery(sql string, args map[string]any) (*driver.QueryResult, error) {
 	d.configure()
-	stats, err := d.drv.RunQuery(d.vu.Context(), sql, args)
+	result, err := d.drv.RunQuery(d.vu.Context(), sql, args)
 	if err != nil {
-		return fmt.Errorf("error while executing sql query: %w", err)
+		return nil, fmt.Errorf("error while executing sql query: %w", err)
 	}
-	return stats
+	return result, nil
 }
 
 // InsertValuesBin starts bulk insert blocking operation on driver.
-func (d *DriverWrapper) InsertValuesBin(insertMsg []byte, count int64) any {
+func (d *DriverWrapper) InsertValuesBin(insertMsg []byte, count int64) (*stats.Query, error) {
 	d.configure()
 	var descriptor stroppy.InsertDescriptor
 	err := proto.Unmarshal(insertMsg, &descriptor)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("error while unmarshalling insert descriptor: %w", err)
 	}
 
-	stats, err := d.drv.InsertValues(d.vu.Context(), &descriptor)
+	result, err := d.drv.InsertValues(d.vu.Context(), &descriptor)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("error while executing insert: %w", err)
 	}
 
-	return stats
+	return result, nil
 }

--- a/internal/runner/script_extractor.go
+++ b/internal/runner/script_extractor.go
@@ -232,26 +232,27 @@ func createVM() *js.Runtime {
 	return vm
 }
 
+// for [xk6air.DriverWrapper].
 type driverStub struct{}
 
-func (*driverStub) RunQuery(string, map[string]any) *driver.QueryResult {
+func (*driverStub) RunQuery(string, map[string]any) (*driver.QueryResult, error) {
 	return &driver.QueryResult{
 		Stats: &stats.Query{},
 		Rows:  &rowsStub{},
-	}
+	}, nil
 }
 
-func (*driverStub) InsertValuesBin([]byte, int64) *stats.Query {
-	return &stats.Query{}
+func (*driverStub) InsertValuesBin([]byte, int64) (*stats.Query, error) {
+	return &stats.Query{}, nil
 }
 
 // rowsStub implements driver.Rows for the probe VM.
 type rowsStub struct{}
 
-func (*rowsStub) Columns() []string   { return nil }
+func (*rowsStub) Columns() []string   { return []string{} }
 func (*rowsStub) Next() bool          { return false }
 func (*rowsStub) Values() []any       { return nil }
-func (*rowsStub) ReadAll(int) [][]any { return nil }
+func (*rowsStub) ReadAll(int) [][]any { return [][]any{} }
 func (*rowsStub) Err() error          { return nil }
 func (*rowsStub) Close() error        { return nil }
 

--- a/internal/runner/script_extractor.go
+++ b/internal/runner/script_extractor.go
@@ -20,6 +20,8 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	"github.com/stroppy-io/stroppy/pkg/driver"
+	"github.com/stroppy-io/stroppy/pkg/driver/stats"
 
 	_ "embed"
 )
@@ -232,8 +234,26 @@ func createVM() *js.Runtime {
 
 type driverStub struct{}
 
-func (*driverStub) RunQuery(string, map[string]any) any { return nil }
-func (*driverStub) InsertValuesBin([]byte, int64) any   { return nil }
+func (*driverStub) RunQuery(string, map[string]any) *driver.QueryResult {
+	return &driver.QueryResult{
+		Stats: &stats.Query{},
+		Rows:  &rowsStub{},
+	}
+}
+
+func (*driverStub) InsertValuesBin([]byte, int64) *stats.Query {
+	return &stats.Query{}
+}
+
+// rowsStub implements driver.Rows for the probe VM.
+type rowsStub struct{}
+
+func (*rowsStub) Columns() []string   { return nil }
+func (*rowsStub) Next() bool          { return false }
+func (*rowsStub) Values() []any       { return nil }
+func (*rowsStub) ReadAll(int) [][]any { return nil }
+func (*rowsStub) Err() error          { return nil }
+func (*rowsStub) Close() error        { return nil }
 
 type genStub struct{}
 
@@ -282,9 +302,9 @@ func prepareVMEnvironment(vm *js.Runtime, probeprint *Probeprint) error {
 		{"open", func(string) string { return "" }},
 		{"console", consoleMock(vm)},
 		// k6/metrics
-		{"Trend", dummyWithNoopConstructor(vm)},
-		{"Rate", dummyWithNoopConstructor(vm)},
-		{"Counter", dummyWithNoopConstructor(vm)},
+		{"Trend", metricsDummy(vm)},
+		{"Rate", metricsDummy(vm)},
+		{"Counter", metricsDummy(vm)},
 		// TODO: what if user will use other default modules and their functions?
 
 		// k6/x/stroppy defines
@@ -424,11 +444,12 @@ func spyProxyObject(
 	return proxy
 }
 
-func dummyWithNoopConstructor(rt *js.Runtime) *js.Object {
+func metricsDummy(rt *js.Runtime) *js.Object {
 	src := `
-  function MyDummy() {}
-  MyDummy.prototype.constructor = MyDummy;
-  MyDummy;
+	function MyDummy() {}
+	MyDummy.prototype.constructor = MyDummy;
+	MyDummy.prototype.add = function() {};
+	MyDummy;
 `
 	val, _ := rt.RunString(src)
 

--- a/internal/runner/script_extractor_test.go
+++ b/internal/runner/script_extractor_test.go
@@ -16,43 +16,6 @@ import (
 	"github.com/stroppy-io/stroppy/workloads"
 )
 
-func Test_defaultFunctionExport(t *testing.T) {
-	vm := createVM()
-	vm.RunString(` export default function () {} `)
-	global := vm.GlobalObject()
-	t.Log(global.GetOwnPropertyNames())
-
-	fn := vm.Get("default")
-	t.Log(fn)
-	fnFunc, ok := js.AssertFunction(fn)
-	t.Log(fnFunc, ok)
-}
-
-func Test_defaultFunctionTranspilation(t *testing.T) {
-	vm := createVM()
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "test_file_name.ts")
-	os.WriteFile(
-		filePath,
-		[]byte(` export default function (): void {} `),
-		common.FileMode,
-	)
-
-	jsCode, err := TranspileTypeScript(filePath)
-
-	t.Log(jsCode, err)
-
-	vm.RunString(jsCode)
-
-	global := vm.GlobalObject()
-	t.Log(global.GetOwnPropertyNames())
-
-	fn := vm.Get("test_file_name_default")
-	t.Log(fn)
-	fnFunc, ok := js.AssertFunction(fn)
-	t.Log(fnFunc, ok)
-}
-
 func Test_spyProxyObject(t *testing.T) {
 	vm := createVM()
 	accessedProps := []string{}

--- a/internal/runner/sobek_test.go
+++ b/internal/runner/sobek_test.go
@@ -1,0 +1,142 @@
+package runner
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	js "github.com/grafana/sobek"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stroppy-io/stroppy/internal/common"
+)
+
+// Sobek internal reference tests — understanding how the Go↔JS bridge behaves.
+
+func Test_multipleReturns(t *testing.T) {
+	vm := createVM()
+	vm.Set("my_func", func(a, b int) (c int, d int, str string, err error) {
+		if a < b {
+			return a + b, a * b, "yes", nil
+		} else {
+			return a, b, "no", errors.New("a > b")
+		}
+	})
+	val, err := vm.RunString("my_func(5, 10)")
+	t.Logf("|%T|%T|", val, err)
+	t.Logf("|%v|%v|", val, err)
+
+	val, err = vm.RunString("my_func(10, 5)")
+	t.Logf("|%T|%T|", val, err)
+	t.Logf("|%v|%v|", val, err)
+}
+
+func Test_anyError(t *testing.T) {
+	vm := createVM()
+	vm.Set("my_func", func(a, b int) any {
+		if a < b {
+			return a + b
+		} else {
+			return errors.New("a > b")
+		}
+	})
+	val, err := vm.RunString("my_func(5, 10)")
+	t.Logf("|%T|%v|%T|", val, val.ExportType(), err)
+	t.Logf("|%v|%v|", val, err)
+
+	val, err = vm.RunString("my_func(10, 5)")
+	t.Logf("|%T|%v|%T|", val, val.ExportType(), err)
+	t.Logf("|%v|%v|", val, err)
+}
+
+func Test_defaultFunctionExport(t *testing.T) {
+	vm := createVM()
+	vm.RunString(` export default function () {} `)
+	global := vm.GlobalObject()
+	t.Log(global.GetOwnPropertyNames())
+
+	fn := vm.Get("default")
+	t.Log(fn)
+	fnFunc, ok := js.AssertFunction(fn)
+	t.Log(fnFunc, ok)
+}
+
+func Test_defaultFunctionTranspilation(t *testing.T) {
+	vm := createVM()
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test_file_name.ts")
+	require.NoError(t, os.WriteFile(filePath, []byte(` export default function (): void {} `), common.FileMode))
+
+	jsCode, err := TranspileTypeScript(filePath)
+	require.NoError(t, err)
+	t.Log(jsCode)
+
+	_, err = vm.RunString(jsCode)
+	require.NoError(t, err)
+
+	global := vm.GlobalObject()
+	t.Log(global.GetOwnPropertyNames())
+
+	fn := vm.Get("test_file_name_default")
+	t.Log(fn)
+	fnFunc, ok := js.AssertFunction(fn)
+	t.Log(fnFunc, ok)
+}
+
+// Test that driverStub exposes QueryResult fields (stats, rows) correctly
+// through sobek's UncapFieldNameMapper.
+func Test_driverStubRunQuery(t *testing.T) {
+	vm := createVM()
+
+	stub := &driverStub{}
+	require.NoError(t, vm.Set("driver", stub))
+
+	val, err := vm.RunString(`
+		const result = driver.runQuery("SELECT 1", {});
+		JSON.stringify({
+			hasResult: result !== undefined && result !== null,
+			hasRows:   result.rows !== undefined,
+			hasStats:  result.stats !== undefined,
+		});
+	`)
+	require.NoError(t, err)
+	require.Equal(t, `{"hasResult":true,"hasRows":true,"hasStats":true}`, val.String())
+}
+
+// Test that rowsStub methods are callable from JS.
+func Test_rowsStubMethods(t *testing.T) {
+	vm := createVM()
+
+	stub := &driverStub{}
+	require.NoError(t, vm.Set("driver", stub))
+
+	val, err := vm.RunString(`
+		const r = driver.runQuery("SELECT 1", {});
+		const rows = r.rows;
+		const nextResult = rows.next();
+		rows.close();
+		const allRows = rows.readAll(0);
+		JSON.stringify({
+			next: nextResult,
+			readAll: allRows,
+		});
+	`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"next":false,"readAll":[]}`, val.String())
+}
+
+// Test that driverStub.InsertValuesBin returns stats with elapsed field.
+func Test_driverStubInsertValues(t *testing.T) {
+	vm := createVM()
+
+	stub := &driverStub{}
+	require.NoError(t, vm.Set("driver", stub))
+
+	val, err := vm.RunString(`
+		const stats = driver.insertValuesBin(new Uint8Array(0), 0);
+		stats.elapsed.milliseconds() >= 0;
+	`)
+	require.NoError(t, err)
+	require.Equal(t, "true", val.String())
+}

--- a/internal/static/helpers.ts
+++ b/internal/static/helpers.ts
@@ -223,7 +223,7 @@ export class DriverX implements QueryAPI {
       ? {
           tableName: insertOrTableName,
           method: insert?.method ? insertMethodMap[insert.method] : undefined,
-          seed: insert?.seed ?? _seed,
+          seed: String(insert?.seed ?? _seed),
           params: R.group(insert?.params ?? {}),
           groups: R.groups(insert?.groups ?? {}),
           count,

--- a/internal/static/helpers.ts
+++ b/internal/static/helpers.ts
@@ -10,6 +10,7 @@ import {
   NotifyStep,
   Driver,
   QueryStats,
+  QueryResult,
 } from "k6/x/stroppy";
 import {
   Generation_Rule,
@@ -23,6 +24,7 @@ import {
   Status,
   Timestamp,
 } from "./stroppy.pb.js";
+
 import { ParsedQuery } from "./parse_sql.js";
 
 
@@ -84,15 +86,121 @@ const runQueryMetric = new Trend("run_query_duration", true);
 const runQueryCounterMetric = new Counter("run_query_count");
 const runQueryErrRateMetric = new Rate("run_query_error_rate");
 
-function isQueryStats(obj: any): obj is QueryStats {
-  return typeof obj.elapsed !== "undefined"
+export interface TaggedQuery {
+  sql: string | ParsedQuery;
+  tags?: Record<string, string>;
 }
 
-export class DriverX {
+export type SqlArg = string | ParsedQuery | TaggedQuery;
+
+function resolveSqlArg(arg: SqlArg): {
+  sql: string;
+  tags: Record<string, string> | undefined;
+} {
+  // Plain SQL string
+  if (typeof arg === "string") return { sql: arg, tags: undefined };
+
+    // TaggedQuery
+  if ("sql" in arg && (typeof arg.sql === "string" || "name" in arg.sql)) {
+    const inner = arg as TaggedQuery;
+    const parsed =
+      typeof inner.sql === "string" ? inner.sql : (inner.sql as ParsedQuery);
+    const baseTags =
+      typeof parsed === "string"
+        ? undefined
+        : { name: parsed.name, type: parsed.type };
+    return {
+      sql: typeof parsed === "string" ? parsed : parsed.sql,
+      tags: inner.tags ? { ...baseTags, ...inner.tags } : baseTags,
+    };
+  }
+
+  // ParsedQuery
+  const pq = arg as ParsedQuery;
+  return { sql: pq.sql, tags: { name: pq.name, type: pq.type } };
+}
+
+// Sugar interface for convenient query patterns.
+// Reusable across DriverX, future Tx, etc.
+// All methods accept a raw SQL string, a ParsedQuery, or a TaggedQuery.
+// All methods throw on query execution error.
+export interface QueryAPI {
+  exec(sql: SqlArg, args?: Record<string, any>): QueryStats;
+  queryRows(sql: SqlArg, args?: Record<string, any>, limit?: number): any[][];
+  queryRow(sql: SqlArg, args?: Record<string, any>): any[] | undefined;
+  queryValue<T = any>(sql: SqlArg, args?: Record<string, any>): T | undefined;
+  queryCursor(sql: SqlArg, args?: Record<string, any>): QueryResult;
+}
+
+type RunQueryFn = (sql: string, args: Record<string, any>) => QueryResult;
+
+function createQueryAPI(runQuery: RunQueryFn): QueryAPI {
+  return {
+    exec(sql: SqlArg, args?: Record<string, any>): QueryStats {
+      const { sql: s } = resolveSqlArg(sql);
+      const result = runQuery(s, args ?? {});
+      result.rows.close();
+      return result.stats;
+    },
+
+    queryRows(
+      sql: SqlArg,
+      args?: Record<string, any>,
+      limit?: number,
+    ): any[][] {
+      const { sql: s } = resolveSqlArg(sql);
+      const result = runQuery(s, args ?? {});
+      return result.rows.readAll(limit ?? 0);
+    },
+
+    queryRow(sql: SqlArg, args?: Record<string, any>): any[] | undefined {
+      const { sql: s } = resolveSqlArg(sql);
+      const result = runQuery(s, args ?? {});
+      const row = result.rows.next() ? result.rows.values() : undefined;
+      result.rows.close();
+      return row;
+    },
+
+    queryValue<T = any>(
+      sql: SqlArg,
+      args?: Record<string, any>,
+    ): T | undefined {
+      const { sql: s } = resolveSqlArg(sql);
+      const result = runQuery(s, args ?? {});
+      if (!result.rows.next()) {
+        result.rows.close();
+        return undefined;
+      }
+      const vals = result.rows.values();
+      result.rows.close();
+      return vals?.length ? (vals[0] as T) : undefined;
+    },
+
+    queryCursor(sql: SqlArg, args?: Record<string, any>): QueryResult {
+      const { sql: s } = resolveSqlArg(sql);
+      return runQuery(s, args ?? {});
+    },
+  };
+}
+
+export class DriverX implements QueryAPI {
   private driver: Driver;
+  private q: QueryAPI;
+
+  exec!: QueryAPI["exec"];
+  queryRows!: QueryAPI["queryRows"];
+  queryRow!: QueryAPI["queryRow"];
+  queryValue!: QueryAPI["queryValue"];
+  queryCursor!: QueryAPI["queryCursor"];
 
   constructor(driver: Driver) {
     this.driver = driver;
+    this.q = createQueryAPI((sql, args) => driver.runQuery(sql, args));
+    this.exec = this.q.exec;
+    this.queryRows = this.q.queryRows;
+    this.queryRow = this.q.queryRow;
+    this.queryValue = this.q.queryValue;
+    this.queryCursor = this.q.queryCursor;
   }
 
   static fromConfig(config: Partial<GlobalConfig>): DriverX {
@@ -126,46 +234,33 @@ export class DriverX {
       `Insertion into '${descriptor.tableName}' of ${descriptor.count} values starting...`,
     );
 
-    const results = this.driver.insertValuesBin(
-      InsertDescriptor.toBinary(InsertDescriptor.create(descriptor)),
-    );
-
-    const tags = { table_name: descriptor.tableName ?? "unknown" };
-    if (!results) return 
-    if (isQueryStats(results)) {
-      insertErrRateMetric.add(0, tags);
-      insertMetric.add(results.elapsed.milliseconds(), tags);
-    } else {
-      insertErrRateMetric.add(1, tags);
+    const metricTags = { table_name: descriptor.tableName ?? "unknown" };
+    try {
+      const stats = this.driver.insertValuesBin(
+        InsertDescriptor.toBinary(InsertDescriptor.create(descriptor)),
+      );
+      insertErrRateMetric.add(0, metricTags);
+      insertMetric.add(stats.elapsed.milliseconds(), metricTags);
+    } catch {
+      insertErrRateMetric.add(1, metricTags);
     }
 
     console.log(`Insertion into '${descriptor.tableName}' ended`);
   }
 
-  runQuery(sql: string, args: Record<string, any>): void;
-  runQuery(query: ParsedQuery, args: Record<string, any>): void;
-  runQuery(sqlOrQuery: string | ParsedQuery, args: Record<string, any>): void {
-    const isSql = typeof sqlOrQuery === "string";
-    const result = this.driver.runQuery(
-      isSql ? sqlOrQuery : sqlOrQuery.sql,
-      args,
-    );
-
-    const tags = isSql
-      ? undefined
-      : { name: sqlOrQuery.name, type: sqlOrQuery.type };
-
-    if (!result) return 
-    if (isQueryStats(result)) {
-      runQueryMetric.add(result.elapsed.milliseconds(), tags);
-      runQueryErrRateMetric.add(0, tags);
-      runQueryCounterMetric.add(1, tags);
-    } else {
-      runQueryErrRateMetric.add(1, tags);
+  runQuery(sql: SqlArg, args?: Record<string, any>): void {
+    const resolved = resolveSqlArg(sql);
+    try {
+      const result = this.driver.runQuery(resolved.sql, args ?? {});
+      runQueryMetric.add(result.stats.elapsed.milliseconds(), resolved.tags);
+      runQueryErrRateMetric.add(0, resolved.tags);
+      runQueryCounterMetric.add(1, resolved.tags);
+      result.rows.close();
+    } catch {
+      runQueryErrRateMetric.add(1, resolved.tags);
     }
   }
 
-  // Expose the underlying driver if needed for advanced usage
   getDriver(): Driver {
     return this.driver;
   }

--- a/internal/static/stroppy.d.ts
+++ b/internal/static/stroppy.d.ts
@@ -23,10 +23,29 @@ declare module "k6/x/stroppy" {
     elapsed: GoDuration;
   }
 
-  // Driver interface - provides database operations
+  // Cursor-style row iteration over query results.
+  // Auto-closes when next() returns false.
+  export interface Rows {
+    columns(): string[];
+    next(): boolean;
+    values(): any[];
+    readAll(limit: number): any[][];
+    err(): Error | null;
+    close(): Error | null;
+  }
+
+  export interface QueryResult {
+    stats: QueryStats;
+    rows: Rows;
+  }
+
+  // Driver interface - provides database operations.
+  // All methods throw on error (Go errors become JS exceptions via sobek).
   export interface Driver {
-    insertValuesBin(insert: BinMsg<InsertDescriptor>): Error | QueryStats;
-    runQuery(sql: string, args: Record<string, any>): Error | QueryStats;
+    /** @throws {Error} on insert failure or protobuf unmarshal error */
+    insertValuesBin(insert: BinMsg<InsertDescriptor>): QueryStats;
+    /** @throws {Error} on query execution or argument processing error */
+    runQuery(sql: string, args: Record<string, any>): QueryResult;
   }
 
   // Generator interface - provides data generation

--- a/pkg/driver/dispatcher.go
+++ b/pkg/driver/dispatcher.go
@@ -18,9 +18,25 @@ type (
 		DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 	}
 
+	// Rows provides cursor-style iteration over query result rows.
+	// Automatically closes when Next() returns false (exhaustion or error).
+	Rows interface {
+		Columns() []string
+		Next() bool
+		Values() []any
+		ReadAll(limit int) [][]any
+		Err() error
+		Close() error
+	}
+
+	QueryResult struct {
+		Stats *stats.Query
+		Rows  Rows
+	}
+
 	Driver interface {
 		InsertValues(ctx context.Context, unit *stroppy.InsertDescriptor) (*stats.Query, error)
-		RunQuery(ctx context.Context, sql string, args map[string]any) (*stats.Query, error)
+		RunQuery(ctx context.Context, sql string, args map[string]any) (*QueryResult, error)
 		Teardown(ctx context.Context) error
 		Configure(ctx context.Context, opts Options) error
 	}

--- a/pkg/driver/postgres/driver.go
+++ b/pkg/driver/postgres/driver.go
@@ -26,6 +26,7 @@ func init() {
 
 type Executor interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 	CopyFrom(
 		ctx context.Context,
 		tableName pgx.Identifier,

--- a/pkg/driver/postgres/driver_run_query.go
+++ b/pkg/driver/postgres/driver_run_query.go
@@ -13,15 +13,16 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/stroppy-io/stroppy/pkg/driver"
 	"github.com/stroppy-io/stroppy/pkg/driver/stats"
 )
 
-// RunQuery exucetse sql with args in form :arg.
+// RunQuery executes sql with args in form :arg and returns rows cursor.
 func (d *Driver) RunQuery(
 	ctx context.Context,
 	sql string,
 	args map[string]any,
-) (*stats.Query, error) {
+) (*driver.QueryResult, error) {
 	processedSQL, argsArr, err := processArgs(sql, args)
 	if err != nil {
 		if errors.Is(err, ErrExtraArgument) {
@@ -34,14 +35,17 @@ func (d *Driver) RunQuery(
 	}
 
 	start := time.Now()
-	_, err = d.pgxPool.Exec(ctx, processedSQL, argsArr...)
+	pgxRows, err := d.pgxPool.Query(ctx, processedSQL, argsArr...)
 	elapsed := time.Since(start)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute sql: %w", err)
 	}
 
-	return &stats.Query{Elapsed: elapsed}, nil
+	return &driver.QueryResult{
+		Stats: &stats.Query{Elapsed: elapsed},
+		Rows:  newRows(pgxRows),
+	}, nil
 }
 
 var (

--- a/pkg/driver/postgres/rows.go
+++ b/pkg/driver/postgres/rows.go
@@ -1,0 +1,82 @@
+package postgres
+
+import (
+	"github.com/jackc/pgx/v5"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+var _ driver.Rows = (*rows)(nil)
+
+type rows struct {
+	pgxRows pgx.Rows
+	closed  bool
+}
+
+func newRows(pgxRows pgx.Rows) *rows {
+	return &rows{pgxRows: pgxRows}
+}
+
+func (r *rows) Columns() []string {
+	fds := r.pgxRows.FieldDescriptions()
+
+	cols := make([]string, len(fds))
+	for i, fd := range fds {
+		cols[i] = fd.Name
+	}
+
+	return cols
+}
+
+func (r *rows) Next() bool {
+	if r.closed {
+		return false
+	}
+
+	hasNext := r.pgxRows.Next()
+	if !hasNext {
+		r.closed = true
+		r.pgxRows.Close()
+	}
+
+	return hasNext
+}
+
+func (r *rows) Values() []any {
+	vals, err := r.pgxRows.Values()
+	if err != nil {
+		return nil
+	}
+
+	return vals
+}
+
+// ReadAll reads up to limit rows and closes the cursor.
+// limit <= 0 means no limit.
+func (r *rows) ReadAll(limit int) [][]any {
+	var result [][]any
+	for r.Next() {
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+
+		result = append(result, r.Values())
+	}
+
+	r.Close()
+
+	return result
+}
+
+func (r *rows) Err() error {
+	return r.pgxRows.Err()
+}
+
+func (r *rows) Close() error {
+	if !r.closed {
+		r.closed = true
+		r.pgxRows.Close()
+	}
+
+	return r.pgxRows.Err()
+}

--- a/pkg/driver/postgres/rows_test.go
+++ b/pkg/driver/postgres/rows_test.go
@@ -1,0 +1,122 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunQuery_ReturnsRows(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+
+	defer mock.Close()
+
+	drv := newTestDriver(mock)
+
+	mock.ExpectQuery("SELECT").
+		WillReturnRows(
+			mock.NewRows([]string{"id", "name"}).
+				AddRow(1, "alice").
+				AddRow(2, "bob"),
+		)
+
+	result, err := drv.RunQuery(context.Background(), "SELECT id, name FROM users", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result.Stats)
+	require.NotNil(t, result.Rows)
+
+	require.Equal(t, []string{"id", "name"}, result.Rows.Columns())
+
+	require.True(t, result.Rows.Next())
+	require.Equal(t, []any{int(1), "alice"}, result.Rows.Values())
+
+	require.True(t, result.Rows.Next())
+	require.Equal(t, []any{int(2), "bob"}, result.Rows.Values())
+
+	require.False(t, result.Rows.Next())
+	require.NoError(t, result.Rows.Err())
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRunQuery_ReadAll(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+
+	defer mock.Close()
+
+	drv := newTestDriver(mock)
+
+	mock.ExpectQuery("SELECT").
+		WillReturnRows(
+			mock.NewRows([]string{"val"}).
+				AddRow(10).
+				AddRow(20).
+				AddRow(30),
+		)
+
+	result, err := drv.RunQuery(context.Background(), "SELECT val FROM t", nil)
+	require.NoError(t, err)
+
+	all := result.Rows.ReadAll(0)
+	require.Len(t, all, 3)
+	require.Equal(t, []any{int(10)}, all[0])
+	require.Equal(t, []any{int(20)}, all[1])
+	require.Equal(t, []any{int(30)}, all[2])
+
+	require.NoError(t, result.Rows.Err())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRunQuery_ReadAllWithLimit(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+
+	defer mock.Close()
+
+	drv := newTestDriver(mock)
+
+	mock.ExpectQuery("SELECT").
+		WillReturnRows(
+			mock.NewRows([]string{"val"}).
+				AddRow(1).
+				AddRow(2).
+				AddRow(3).
+				AddRow(4).
+				AddRow(5),
+		)
+
+	result, err := drv.RunQuery(context.Background(), "SELECT val FROM t", nil)
+	require.NoError(t, err)
+
+	all := result.Rows.ReadAll(2)
+	require.Len(t, all, 2)
+	require.Equal(t, []any{int(1)}, all[0])
+	require.Equal(t, []any{int(2)}, all[1])
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRunQuery_ExecStyleEmptyRows(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+
+	defer mock.Close()
+
+	drv := newTestDriver(mock)
+
+	mock.ExpectQuery("INSERT").
+		WillReturnRows(mock.NewRows([]string{}))
+
+	result, err := drv.RunQuery(context.Background(), "INSERT INTO t (a) VALUES (1)", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result.Stats)
+
+	require.False(t, result.Rows.Next())
+	require.Empty(t, result.Rows.Columns())
+	require.NoError(t, result.Rows.Err())
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/workloads/tests/sqlapi_test.ts
+++ b/workloads/tests/sqlapi_test.ts
@@ -1,0 +1,134 @@
+import { Options } from "k6/options";
+import { Teardown } from "k6/x/stroppy";
+
+import { DriverConfig_DriverType } from "./stroppy.pb.js";
+import { DriverX } from "./helpers.ts";
+
+export const options: Options = {
+  iterations: 1,
+  vus: 1,
+};
+
+const driver = DriverX.fromConfig({
+  driver: {
+    url: __ENV.DRIVER_URL || "postgres://postgres:postgres@localhost:5432",
+    driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
+    dbSpecific: {
+      fields: [],
+    },
+  },
+});
+
+function assert(condition: boolean, msg: string) {
+  if (!condition) throw new Error(`ASSERT FAILED: ${msg}`);
+}
+
+export default function () {
+  // -- setup: create temp table --
+  driver.exec("DROP TABLE IF EXISTS _sqlapi_test");
+  driver.exec(
+    "CREATE TABLE _sqlapi_test (id serial PRIMARY KEY, name text, value int)",
+  );
+
+  // -- exec: insert rows --
+  driver.exec("INSERT INTO _sqlapi_test (name, value) VALUES ('alice', 10)");
+  driver.exec("INSERT INTO _sqlapi_test (name, value) VALUES ('bob', 20)");
+  driver.exec("INSERT INTO _sqlapi_test (name, value) VALUES ('carol', 30)");
+  console.log("exec: inserts OK");
+
+  // -- exec: returns stats with elapsed --
+  const stats = driver.exec("SELECT 1");
+  assert(
+    stats.elapsed.milliseconds() >= 0,
+    "exec should return stats with elapsed",
+  );
+  console.log(`exec: stats.elapsed = ${stats.elapsed.milliseconds()}ms`);
+
+  // -- queryValue: single scalar --
+  const count = driver.queryValue<number>(
+    "SELECT count(*) FROM _sqlapi_test",
+  );
+  assert(count === 3, `queryValue: expected 3, got ${count}`);
+  console.log(`queryValue: count = ${count}`);
+
+  // -- queryValue: returns undefined for empty result --
+  const empty = driver.queryValue(
+    "SELECT id FROM _sqlapi_test WHERE id = -1",
+  );
+  assert(empty === undefined, `queryValue: expected undefined, got ${empty}`);
+  console.log("queryValue: empty = undefined OK");
+
+  // -- queryRow: single row, destructurable --
+  const row = driver.queryRow(
+    "SELECT name, value FROM _sqlapi_test ORDER BY id LIMIT 1",
+  );
+  assert(row !== undefined, "queryRow: should return a row");
+  const [name, value] = row!;
+  assert(name === "alice", `queryRow: expected alice, got ${name}`);
+  assert(value === 10, `queryRow: expected 10, got ${value}`);
+  console.log(`queryRow: [${name}, ${value}] OK`);
+
+  // -- queryRow: returns undefined for empty result --
+  const emptyRow = driver.queryRow(
+    "SELECT * FROM _sqlapi_test WHERE id = -1",
+  );
+  assert(
+    emptyRow === undefined,
+    `queryRow: expected undefined, got ${emptyRow}`,
+  );
+  console.log("queryRow: empty = undefined OK");
+
+  // -- queryRows: all rows --
+  const allRows = driver.queryRows(
+    "SELECT name, value FROM _sqlapi_test ORDER BY id",
+  );
+  assert(allRows.length === 3, `queryRows: expected 3 rows, got ${allRows.length}`);
+  assert(allRows[0][0] === "alice", `queryRows[0]: expected alice`);
+  assert(allRows[1][0] === "bob", `queryRows[1]: expected bob`);
+  assert(allRows[2][0] === "carol", `queryRows[2]: expected carol`);
+  console.log(`queryRows: ${allRows.length} rows OK`);
+
+  // -- queryRows: with limit --
+  const limited = driver.queryRows(
+    "SELECT name FROM _sqlapi_test ORDER BY id",
+    {},
+    2,
+  );
+  assert(limited.length === 2, `queryRows(limit=2): expected 2, got ${limited.length}`);
+  console.log(`queryRows(limit=2): ${limited.length} rows OK`);
+
+  // -- queryCursor: manual iteration --
+  const result = driver.queryCursor(
+    "SELECT value FROM _sqlapi_test ORDER BY id",
+  );
+  const values: number[] = [];
+  while (result.rows.next()) {
+    values.push(result.rows.values()[0] as number);
+  }
+  assert(values.length === 3, `queryCursor: expected 3 values`);
+  assert(values[0] === 10 && values[1] === 20 && values[2] === 30,
+    `queryCursor: expected [10,20,30], got [${values}]`);
+  console.log(`queryCursor: [${values}] OK`);
+
+  // -- runQuery: legacy method with metrics, should not throw --
+  driver.runQuery("SELECT 1");
+  console.log("runQuery: OK");
+
+  // -- tags: TaggedQuery syntax --
+  const taggedStats = driver.exec({
+    sql: "SELECT 1",
+    tags: { op: "health_check" },
+  });
+  assert(taggedStats.elapsed.milliseconds() >= 0, "tagged exec should work");
+  console.log("TaggedQuery: OK");
+
+  // -- cleanup --
+  driver.exec("DROP TABLE _sqlapi_test");
+  console.log("cleanup: OK");
+
+  console.log("--- ALL TESTS PASSED ---");
+}
+
+export function teardown() {
+  Teardown();
+}

--- a/workloads/tsconfig.json
+++ b/workloads/tsconfig.json
@@ -29,7 +29,8 @@
       "./tpcb/",
       "./tpcc/",
       "./tpcds/"
-      "./execsql/"
+      "./execute_sql/",
+      "./tests/"
     ],
     "paths": {
       "k6/x/stroppy": ["../internal/static/stroppy.d.ts"]


### PR DESCRIPTION
## Description of Changes
Replaced the fire-and-forget `RunQuery` / `InsertValuesBin` model with a proper cursor-based result API. `RunQuery` now returns a `QueryResult` containing both `QueryStats` and a `Rows` cursor (wrapping `pgx.Rows`). The JS/TS surface was extended with a `QueryAPI` mixin on `DriverX` exposing `exec`, `queryRows`, `queryRow`, `queryValue`, and `queryCursor`. Go errors are now propagated as JS exceptions instead of being returned as values.

## Motivation and Context
Previously query results were discarded — there was no way for workload scripts to read returned rows. This made it impossible to write data-dependent workloads (e.g. read-modify-write patterns, SELECT-based assertions). The change also cleans up a long-standing awkwardness where Go errors were returned as `any` and TypeScript had to type-guard against `Error | QueryStats`.

## How Has This Been Tested?
- New unit tests in `pkg/driver/postgres/rows_test.go` cover `Rows` iteration, `ReadAll`, `ReadAll` with limit, and empty result sets using `pgxmock`.
- New Sobek bridge tests in `internal/runner/sobek_test.go` verify that `driverStub` fields and methods are correctly exposed to JS through `UncapFieldNameMapper`.
- New integration test workload `workloads/tests/sqlapi_test.ts` exercises the full `QueryAPI` surface end-to-end against a real Postgres instance (`make run-sqlapi-test`).

## Type of Changes
- [x] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [x] Refactoring
- [ ] Other

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] I have checked build and tests
- [x] I have updated documentation if needed