### PR TITLE
[RNDSTROPPY-92]: pick/weighted, ENV(...) api, steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,9 @@ Drivers register themselves via `init()` using `driver.RegisterDriver()`. The di
 - `DriverX` - Typed driver wrapper with metrics tracking; `DriverX.fromConfig()`, `.insert()`, `.runQuery()`
 - `InsertMethodName` - `"plain_query" | "copy_from"` — friendly string type for `DriverX.insert()` method option
 - `Step()` - Named execution blocks with cloud notification; also `Step.begin()` / `Step.end()`
+- `ENV()` - Typed environment variable accessor replacing raw `__ENV`; supports aliases, defaults, descriptions. Metadata captured by probe for `Explain` output
+- `NewPicker(seed)` - Weighted random selection from arrays; `picker.pick(items)` for uniform, `picker.pickWeighted(items, weights)` for weighted selection
+
 
 ### SQL Syntax
 

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ revision: # Recreate git tag with version tag=<semver>
 ## Local K6 fast tests
 ##
 
-.PHONY: run-simple-test run-tpcb-test run-tpcc-test run-tpcds-test run-sqlapi-test .rm-dev
+.PHONY: run-simple-test run-tpcb-test run-tpcc-test run-tpcc-pick-test run-tpcds-test run-sqlapi-test .rm-dev
 
 WORKDIR=dev
 
@@ -294,6 +294,10 @@ run-tpcb-test:
 run-tpcc-test: .rm-dev
 	./build/stroppy gen --workdir $(WORKDIR) --preset=tpcc
 	cd $(WORKDIR) && DURATION="1s" SCALE_FACTOR=1 ./stroppy run tpcc.ts tpcc.sql
+
+run-tpcc-pick-test: .rm-dev
+	./build/stroppy gen --workdir $(WORKDIR) --preset=tpcc
+	cd $(WORKDIR) && SCALE_FACTOR=1 ./stroppy run tpcc-pick.ts tpcc.sql -- --duration "1s"
 
 run-tpcds-test: .rm-dev
 	./build/stroppy gen --workdir $(WORKDIR) --preset=tpcds

--- a/cmd/stroppy/commands/probe/probe.go
+++ b/cmd/stroppy/commands/probe/probe.go
@@ -22,6 +22,12 @@ const (
 	localFlag  = "local"
 	formatFlag = "output"
 
+	configFlag  = "config"
+	optionsFlag = "options"
+	sqlFlag     = "sql"
+	stepsFlag   = "steps"
+	envsFlag    = "envs"
+
 	humanFormat = "human"
 	jsonFormat  = "json"
 )
@@ -104,9 +110,11 @@ stroppy envs). Current environment values are also shown if found.
 					return fmt.Errorf("error while probbing %q: %w", scriptPath, err)
 				}
 
+				sections := buildSections(cmd)
+
 				switch formatFlagValue {
 				case humanFormat:
-					fmt.Fprintf(os.Stdout, "\n%s\n", probeprint.Explain())
+					fmt.Fprintf(os.Stdout, "\n%s\n", probeprint.Explain(sections))
 				case jsonFormat:
 					bytes, err := json.Marshal(probeprint)
 					if err != nil {
@@ -128,6 +136,41 @@ stroppy envs). Current environment values are also shown if found.
 			BoolP(localFlag, string(localFlag[0]), false,
 				"prevent tmp dir creation (use local dependencies in test working directory)")
 
+		cmd.Flags().Bool(configFlag, false, "show only stroppy config section")
+		cmd.Flags().Bool(optionsFlag, false, "show only k6 options section")
+		cmd.Flags().Bool(sqlFlag, false, "show only sql file structure section")
+		cmd.Flags().Bool(stepsFlag, false, "show only steps section")
+		cmd.Flags().Bool(envsFlag, false, "show only environment variables section")
+
 		return cmd
 	}()
 )
+
+// buildSections maps bool flags to ExplainSection bitmask.
+// If no section flags are set, all sections are included.
+func buildSections(cmd *cobra.Command) runner.ExplainSection {
+	flagMap := []struct {
+		name    string
+		section runner.ExplainSection
+	}{
+		{configFlag, runner.ExplainConfig},
+		{optionsFlag, runner.ExplainOptions},
+		{sqlFlag, runner.ExplainSQL},
+		{stepsFlag, runner.ExplainSteps},
+		{envsFlag, runner.ExplainEnvs},
+	}
+
+	var sections runner.ExplainSection
+
+	for _, f := range flagMap {
+		if v, _ := cmd.Flags().GetBool(f.name); v {
+			sections |= f.section
+		}
+	}
+
+	if sections == 0 {
+		return runner.ExplainAll
+	}
+
+	return sections
+}

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -5,16 +5,21 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
 )
 
-var errNoScript = errors.New("script argument is required")
+var (
+	errNoScript          = errors.New("script argument is required")
+	errFlagRequiresValue = errors.New("flag requires a value")
+	errStepsMutExclusive = errors.New("--steps and --no-steps are mutually exclusive")
+)
 
 var Cmd = &cobra.Command{
-	Use:   "run <script> [sql_file] [-- <k6 run direct args>]",
+	Use:   "run <script> [sql_file] [--steps step1,step2] [--no-steps step1,step2] [-- <k6 run direct args>]",
 	Short: "Run benchmark script with k6",
 	Long: `Run a benchmark with k6. The extension determines the mode:
 
@@ -35,6 +40,8 @@ Examples:
   stroppy run ./benchmarks/custom.ts data.sql   # explicit paths
   stroppy run queries.sql                       # execute a SQL file
   stroppy run "select 1"                        # execute inline SQL
+  stroppy run tpcc --steps create_schema,load   # only run specified steps
+  stroppy run tpcc --no-steps load              # run all steps except specified
 `,
 	DisableFlagParsing: true,
 	RunE: func(_ *cobra.Command, args []string) error {
@@ -55,11 +62,48 @@ Examples:
 			positional = args
 		}
 
-		scriptArg := positional[0]
+		// Extract --steps and --no-steps flags from positional args.
+		var (
+			scriptArg string
+			sqlArg    string
+			steps     []string
+			noSteps   []string
+		)
 
-		sqlArg := ""
-		if len(positional) > 1 {
-			sqlArg = positional[1]
+		for i := 0; i < len(positional); i++ {
+			arg := positional[i]
+
+			switch {
+			case arg == "--steps" || arg == "--no-steps":
+				if i+1 >= len(positional) {
+					return fmt.Errorf("%s: %w", arg, errFlagRequiresValue)
+				}
+
+				i++
+
+				vals := strings.Split(positional[i], ",")
+				if arg == "--steps" {
+					steps = append(steps, vals...)
+				} else {
+					noSteps = append(noSteps, vals...)
+				}
+
+			case strings.HasPrefix(arg, "--steps="):
+				steps = append(steps, strings.Split(strings.TrimPrefix(arg, "--steps="), ",")...)
+
+			case strings.HasPrefix(arg, "--no-steps="):
+				noSteps = append(noSteps, strings.Split(strings.TrimPrefix(arg, "--no-steps="), ",")...)
+
+			case scriptArg == "":
+				scriptArg = arg
+
+			default:
+				sqlArg = arg
+			}
+		}
+
+		if len(steps) > 0 && len(noSteps) > 0 {
+			return errStepsMutExclusive
 		}
 
 		// Resolve files through search path.
@@ -68,7 +112,7 @@ Examples:
 			return fmt.Errorf("failed to resolve input: %w", err)
 		}
 
-		r, err := runner.NewScriptRunner(input, afterDash)
+		r, err := runner.NewScriptRunner(input, afterDash, steps, noSteps)
 		if err != nil {
 			return fmt.Errorf("failed to create runner: %w", err)
 		}

--- a/cmd/xk6air/instance.go
+++ b/cmd/xk6air/instance.go
@@ -54,6 +54,7 @@ func (i *Instance) Exports() modules.Exports {
 			"Teardown":                    rootModule.Teardown,
 			"NewGeneratorByRuleBin":       NewGeneratorByRuleBin,
 			"NewGroupGeneratorByRulesBin": NewGroupGeneratorByRulesBin,
+			"NewPicker":                   NewPicker,
 		},
 	}
 }

--- a/cmd/xk6air/instance.go
+++ b/cmd/xk6air/instance.go
@@ -55,6 +55,7 @@ func (i *Instance) Exports() modules.Exports {
 			"NewGeneratorByRuleBin":       NewGeneratorByRuleBin,
 			"NewGroupGeneratorByRulesBin": NewGroupGeneratorByRulesBin,
 			"NewPicker":                   NewPicker,
+			"DeclareEnv":                  func([]string, string, string) {},
 		},
 	}
 }

--- a/cmd/xk6air/pick.go
+++ b/cmd/xk6air/pick.go
@@ -1,0 +1,54 @@
+package xk6air
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/grafana/sobek"
+	"github.com/stroppy-io/stroppy/pkg/common/generate"
+)
+
+type Picker struct {
+	randomness *rand.Rand
+	seed       uint64
+}
+
+func NewPicker(seed uint64) *Picker {
+	seed = generate.ResolveSeed(seed)
+
+	return &Picker{
+		randomness: rand.New(rand.NewSource(int64(seed))),
+		seed:       seed,
+	}
+}
+
+// Pick returns a random element from the given array.
+func (g *Picker) Pick(array []sobek.Value) (sobek.Value, error) {
+	return array[g.randomness.Intn(len(array))], nil
+}
+
+// WeightedPick returns a random element from the given array, based on the
+// given weights.
+func (g *Picker) PickWeighted(array []sobek.Value, weights []float64) (sobek.Value, error) {
+	if len(array) != len(weights) {
+		return sobek.Undefined(), fmt.Errorf("array and weights must be of the same length")
+	}
+
+	totalWeight := 0.0
+	for _, weight := range weights {
+		totalWeight += weight
+	}
+
+	threshold := g.randomness.Float64() * totalWeight
+
+	cumulativeWeight := 0.0
+	for index, weight := range weights {
+		cumulativeWeight += weight
+
+		if cumulativeWeight >= threshold {
+			return array[index], nil
+		}
+	}
+
+	return sobek.Undefined(), fmt.Errorf("unreachable! weightedPick should never reach here")
+}

--- a/internal/runner/probepint.go
+++ b/internal/runner/probepint.go
@@ -24,6 +24,13 @@ type SQLSection struct {
 	Queries []SQLQuery `json:"queries"`
 }
 
+// EnvDeclaration captures metadata from ENV() calls in user scripts.
+type EnvDeclaration struct {
+	Names       []string `json:"names"`
+	Default     string   `json:"default,omitempty"`
+	Description string   `json:"description,omitempty"`
+}
+
 type Subprobe struct {
 	// Options is k6 export const options = { ... }
 	Options *lib.Options `json:"options"`
@@ -32,9 +39,11 @@ type Subprobe struct {
 	// Like this sections["create_schema"]...
 	SQLSections []SQLSection `json:"sql_sections"`
 
-	// Envs is environment variables which test checks while execution.
-	// It's a list of envs names (not K=V, just K)
+	// Envs is environment variables accessed via __ENV directly (legacy).
 	Envs []string `json:"envs"`
+
+	// EnvDeclarations is environment variables declared via ENV() with metadata.
+	EnvDeclarations []EnvDeclaration `json:"env_declarations"`
 
 	// Steps is which ones registered with 'Step("", ()=>{})' function.
 	Steps []string `json:"steps"`
@@ -153,16 +162,62 @@ func (p *Probeprint) Explain() string { //nolint: gocognit // just fine
 
 	sb.WriteString("# Environment Variables:\n")
 
-	if len(p.Envs) > 0 {
-		for _, envName := range p.Envs {
-			currentVal := os.Getenv(envName)
-			if currentVal == "" {
-				fmt.Fprintf(sb, "  %s=\"\"\n", envName)
-			} else {
-				fmt.Fprintf(sb, "  %s=%s\n", envName, currentVal)
+	if len(p.EnvDeclarations) > 0 {
+		for _, decl := range p.EnvDeclarations {
+			names := strings.Join(decl.Names, " | ")
+			currentVal := ""
+
+			for _, name := range decl.Names {
+				if v := os.Getenv(name); v != "" {
+					currentVal = v
+
+					break
+				}
 			}
+
+			if currentVal != "" {
+				fmt.Fprintf(sb, "  %s=%s", names, currentVal)
+			} else if decl.Default != "" {
+				fmt.Fprintf(sb, "  %s=\"\" (default: %s)", names, decl.Default)
+			} else {
+				fmt.Fprintf(sb, "  %s=\"\"", names)
+			}
+
+			if decl.Description != "" {
+				fmt.Fprintf(sb, "  # %s", decl.Description)
+			}
+
+			sb.WriteString("\n")
 		}
-	} else {
+	}
+
+	// Plain __ENV access (not via ENV())
+	declared := map[string]bool{}
+
+	for _, decl := range p.EnvDeclarations {
+		for _, name := range decl.Names {
+			declared[name] = true
+		}
+	}
+
+	hasPlain := false
+
+	for _, envName := range p.Envs {
+		if declared[envName] {
+			continue
+		}
+
+		currentVal := os.Getenv(envName)
+		if currentVal == "" {
+			fmt.Fprintf(sb, "  %s=\"\"\n", envName)
+		} else {
+			fmt.Fprintf(sb, "  %s=%s\n", envName, currentVal)
+		}
+
+		hasPlain = true
+	}
+
+	if len(p.EnvDeclarations) == 0 && !hasPlain {
 		sb.WriteString("  (no environment variables)\n")
 	}
 

--- a/internal/runner/probepint.go
+++ b/internal/runner/probepint.go
@@ -81,13 +81,50 @@ func (p *Probeprint) MarshalJSON() ([]byte, error) {
 	return buff.Bytes(), nil
 }
 
-// Explain - human-readable message for users.
-// TODO: Explain(parts (config|options|sql|envs)) feature flags (bit-flags) format.
-func (p *Probeprint) Explain() string { //nolint: gocognit // just fine
+// ExplainSection is a bitmask for selecting which sections to include in Explain output.
+type ExplainSection uint8
+
+const (
+	ExplainConfig ExplainSection = 1 << iota
+	ExplainOptions
+	ExplainSQL
+	ExplainSteps
+	ExplainEnvs
+
+	ExplainAll ExplainSection = ExplainConfig | ExplainOptions | ExplainSQL | ExplainSteps | ExplainEnvs
+)
+
+// Explain returns a human-readable message for users.
+// Use sections bitmask to select which parts to include.
+func (p *Probeprint) Explain(sections ExplainSection) string {
 	sb := &strings.Builder{}
 
 	sb.WriteString("Use 'probe --help' to get details about sections\n\n")
 
+	if sections&ExplainConfig != 0 {
+		p.explainConfig(sb)
+	}
+
+	if sections&ExplainOptions != 0 {
+		p.explainOptions(sb)
+	}
+
+	if sections&ExplainSQL != 0 {
+		p.explainSQL(sb)
+	}
+
+	if sections&ExplainSteps != 0 {
+		p.explainSteps(sb)
+	}
+
+	if sections&ExplainEnvs != 0 {
+		p.explainEnvs(sb)
+	}
+
+	return sb.String()
+}
+
+func (p *Probeprint) explainConfig(sb *strings.Builder) {
 	sb.WriteString("# Stroppy Config:\n")
 
 	if p.GlobalConfig != nil {
@@ -107,7 +144,9 @@ func (p *Probeprint) Explain() string { //nolint: gocognit // just fine
 	} else {
 		sb.WriteString("  (no config)\n\n")
 	}
+}
 
+func (p *Probeprint) explainOptions(sb *strings.Builder) {
 	sb.WriteString("# K6 Options:\n")
 
 	if p.Options != nil {
@@ -127,7 +166,9 @@ func (p *Probeprint) Explain() string { //nolint: gocognit // just fine
 	} else {
 		sb.WriteString("  (no options)\n\n")
 	}
+}
 
+func (p *Probeprint) explainSQL(sb *strings.Builder) {
 	sb.WriteString("# SQL File Structure:\n")
 
 	if len(p.SQLSections) > 0 {
@@ -147,7 +188,9 @@ func (p *Probeprint) Explain() string { //nolint: gocognit // just fine
 	}
 
 	sb.WriteString("\n")
+}
 
+func (p *Probeprint) explainSteps(sb *strings.Builder) {
 	sb.WriteString("# Steps\n")
 
 	if len(p.Steps) > 0 {
@@ -159,39 +202,55 @@ func (p *Probeprint) Explain() string { //nolint: gocognit // just fine
 	}
 
 	sb.WriteString("\n")
+}
 
+func (p *Probeprint) explainEnvs(sb *strings.Builder) {
 	sb.WriteString("# Environment Variables:\n")
 
-	if len(p.EnvDeclarations) > 0 {
-		for _, decl := range p.EnvDeclarations {
-			names := strings.Join(decl.Names, " | ")
-			currentVal := ""
+	for _, decl := range p.EnvDeclarations {
+		explainEnvDecl(sb, decl)
+	}
 
-			for _, name := range decl.Names {
-				if v := os.Getenv(name); v != "" {
-					currentVal = v
+	hasPlain := p.explainPlainEnvs(sb)
 
-					break
-				}
-			}
+	if len(p.EnvDeclarations) == 0 && !hasPlain {
+		sb.WriteString("  (no environment variables)\n")
+	}
+}
 
-			if currentVal != "" {
-				fmt.Fprintf(sb, "  %s=%s", names, currentVal)
-			} else if decl.Default != "" {
-				fmt.Fprintf(sb, "  %s=\"\" (default: %s)", names, decl.Default)
-			} else {
-				fmt.Fprintf(sb, "  %s=\"\"", names)
-			}
+func explainEnvDecl(sb *strings.Builder, decl EnvDeclaration) {
+	names := strings.Join(decl.Names, " | ")
+	currentVal := lookupEnv(decl.Names)
 
-			if decl.Description != "" {
-				fmt.Fprintf(sb, "  # %s", decl.Description)
-			}
+	switch {
+	case currentVal != "":
+		fmt.Fprintf(sb, "  %s=%s", names, currentVal)
+	case decl.Default != "":
+		fmt.Fprintf(sb, "  %s=\"\" (default: %s)", names, decl.Default)
+	default:
+		fmt.Fprintf(sb, "  %s=\"\"", names)
+	}
 
-			sb.WriteString("\n")
+	if decl.Description != "" {
+		fmt.Fprintf(sb, "  # %s", decl.Description)
+	}
+
+	sb.WriteString("\n")
+}
+
+func lookupEnv(names []string) string {
+	for _, name := range names {
+		if v := os.Getenv(name); v != "" {
+			return v
 		}
 	}
 
-	// Plain __ENV access (not via ENV())
+	return ""
+}
+
+// explainPlainEnvs writes env vars accessed via __ENV directly (not via ENV()).
+// Returns true if any plain env vars were written.
+func (p *Probeprint) explainPlainEnvs(sb *strings.Builder) bool {
 	declared := map[string]bool{}
 
 	for _, decl := range p.EnvDeclarations {
@@ -217,9 +276,5 @@ func (p *Probeprint) Explain() string { //nolint: gocognit // just fine
 		hasPlain = true
 	}
 
-	if len(p.EnvDeclarations) == 0 && !hasPlain {
-		sb.WriteString("  (no environment variables)\n")
-	}
-
-	return sb.String()
+	return hasPlain
 }

--- a/internal/runner/script_extractor.go
+++ b/internal/runner/script_extractor.go
@@ -326,6 +326,7 @@ func prepareVMEnvironment(vm *js.Runtime, probeprint *Probeprint) error {
 		// TODO: research. Some esbuild name resolution artifact, probably
 		{"NotifyStep2", notifyStepSpy(&probeprint.Steps)},
 		{"NewPicker", newPickerStub},
+		{"DeclareEnv", declareEnvSpy(&probeprint.EnvDeclarations)},
 
 		{"parse_sql_with_sections", parseSectionsSpy(&probeprint.SQLSections)},
 		{"parse_sql", parseSpy(&probeprint.SQLSections)},
@@ -334,6 +335,16 @@ func prepareVMEnvironment(vm *js.Runtime, probeprint *Probeprint) error {
 	}
 
 	return nil
+}
+
+func declareEnvSpy(decls *[]EnvDeclaration) func([]string, string, string) {
+	return func(names []string, default_ string, description string) {
+		*decls = append(*decls, EnvDeclaration{
+			Names:       names,
+			Default:     default_,
+			Description: description,
+		})
+	}
 }
 
 func notifyStepSpy(steps *[]string) func(string, any) {

--- a/internal/runner/script_extractor.go
+++ b/internal/runner/script_extractor.go
@@ -260,6 +260,16 @@ type genStub struct{}
 
 func (*genStub) Next() any { return nil }
 
+type pickerStub struct{}
+
+//nolint:ireturn // sobek
+func (g *pickerStub) Pick(a []js.Value) (js.Value, error) { return a[0], nil }
+
+//nolint:ireturn // sobek
+func (g *pickerStub) PickWeighted(a []js.Value, _ []float64) (js.Value, error) { return a[0], nil }
+
+func newPickerStub(seed uint64) *pickerStub { return &pickerStub{} }
+
 type Mocks []struct {
 	name  string
 	value any
@@ -315,6 +325,7 @@ func prepareVMEnvironment(vm *js.Runtime, probeprint *Probeprint) error {
 		{"NotifyStep", notifyStepSpy(&probeprint.Steps)},
 		// TODO: research. Some esbuild name resolution artifact, probably
 		{"NotifyStep2", notifyStepSpy(&probeprint.Steps)},
+		{"NewPicker", newPickerStub},
 
 		{"parse_sql_with_sections", parseSectionsSpy(&probeprint.SQLSections)},
 		{"parse_sql", parseSpy(&probeprint.SQLSections)},

--- a/internal/runner/script_runner.go
+++ b/internal/runner/script_runner.go
@@ -29,10 +29,12 @@ type ScriptRunner struct {
 	config     *Probeprint
 	k6RunArgs  []string // pass args directly to 'k6 run <k6RunArgs>'
 	filesInTmp []string
+	steps      []string // --steps: only run these steps
+	noSteps    []string // --no-steps: skip these steps
 }
 
 // NewScriptRunner creates a new ScriptRunner for the given resolved input.
-func NewScriptRunner(input *ResolvedInput, k6RunArgs []string) (*ScriptRunner, error) {
+func NewScriptRunner(input *ResolvedInput, k6RunArgs, steps, noSteps []string) (*ScriptRunner, error) {
 	lg := logger.Global().
 		Named("script_runner").
 		WithOptions(zap.WithCaller(false), zap.AddStacktrace(zap.FatalLevel))
@@ -70,6 +72,15 @@ func NewScriptRunner(input *ResolvedInput, k6RunArgs []string) (*ScriptRunner, e
 
 	lg.Debug("Got config extracted", zap.Any("config", config))
 
+	// Validate --steps / --no-steps against probed steps.
+	if err := validateStepNames(config.Steps, steps, "--steps"); err != nil {
+		return nil, err
+	}
+
+	if err := validateStepNames(config.Steps, noSteps, "--no-steps"); err != nil {
+		return nil, err
+	}
+
 	// Update logger with config if available
 	if config.GlobalConfig.GetLogger() != nil {
 		lg = logger.NewFromProtoConfig(config.GlobalConfig.GetLogger()).
@@ -92,6 +103,8 @@ func NewScriptRunner(input *ResolvedInput, k6RunArgs []string) (*ScriptRunner, e
 		tempDir:    tempDir,
 		k6RunArgs:  k6RunArgs,
 		filesInTmp: tmpFiles,
+		steps:      steps,
+		noSteps:    noSteps,
 	}, nil
 }
 
@@ -165,7 +178,11 @@ func copyFile(src, dst string) error {
 	return os.WriteFile(dst, data, common.FileMode)
 }
 
-var ErrNotADir = errors.New("is not a directory")
+var (
+	ErrNotADir      = errors.New("is not a directory")
+	errNoSteps      = errors.New("script has no steps")
+	errUnknownSteps = errors.New("unknown steps")
+)
 
 func copyFiles(srcDir, dstDir string, excludeNames []string) (copied []string, err error) {
 	srcInfo, err := os.Stat(srcDir)
@@ -230,7 +247,45 @@ func (r *ScriptRunner) buildEnvVars() []string {
 		envs = append(envs, "SQL_FILE="+path.Join(r.tempDir, r.sqlName))
 	}
 
+	if len(r.steps) > 0 {
+		envs = append(envs, "STROPPY_STEPS="+strings.Join(r.steps, ","))
+	}
+
+	if len(r.noSteps) > 0 {
+		envs = append(envs, "STROPPY_NO_STEPS="+strings.Join(r.noSteps, ","))
+	}
+
 	return envs
+}
+
+// validateStepNames checks that all names exist in the probed steps.
+func validateStepNames(probed, requested []string, flag string) error {
+	if len(requested) == 0 {
+		return nil
+	}
+
+	if len(probed) == 0 {
+		return fmt.Errorf("%s %v: %w", flag, requested, errNoSteps)
+	}
+
+	known := make(map[string]struct{}, len(probed))
+	for _, s := range probed {
+		known[s] = struct{}{}
+	}
+
+	var unknown []string
+
+	for _, s := range requested {
+		if _, ok := known[s]; !ok {
+			unknown = append(unknown, s)
+		}
+	}
+
+	if len(unknown) > 0 {
+		return fmt.Errorf("%s %v (available: %v): %w", flag, unknown, probed, errUnknownSteps)
+	}
+
+	return nil
 }
 
 // addOtelExportArgs adds OpenTelemetry exporter arguments and environment variables.

--- a/internal/static/helpers.ts
+++ b/internal/static/helpers.ts
@@ -8,6 +8,7 @@ import {
   NewGeneratorByRuleBin,
   NewGroupGeneratorByRulesBin,
   NotifyStep,
+  DeclareEnv,
   Driver,
   QueryStats,
   QueryResult,
@@ -27,6 +28,18 @@ import {
 
 import { ParsedQuery } from "./parse_sql.js";
 
+declare const __ENV: Record<string, string>;
+
+export function ENV<T extends string | number>(env: string | string[], default_?: T, description?: string): T {
+  const names = Array.isArray(env) ? env : [env];
+  DeclareEnv(names, String(default_ ?? ""), description ?? "");
+  const asNum = typeof default_ === "number";
+  for (const name of names) {
+    const val = __ENV[name];
+    if (val !== undefined && val !== "") return (asNum ? Number(val) : val) as T;
+  }
+  return default_ as T;
+}
 
 // ============================================================================
 // Module-wide seed (0 = random, >0 = fixed). Inherited by .gen() and insert().

--- a/internal/static/helpers.ts
+++ b/internal/static/helpers.ts
@@ -30,15 +30,17 @@ import { ParsedQuery } from "./parse_sql.js";
 
 declare const __ENV: Record<string, string>;
 
-export function ENV<T extends string | number>(env: string | string[], default_?: T, description?: string): T {
+export function ENV(env: string | string[], default_?: string, description?: string): string;
+export function ENV(env: string | string[], default_?: number, description?: string): number;
+export function ENV(env: string | string[], default_?: string | number, description?: string): string | number {
   const names = Array.isArray(env) ? env : [env];
   DeclareEnv(names, String(default_ ?? ""), description ?? "");
   const asNum = typeof default_ === "number";
   for (const name of names) {
     const val = __ENV[name];
-    if (val !== undefined && val !== "") return (asNum ? Number(val) : val) as T;
+    if (val !== undefined && val !== "") return asNum ? Number(val) : val;
   }
-  return default_ as T;
+  return default_ as string | number;
 }
 
 // ============================================================================
@@ -285,8 +287,30 @@ export function NewDriverByConfig(config: Partial<GlobalConfig>): Driver {
   );
 }
 
+const _stepFilter: Set<string> | null = (() => {
+  const only = ENV("STROPPY_STEPS", "", "comma-separated list of steps to run (allowlist), same as --steps");
+  if (only) return new Set(only.split(","));
+  return null;
+})();
+
+const _stepSkip: Set<string> | null = (() => {
+  const skip = ENV("STROPPY_NO_STEPS", "", "comma-separated list of steps to skip (blocklist), same as --no-steps");
+  if (skip) return new Set(skip.split(","));
+  return null;
+})();
+
+function isStepEnabled(name: string): boolean {
+  if (_stepFilter) return _stepFilter.has(name);
+  if (_stepSkip) return !_stepSkip.has(name);
+  return true;
+}
+
 export const Step = Object.assign(
   (name: string, step: () => void): void => {
+    if (!isStepEnabled(name)) {
+      console.log(`Skipping step '${name}'`);
+      return;
+    }
     Step.begin(name);
     step();
     Step.end(name);

--- a/internal/static/stroppy.d.ts
+++ b/internal/static/stroppy.d.ts
@@ -54,17 +54,23 @@ declare module "k6/x/stroppy" {
   }
 
   // k6 module functions provided by Go module
-  export declare function NotifyStep(name: String, status: Number): void;
+  export declare function NotifyStep(name: String, status: number): void;
   export declare function Teardown(): Error;
   export declare function NewDriverByConfigBin(
     configBin: BinMsg<GlobalConfig>,
   ): Driver;
   export declare function NewGeneratorByRuleBin(
-    seed: Number,
+    seed: number,
     rule: BinMsg<Generation_Rule>,
   ): Generator;
   export declare function NewGroupGeneratorByRulesBin(
-    seed: Number,
+    seed: number,
     rule: BinMsg<QueryParamGroup>,
   ): Generator;
+
+  export interface Picker {
+    pick(array: any[]): any;
+    pickWeighted(array: any[], weights: number[]): any;
+  }
+  export declare function NewPicker(seed: number): Picker;
 }

--- a/internal/static/stroppy.d.ts
+++ b/internal/static/stroppy.d.ts
@@ -73,4 +73,10 @@ declare module "k6/x/stroppy" {
     pickWeighted(array: any[], weights: number[]): any;
   }
   export declare function NewPicker(seed: number): Picker;
+
+  export declare function DeclareEnv(
+    names: string[],
+    default_: string,
+    description: string,
+  ): void;
 }

--- a/workloads/execute_sql/execute_sql.ts
+++ b/workloads/execute_sql/execute_sql.ts
@@ -2,14 +2,16 @@ import { Options } from "k6/options";
 import { Teardown } from "k6/x/stroppy";
 
 import { DriverConfig_DriverType } from "./stroppy.pb.js";
-import { DriverX } from "./helpers.ts";
+import { DriverX, ENV } from "./helpers.ts";
 import { parse_sql } from "./parse_sql.js";
+
+const SQL_FILE = ENV("SQL_FILE", "", "Path to SQL file (automatically set if .sql file provided as argument)");
 
 export const options: Options = {};
 
 const driver = DriverX.fromConfig({
   driver: {
-    url: __ENV.DRIVER_URL || "postgres://postgres:postgres@localhost:5432",
+    url: ENV("DRIVER_URL", "postgres://postgres:postgres@localhost:5432", "Database connection URL"),
     driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
     dbSpecific: {
       fields: [],
@@ -17,7 +19,7 @@ const driver = DriverX.fromConfig({
   },
 });
 
-const parsedQueries = parse_sql(open(__ENV.SQL_FILE));
+const parsedQueries = parse_sql(open(SQL_FILE));
 
 export default function () {
   parsedQueries().forEach((query) => {

--- a/workloads/simple/simple.ts
+++ b/workloads/simple/simple.ts
@@ -1,7 +1,7 @@
 import { Options } from "k6/options";
 import { Teardown } from "k6/x/stroppy";
 import { DriverConfig_DriverType } from "./stroppy.pb.js";
-import { DriverX, AB, R, S, Step, setSeed } from "./helpers.ts";
+import { DriverX, AB, R, S, Step, setSeed, ENV } from "./helpers.ts";
 
 export const options: Options = {
   setupTimeout: "5m",
@@ -18,7 +18,7 @@ export const options: Options = {
 
 const driver: DriverX = DriverX.fromConfig({
   driver: {
-    url: __ENV.DRIVER_URL || "postgres://postgres:postgres@localhost:5432",
+    url: ENV("DRIVER_URL", "postgres://postgres:postgres@localhost:5432", "Database connection URL"),
     driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
     dbSpecific: {
       fields: [],

--- a/workloads/tests/sqlapi_test.ts
+++ b/workloads/tests/sqlapi_test.ts
@@ -2,7 +2,7 @@ import { Options } from "k6/options";
 import { Teardown } from "k6/x/stroppy";
 
 import { DriverConfig_DriverType } from "./stroppy.pb.js";
-import { DriverX } from "./helpers.ts";
+import { DriverX, ENV } from "./helpers.ts";
 
 export const options: Options = {
   iterations: 1,
@@ -11,7 +11,7 @@ export const options: Options = {
 
 const driver = DriverX.fromConfig({
   driver: {
-    url: __ENV.DRIVER_URL || "postgres://postgres:postgres@localhost:5432",
+    url: ENV("DRIVER_URL", "postgres://postgres:postgres@localhost:5432", "Database connection URL"),
     driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
     dbSpecific: {
       fields: [],

--- a/workloads/tpcb/tpcb.ts
+++ b/workloads/tpcb/tpcb.ts
@@ -1,11 +1,13 @@
 import { Options } from "k6/options";
 import { Teardown } from "k6/x/stroppy";
 import { DriverConfig_DriverType } from "./stroppy.pb.js";
-import { DriverX, AB, C, R, Step, S } from "./helpers.ts";
+import { DriverX, AB, C, R, Step, S, ENV } from "./helpers.ts";
 import { parse_sql_with_sections } from "./parse_sql.js";
 
+const SQL_FILE = ENV("SQL_FILE", "", "Path to SQL file (automatically set if .sql file provided as argument)");
+
 // TPC-B Configuration Constants
-const SCALE_FACTOR = +(__ENV.SCALE_FACTOR || 1);
+const SCALE_FACTOR = ENV("SCALE_FACTOR", 1, "TPC-B scale factor");
 const BRANCHES = SCALE_FACTOR;
 const TELLERS = 10 * SCALE_FACTOR;
 const ACCOUNTS = 100000 * SCALE_FACTOR;
@@ -18,7 +20,7 @@ export const options: Options = {
       executor: "constant-vus",
       exec: "tpcb_transaction",
       vus: 10,
-      duration: __ENV.DURATION || "1h",
+      duration: ENV("DURATION", "1h", "Test duration"),
     },
   },
 };
@@ -26,7 +28,7 @@ export const options: Options = {
 // Initialize driver with GlobalConfig
 const driver = DriverX.fromConfig({
   driver: {
-    url: __ENV.DRIVER_URL || "postgres://postgres:postgres@localhost:5432",
+    url: ENV("DRIVER_URL", "postgres://postgres:postgres@localhost:5432", "Database connection URL"),
     driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
     connectionType: { is: {oneofKind:"sharedPool", sharedPool: {sharedConnections: 10}}},
     dbSpecific: {
@@ -35,7 +37,7 @@ const driver = DriverX.fromConfig({
   },
 });
 
-const sql = parse_sql_with_sections(open(__ENV.SQL_FILE));
+const sql = parse_sql_with_sections(open(SQL_FILE));
 
 // Setup function: create schema and load data
 export function setup() {

--- a/workloads/tpcb/tpcb.ts
+++ b/workloads/tpcb/tpcb.ts
@@ -4,25 +4,17 @@ import { DriverConfig_DriverType } from "./stroppy.pb.js";
 import { DriverX, AB, C, R, Step, S, ENV } from "./helpers.ts";
 import { parse_sql_with_sections } from "./parse_sql.js";
 
-const SQL_FILE = ENV("SQL_FILE", "", "Path to SQL file (automatically set if .sql file provided as argument)");
+const SQL_FILE = ENV("SQL_FILE", "./tpcb.sql", "Path to SQL file (automatically set if .sql file provided as argument)");
 
 // TPC-B Configuration Constants
-const SCALE_FACTOR = ENV("SCALE_FACTOR", 1, "TPC-B scale factor");
+const SCALE_FACTOR = ENV(["SCALE_FACTOR", "BRANCHES"], 1, "TPC-B scale factor");
 const BRANCHES = SCALE_FACTOR;
 const TELLERS = 10 * SCALE_FACTOR;
 const ACCOUNTS = 100000 * SCALE_FACTOR;
 
 // K6 options
 export const options: Options = {
-  setupTimeout: "5h",
-  scenarios: {
-    tpcb_transaction: {
-      executor: "constant-vus",
-      exec: "tpcb_transaction",
-      vus: 10,
-      duration: ENV("DURATION", "1h", "Test duration"),
-    },
-  },
+  setupTimeout: String(SCALE_FACTOR) + "m" ,
 };
 
 // Initialize driver with GlobalConfig
@@ -41,8 +33,11 @@ const sql = parse_sql_with_sections(open(SQL_FILE));
 
 // Setup function: create schema and load data
 export function setup() {
-  Step("create_schema", () => {
+  Step("cleanup", () => {
     sql("cleanup").forEach((query) => driver.runQuery(query, {}));
+  })
+
+  Step("create_schema", () => {
     sql("create_schema").forEach((query) => driver.runQuery(query, {}));
   });
 
@@ -90,7 +85,7 @@ const bidGen = R.int32(1, BRANCHES).gen();
 const deltaGen = R.int32(-5000, 5000).gen();
 
 // TPC-B transaction workload
-export function tpcb_transaction() {
+export default function (): void {
   driver.runQuery(sql("workload", "tpcb_transaction")!, {
     p_aid: aidGen.next(),
     p_tid: tidGen.next(),

--- a/workloads/tpcc/tpcc-pick.ts
+++ b/workloads/tpcc/tpcc-pick.ts
@@ -1,0 +1,243 @@
+import { Options } from "k6/options";
+import { Teardown, NewPicker } from "k6/x/stroppy";
+import { DriverConfig_DriverType } from "./stroppy.pb.js";
+import { AB, C, R, Step, DriverX, S } from "./helpers.ts";
+import { parse_sql_with_sections } from "./parse_sql.js";
+
+
+// TPCC Configuration Constants
+const POOL_SIZE = +(__ENV.POOL_SIZE || 100);
+const WAREHOUSES = +(__ENV.SCALE_FACTOR || __ENV.WAREHOUSES || 1);
+const DISTRICTS_PER_WAREHOUSE = 10;
+const CUSTOMERS_PER_DISTRICT = 3000;
+const ITEMS = 100000;
+
+const TOTAL_DISTRICTS = WAREHOUSES * DISTRICTS_PER_WAREHOUSE;
+const TOTAL_CUSTOMERS =
+  WAREHOUSES * DISTRICTS_PER_WAREHOUSE * CUSTOMERS_PER_DISTRICT;
+const TOTAL_STOCK = WAREHOUSES * ITEMS;
+
+export const options: Options = {
+  setupTimeout:  String(WAREHOUSES * 5) + "m", // 5 min for every 1 in scale
+};
+
+// Initialize driver with GlobalConfig
+const driver = DriverX.fromConfig({
+  driver: {
+    url: __ENV.DRIVER_URL || "postgres://postgres:postgres@localhost:5432",
+    driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
+    connectionType: { is: {oneofKind:"sharedPool", sharedPool: {sharedConnections: POOL_SIZE}}},
+    dbSpecific: {
+      fields: [],
+    },
+  },
+});
+
+const sql = parse_sql_with_sections(open(__ENV.SQL_FILE));
+
+export function setup() {
+  Step("create_schema", () => {
+    sql("drop_schema").forEach((query) => driver.runQuery(query, {}));
+    sql("create_schema").forEach((query) => driver.runQuery(query, {}));
+  });
+
+  Step("load_data", () => {
+    // Load data into tables using InsertValues with COPY_FROM method
+    driver.insert("item", ITEMS, {
+      method: "copy_from",
+      params: {
+        i_id: S.int32(1, ITEMS),
+        i_im_id: S.int32(1, ITEMS), // WHY: not unique originaly
+        i_name: R.str(14, 24, AB.enSpc),
+        i_price: R.float(1, 100),
+        i_data: R.str(26, 50, AB.enSpc),
+      },
+    });
+
+    driver.insert("warehouse", WAREHOUSES, {
+      method: "copy_from",
+      params: {
+        w_id: S.int32(1, WAREHOUSES),
+        w_name: R.str(6, 10),
+        w_street_1: R.str(10, 20),
+        w_street_2: R.str(10, 20),
+        w_city: R.str(10, 20),
+        w_state: R.str(2),
+        w_zip: R.str(9, AB.num),
+        w_tax: R.float(0, 0.2),
+        w_ytd: C.float(300000),
+      },
+    });
+
+    driver.insert("district", TOTAL_DISTRICTS, {
+      method: "copy_from",
+      params: {
+        d_name: R.str(6, 10),
+        d_street_1: R.str(10, 20, AB.enSpc),
+        d_street_2: R.str(10, 20, AB.enSpc),
+        d_city: R.str(10, 20, AB.enSpc),
+        d_state: R.str(2, AB.enUpper),
+        d_zip: R.str(9, AB.num),
+        d_tax: R.float(0, 0.2),
+        d_ytd: C.float(30000),
+        d_next_o_id: C.int32(3001),
+      },
+      groups: {
+        district_pk: {
+          d_w_id: S.int32(1, WAREHOUSES),
+          d_id: S.int32(1, DISTRICTS_PER_WAREHOUSE),
+        },
+      },
+    });
+
+    driver.insert("customer", TOTAL_CUSTOMERS, {
+      method: "copy_from",
+      params: {
+        c_first: R.str(8, 16),
+        c_middle: R.str(2, AB.enUpper),
+        c_last: S.str(6, 16),
+        c_street_1: R.str(10, 20, AB.enNumSpc),
+        c_street_2: R.str(10, 20, AB.enNumSpc),
+        c_city: R.str(10, 20, AB.enSpc),
+        c_state: R.str(2, AB.enUpper),
+        c_zip: R.str(9, AB.num),
+        c_phone: R.str(16, AB.num),
+        c_since: C.datetime(new Date()),
+        c_credit: C.str("GC"), // TODO: "GC" | "BC" (good/bad credit), and 10% should be "BC"
+        c_credit_lim: C.float(50000),
+        c_discount: R.float(0, 0.5),
+        c_balance: C.float(-10),
+        c_ytd_payment: C.float(10),
+        c_payment_cnt: C.int32(1),
+        c_delivery_cnt: C.int32(0),
+        c_data: R.str(300, 500, AB.enNumSpc),
+      },
+      groups: {
+        customer_pk: {
+          c_d_id: S.int32(1, DISTRICTS_PER_WAREHOUSE),
+          c_w_id: S.int32(1, WAREHOUSES),
+          c_id: S.int32(1, CUSTOMERS_PER_DISTRICT),
+        },
+      },
+    });
+
+    driver.insert("stock", TOTAL_STOCK, {
+      method: "copy_from",
+      params: {
+        s_quantity: R.int32(10, 100),
+        s_dist_01: R.str(24, AB.enNum),
+        s_dist_02: R.str(24, AB.enNum),
+        s_dist_03: R.str(24, AB.enNum),
+        s_dist_04: R.str(24, AB.enNum),
+        s_dist_05: R.str(24, AB.enNum),
+        s_dist_06: R.str(24, AB.enNum),
+        s_dist_07: R.str(24, AB.enNum),
+        s_dist_08: R.str(24, AB.enNum),
+        s_dist_09: R.str(24, AB.enNum),
+        s_dist_10: R.str(24, AB.enNum),
+        s_ytd: C.int32(0),
+        s_order_cnt: C.int32(0),
+        s_remote_cnt: C.int32(0),
+        s_data: R.str(26, 50, AB.enNumSpc),
+      },
+      groups: {
+        stock_pk: {
+          s_i_id: S.int32(1, ITEMS),
+          s_w_id: S.int32(1, WAREHOUSES),
+        },
+      },
+    });
+  });
+
+  Step.begin("workload");
+  return;
+}
+
+const newOrderWarehouseGen = R.int32(1, WAREHOUSES).gen();
+const newOrderMaxWarehouseGen = C.int32(WAREHOUSES).gen();
+const newOrderDistrictGen = R.int32(1, DISTRICTS_PER_WAREHOUSE).gen();
+const newOrderCustomerGen = R.int32(1, CUSTOMERS_PER_DISTRICT).gen();
+const newOrderOlCntGen = R.int32(5, 15).gen();
+
+function new_order() {
+  driver.runQuery(sql("workload", "new_order")!, {
+    w_id: newOrderWarehouseGen.next(),
+    max_w_id: newOrderMaxWarehouseGen.next(),
+    d_id: newOrderDistrictGen.next(),
+    c_id: newOrderCustomerGen.next(),
+    ol_cnt: newOrderOlCntGen.next(),
+  });
+}
+
+const paymentWarehouseGen = R.int32(1, WAREHOUSES).gen();
+const paymentDistrictGen = R.int32(1, DISTRICTS_PER_WAREHOUSE).gen();
+const paymentCustomerWarehouseGen = R.int32(1, WAREHOUSES).gen();
+const paymentCustomerDistrictGen = R.int32(1, DISTRICTS_PER_WAREHOUSE).gen();
+const paymentCustomerGen = R.int32(1, CUSTOMERS_PER_DISTRICT).gen();
+const paymentAmountGen = R.double(1, 5000).gen();
+const paymentCustomerLastGen = S.str(6, 16).gen();
+
+function payments() {
+  driver.runQuery(sql("workload", "payment")!, {
+      p_w_id: paymentWarehouseGen.next(),
+      p_d_id: paymentDistrictGen.next(),
+      p_c_w_id: paymentCustomerWarehouseGen.next(),
+      p_c_d_id: paymentCustomerDistrictGen.next(),
+      p_c_id: paymentCustomerGen.next(),
+      byname: 0,
+      h_amount: paymentAmountGen.next(),
+      c_last: paymentCustomerLastGen.next(),
+    },
+  );
+}
+
+const orderStatusWarehouseGen = R.int32(1, WAREHOUSES).gen();
+const orderStatusDistrictGen = R.int32(1, DISTRICTS_PER_WAREHOUSE).gen();
+const orderStatusCustomerGen = R.int32(1, CUSTOMERS_PER_DISTRICT).gen();
+const orderStatusCustomerLastGen = R.str(8, 16).gen();
+
+function order_status() {
+  driver.runQuery(sql("workload", "order_status")!, {
+      os_w_id: orderStatusWarehouseGen.next(),
+      os_d_id: orderStatusDistrictGen.next(),
+      os_c_id: orderStatusCustomerGen.next(),
+      byname: 0,
+      os_c_last: orderStatusCustomerLastGen.next(),
+    },
+  );
+}
+
+const deliveryWarehouseGen = R.int32(1, WAREHOUSES).gen();
+const deliveryCarrierGen = R.int32(1, DISTRICTS_PER_WAREHOUSE).gen();
+
+function delivery() {
+  driver.runQuery(sql("workload", "delivery")!, {
+    d_w_id: deliveryWarehouseGen.next(),
+    d_o_carrier_id: deliveryCarrierGen.next(),
+  });
+}
+
+const stockLevelWarehouseGen = R.int32(1, WAREHOUSES).gen();
+const stockLevelDistrictGen = R.int32(1, DISTRICTS_PER_WAREHOUSE).gen();
+const stockLevelThresholdGen = R.int32(10, 20).gen();
+
+function stock_level() {
+  driver.runQuery(sql("workload", "stock_level")!, {
+    st_w_id: stockLevelWarehouseGen.next(),
+    st_d_id: stockLevelDistrictGen.next(),
+    threshold: stockLevelThresholdGen.next(),
+  });
+}
+
+const picker = NewPicker(0)
+export default function (): void {
+  const workload = picker.pickWeighted(
+    [new_order, payments, order_status, delivery, stock_level],
+    [44,        43,       4,            4,        4]) as () => void;
+  workload()
+}
+
+export function teardown() {
+  Step.begin("workload");
+  Teardown();
+}

--- a/workloads/tpcc/tpcc-pick.ts
+++ b/workloads/tpcc/tpcc-pick.ts
@@ -1,13 +1,15 @@
 import { Options } from "k6/options";
 import { Teardown, NewPicker } from "k6/x/stroppy";
 import { DriverConfig_DriverType } from "./stroppy.pb.js";
-import { AB, C, R, Step, DriverX, S } from "./helpers.ts";
+import { AB, C, R, Step, DriverX, S, ENV } from "./helpers.ts";
 import { parse_sql_with_sections } from "./parse_sql.js";
 
 
+const SQL_FILE = ENV("SQL_FILE", "", "Path to SQL file (automatically set if .sql file provided as argument)");
+
 // TPCC Configuration Constants
-const POOL_SIZE = +(__ENV.POOL_SIZE || 100);
-const WAREHOUSES = +(__ENV.SCALE_FACTOR || __ENV.WAREHOUSES || 1);
+const POOL_SIZE = ENV("POOL_SIZE", 100, "Connection pool size");
+const WAREHOUSES = ENV(["SCALE_FACTOR", "WAREHOUSES"], 1, "Number of warehouses");
 const DISTRICTS_PER_WAREHOUSE = 10;
 const CUSTOMERS_PER_DISTRICT = 3000;
 const ITEMS = 100000;
@@ -24,7 +26,7 @@ export const options: Options = {
 // Initialize driver with GlobalConfig
 const driver = DriverX.fromConfig({
   driver: {
-    url: __ENV.DRIVER_URL || "postgres://postgres:postgres@localhost:5432",
+    url: ENV("DRIVER_URL", "postgres://postgres:postgres@localhost:5432", "Database connection URL"),
     driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
     connectionType: { is: {oneofKind:"sharedPool", sharedPool: {sharedConnections: POOL_SIZE}}},
     dbSpecific: {
@@ -33,7 +35,7 @@ const driver = DriverX.fromConfig({
   },
 });
 
-const sql = parse_sql_with_sections(open(__ENV.SQL_FILE));
+const sql = parse_sql_with_sections(open(SQL_FILE));
 
 export function setup() {
   Step("create_schema", () => {

--- a/workloads/tpcc/tpcc-pick.ts
+++ b/workloads/tpcc/tpcc-pick.ts
@@ -5,7 +5,7 @@ import { AB, C, R, Step, DriverX, S, ENV } from "./helpers.ts";
 import { parse_sql_with_sections } from "./parse_sql.js";
 
 
-const SQL_FILE = ENV("SQL_FILE", "", "Path to SQL file (automatically set if .sql file provided as argument)");
+const SQL_FILE = ENV("SQL_FILE", "./tpcc.sql", "Path to SQL file (automatically set if .sql file provided as argument)");
 
 // TPCC Configuration Constants
 const POOL_SIZE = ENV("POOL_SIZE", 100, "Connection pool size");
@@ -38,8 +38,11 @@ const driver = DriverX.fromConfig({
 const sql = parse_sql_with_sections(open(SQL_FILE));
 
 export function setup() {
-  Step("create_schema", () => {
+  Step("drop_schema", () => {
     sql("drop_schema").forEach((query) => driver.runQuery(query, {}));
+  })
+
+  Step("create_schema", () => {
     sql("create_schema").forEach((query) => driver.runQuery(query, {}));
   });
 

--- a/workloads/tpcc/tpcc.ts
+++ b/workloads/tpcc/tpcc.ts
@@ -1,11 +1,12 @@
 import { Options } from "k6/options";
 import { Teardown } from "k6/x/stroppy";
 import { DriverConfig_DriverType } from "./stroppy.pb.js";
-import { AB, C, R, Step, DriverX, S } from "./helpers.ts";
+import { AB, C, R, Step, DriverX, S, ENV } from "./helpers.ts";
 import { parse_sql_with_sections } from "./parse_sql.js";
 
-const DURATION = __ENV.DURATION || "1h";
-const VUS_SCALE = +(__ENV.VUS_SCALE || 1);
+const SQL_FILE = ENV("SQL_FILE", "", "Path to SQL file (automatically set if .sql file provided as argument)");
+const DURATION = ENV("DURATION", "1h", "Test duration");
+const VUS_SCALE = ENV("VUS_SCALE", 1, "VU scaling factor");
 export const options: Options = {
   setupTimeout: "5m",
   scenarios: {
@@ -42,8 +43,8 @@ export const options: Options = {
   },
 };
 // TPCC Configuration Constants
-const POOL_SIZE = +(__ENV.POOL_SIZE || 100);
-const WAREHOUSES = +(__ENV.SCALE_FACTOR || __ENV.WAREHOUSES || 1);
+const POOL_SIZE = ENV("POOL_SIZE", 100, "Connection pool size");
+const WAREHOUSES = ENV(["SCALE_FACTOR", "WAREHOUSES"], 1, "Number of warehouses");
 const DISTRICTS_PER_WAREHOUSE = 10;
 const CUSTOMERS_PER_DISTRICT = 3000;
 const ITEMS = 100000;
@@ -56,7 +57,7 @@ const TOTAL_STOCK = WAREHOUSES * ITEMS;
 // Initialize driver with GlobalConfig
 const driver = DriverX.fromConfig({
   driver: {
-    url: __ENV.DRIVER_URL || "postgres://postgres:postgres@localhost:5432",
+    url: ENV("DRIVER_URL", "postgres://postgres:postgres@localhost:5432", "Database connection URL"),
     driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
     connectionType: { is: {oneofKind:"sharedPool", sharedPool: {sharedConnections: POOL_SIZE}}},
     dbSpecific: {
@@ -65,7 +66,7 @@ const driver = DriverX.fromConfig({
   },
 });
 
-const sql = parse_sql_with_sections(open(__ENV.SQL_FILE));
+const sql = parse_sql_with_sections(open(SQL_FILE));
 
 export function setup() {
   Step("create_schema", () => {

--- a/workloads/tpcc/tpcc.ts
+++ b/workloads/tpcc/tpcc.ts
@@ -4,7 +4,7 @@ import { DriverConfig_DriverType } from "./stroppy.pb.js";
 import { AB, C, R, Step, DriverX, S, ENV } from "./helpers.ts";
 import { parse_sql_with_sections } from "./parse_sql.js";
 
-const SQL_FILE = ENV("SQL_FILE", "", "Path to SQL file (automatically set if .sql file provided as argument)");
+const SQL_FILE = ENV("SQL_FILE", "./tpcc.sql", "Path to SQL file (automatically set if .sql file provided as argument)");
 const DURATION = ENV("DURATION", "1h", "Test duration");
 const VUS_SCALE = ENV("VUS_SCALE", 1, "VU scaling factor");
 export const options: Options = {
@@ -69,8 +69,11 @@ const driver = DriverX.fromConfig({
 const sql = parse_sql_with_sections(open(SQL_FILE));
 
 export function setup() {
-  Step("create_schema", () => {
+  Step("drop_schema", () => {
     sql("drop_schema").forEach((query) => driver.runQuery(query, {}));
+  })
+
+  Step("create_schema", () => {
     sql("create_schema").forEach((query) => driver.runQuery(query, {}));
   });
 

--- a/workloads/tpcds/tpcds.ts
+++ b/workloads/tpcds/tpcds.ts
@@ -7,15 +7,8 @@ import { parse_sql } from "./parse_sql.js";
 const SQL_FILE = ENV("SQL_FILE", "", "Path to SQL file (automatically set if .sql file provided as argument)");
 
 export const options: Options = {
-  setupTimeout: "5m",
-  scenarios: {
-    workload: {
-      executor: "shared-iterations",
-      exec: "workload",
-      vus: 1,
-      iterations: 1,
-    },
-  },
+  vus: 1,
+  iterations: 1,
 };
 
 // Initialize driver with GlobalConfig
@@ -23,14 +16,7 @@ const driver = DriverX.fromConfig({
   driver: {
     url: ENV("DRIVER_URL", "postgres://postgres:postgres@localhost:5432", "Database connection URL"),
     driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
-    dbSpecific: {
-      fields: [],
-    },
   },
-  version: "",
-  runId: "",
-  seed: "0",
-  metadata: {},
 });
 
 const queries = parse_sql(open(SQL_FILE));
@@ -40,7 +26,7 @@ export function setup() {
   return;
 }
 
-export function workload() {
+export default function (): void {
   queries().forEach((query) => {
     console.log(`tpc-ds-like: ${query.name}`);
     driver.runQuery(query, {});

--- a/workloads/tpcds/tpcds.ts
+++ b/workloads/tpcds/tpcds.ts
@@ -1,8 +1,10 @@
 import { Options } from "k6/options";
 import { Teardown } from "k6/x/stroppy";
 import { DriverConfig_DriverType } from "./stroppy.pb.js";
-import { DriverX, Step } from "./helpers.ts";
+import { DriverX, Step, ENV } from "./helpers.ts";
 import { parse_sql } from "./parse_sql.js";
+
+const SQL_FILE = ENV("SQL_FILE", "", "Path to SQL file (automatically set if .sql file provided as argument)");
 
 export const options: Options = {
   setupTimeout: "5m",
@@ -19,7 +21,7 @@ export const options: Options = {
 // Initialize driver with GlobalConfig
 const driver = DriverX.fromConfig({
   driver: {
-    url: __ENV.DRIVER_URL || "postgres://postgres:postgres@localhost:5432",
+    url: ENV("DRIVER_URL", "postgres://postgres:postgres@localhost:5432", "Database connection URL"),
     driverType: DriverConfig_DriverType.DRIVER_TYPE_POSTGRES,
     dbSpecific: {
       fields: [],
@@ -31,7 +33,7 @@ const driver = DriverX.fromConfig({
   metadata: {},
 });
 
-const queries = parse_sql(open(__ENV.SQL_FILE));
+const queries = parse_sql(open(SQL_FILE));
 
 export function setup() {
   Step.begin("workload");


### PR DESCRIPTION
## Description of Changes

### `ENV()` — typed environment variable accessor
Replaces raw `__ENV` access with `ENV(name, default, description)`. Supports aliases (array of names), typed defaults (string/number), and descriptions. Metadata is captured by probe for the new `--envs` section.

```ts
const WAREHOUSES = ENV(["SCALE_FACTOR", "WAREHOUSES"], 1, "Number of warehouses");
const DRIVER_URL = ENV("DRIVER_URL", "postgres://postgres:postgres@localhost:5432", "Database connection URL");
```

### `NewPicker(seed)` — weighted random selection
Provides `picker.pick(items)` for uniform and `picker.pickWeighted(items, weights)` for weighted selection. Used in new `tpcc-pick.ts` workload for TPC-C transaction mix (44/43/4/4/4):

```ts
const picker = NewPicker(0);
export default function (): void {
  const workload = picker.pickWeighted(
    [new_order, payments, order_status, delivery, stock_level],
    [44,        43,       4,            4,        4]) as () => void;
  workload();
}
```

### `--steps` / `--no-steps` — step filtering
Select or exclude steps at run time without editing the script:
```
stroppy run tpcc --steps create_schema,load_data
stroppy run tpcc --no-steps drop_schema
```
Step names are validated against probed steps; unknown names produce an error.

### Probe section flags
`probe` now supports `--config`, `--options`, `--sql`, `--steps`, `--envs` to show individual sections. Example `stroppy probe tpcc --envs`:

```
# Environment Variables:
  STROPPY_STEPS=""  # comma-separated list of steps to run (allowlist), same as --steps
  STROPPY_NO_STEPS=""  # comma-separated list of steps to skip (blocklist), same as --no-steps
  SQL_FILE="" (default: ./tpcc.sql)  # Path to SQL file (automatically set if .sql file provided as argument)
  DURATION="" (default: 1h)  # Test duration
  VUS_SCALE="" (default: 1)  # VU scaling factor
  POOL_SIZE="" (default: 100)  # Connection pool size
  SCALE_FACTOR | WAREHOUSES="" (default: 1)  # Number of warehouses
  DRIVER_URL="" (default: postgres://postgres:postgres@localhost:5432)  # Database connection URL
```

### Other changes
- All workloads migrated from `__ENV` to `ENV()`
- `drop_schema` split into its own step in tpcb/tpcc
- tpcb/tpcds: simplified k6 options, use `default` export
- New `tpcc-pick.ts` workload (picker-based transaction mix)
- New `run-tpcc-pick-test` Makefile target

## Motivation and Context
Scripts needed a structured way to declare environment variables with defaults and documentation. Weighted random selection was needed for realistic TPC-C transaction mix. Step filtering allows partial re-runs (e.g. skip schema creation during development).

## How Has This Been Tested?
`make run-tpcc-pick-test`, `make run-tpcb-test`, `make run-simple-test`

## Type of Changes
- [x] New feature
- [x] Refactoring

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] I have checked build and tests
- [x] I have updated documentation if needed