### PR TITLE
perf(datagen): reduce row-generation and bulk-insert allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@ proto/bin
 .idea
 # test coverage
 coverage.out
+# datagen perf profiling artifacts
+/tmp/
+*.test
+*.pprof
+*.mem
+*.trace
+cpu.out
+mem.out
 #
 venv
 *node_modules

--- a/pkg/datagen/expr/grammar.go
+++ b/pkg/datagen/expr/grammar.go
@@ -17,6 +17,11 @@ import (
 // require padding.
 const grammarMaxAttempts = 8
 
+// grammarGrowSlack is added to max_len when sizing the walk buffer so a typical
+// untruncated walk (which may overshoot max_len before truncation) fits in one
+// allocation. Overshoots beyond this trigger at most one append regrowth.
+const grammarGrowSlack = 64
+
 // keyedDrawer is an optional Context capability: return a PRNG seeded directly
 // from a precomputed sub-stream key, reusing the context's pooled PCG instead
 // of allocating a fresh source per call. The produced stream is identical to
@@ -96,22 +101,20 @@ func drawGrammar(
 	// second formula.
 	rootKey := rootPRNG.Uint64()
 
-	// out is reused across attempts: each attempt Resets and rebuilds it.
-	// last always views the most recent attempt's backing (no Reset follows
-	// the attempt that produces the returned value), so reuse is safe and
-	// the result costs one backing allocation per row rather than per walk.
 	var (
 		out  strings.Builder
 		last string
 	)
 
-	out.Grow(int(maxLen) + utf8.UTFMax)
-
 	for attempt := range grammarMaxAttempts {
 		walkKey := seed.DeriveGrammarAttempt(rootKey, attempt)
 		prng := grammarPRNG(ctx, walkKey)
 
+		// Reset clears the backing slice; Grow must follow it (not precede
+		// the loop) so each attempt builds into one sized allocation rather
+		// than regrowing geometrically from nil.
 		out.Reset()
+		out.Grow(int(maxLen) + grammarGrowSlack)
 
 		if walkErr := walkGrammar(ctx, prng, grammar, &out); walkErr != nil {
 			return nil, walkErr

--- a/pkg/datagen/expr/grammar.go
+++ b/pkg/datagen/expr/grammar.go
@@ -275,18 +275,18 @@ func resolveLeaf(
 	return pickTemplate(prng, dict, leafKey)
 }
 
-// forEachField invokes fn for each whitespace-delimited field of s, matching
+// forEachField invokes fn for each whitespace-delimited field of text, matching
 // strings.Fields semantics (runs of unicode.IsSpace separate fields; leading,
 // trailing, and repeated whitespace are ignored) but without allocating a
-// []string — each token is a sub-slice of s. fn returning a non-nil error
+// []string — each token is a sub-slice of text. fn returning a non-nil error
 // stops iteration and is propagated.
-func forEachField(s string, fn func(tok string) error) error {
+func forEachField(text string, fn func(tok string) error) error {
 	start := -1
 
-	for i, r := range s {
+	for i, r := range text {
 		if unicode.IsSpace(r) {
 			if start >= 0 {
-				if err := fn(s[start:i]); err != nil {
+				if err := fn(text[start:i]); err != nil {
 					return err
 				}
 
@@ -302,7 +302,7 @@ func forEachField(s string, fn func(tok string) error) error {
 	}
 
 	if start >= 0 {
-		return fn(s[start:])
+		return fn(text[start:])
 	}
 
 	return nil
@@ -355,26 +355,26 @@ func grammarLetter(tok string) (string, bool) {
 	return tok, true
 }
 
-// truncateRunes truncates s to at most n Unicode runes without allocating a
+// truncateRunes truncates text to at most n Unicode runes without allocating a
 // []rune: it scans rune boundaries and slices at the n-th one. It counts runes
 // rather than bytes because dict contents may carry non-ASCII words (e.g.
 // "sauternes", "Tiresias" in the TPC-H grammar).
-func truncateRunes(s string, n int64) string {
+func truncateRunes(text string, n int64) string {
 	if n <= 0 {
 		return ""
 	}
 
 	count := int64(0)
 
-	for i := range s {
+	for i := range text {
 		if count == n {
-			return s[:i]
+			return text[:i]
 		}
 
 		count++
 	}
 
-	return s
+	return text
 }
 
 // truncateRunesToString returns the first n runes of buf as a freshly
@@ -382,22 +382,20 @@ func truncateRunes(s string, n int64) string {
 // (min(n, total runes)). It counts runes rather than bytes so multi-byte dict
 // words are never split mid-rune. The returned string copies buf, so the
 // caller may reuse buf afterward.
-func truncateRunesToString(buf []byte, n int64) (string, int64) {
+func truncateRunesToString(buf []byte, n int64) (truncated string, runeCount int64) {
 	if n <= 0 {
 		return "", 0
 	}
 
-	count := int64(0)
-
 	for i := 0; i < len(buf); {
-		if count == n {
-			return string(buf[:i]), count
+		if runeCount == n {
+			return string(buf[:i]), runeCount
 		}
 
 		_, size := utf8.DecodeRune(buf[i:])
 		i += size
-		count++
+		runeCount++
 	}
 
-	return string(buf), count
+	return string(buf), runeCount
 }

--- a/pkg/datagen/expr/grammar.go
+++ b/pkg/datagen/expr/grammar.go
@@ -3,7 +3,6 @@ package expr
 import (
 	"fmt"
 	"math/rand/v2"
-	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -16,11 +15,6 @@ import (
 // drawGrammar returns the last walk result as-is; the spec does not
 // require padding.
 const grammarMaxAttempts = 8
-
-// grammarGrowSlack is added to max_len when sizing the walk buffer so a typical
-// untruncated walk (which may overshoot max_len before truncation) fits in one
-// allocation. Overshoots beyond this trigger at most one append regrowth.
-const grammarGrowSlack = 64
 
 // keyedDrawer is an optional Context capability: return a PRNG seeded directly
 // from a precomputed sub-stream key, reusing the context's pooled PCG instead
@@ -39,6 +33,29 @@ func grammarPRNG(ctx Context, key uint64) *rand.Rand {
 	}
 
 	return seed.PRNG(key)
+}
+
+// grammarBufferer is an optional Context capability: lend a reusable byte
+// buffer for assembling grammar output. Reusing a context-owned buffer across
+// rows means a grammar draw allocates only its final, exact-sized result
+// string rather than an over-sized builder backing per re-walk attempt.
+// evalContext and the lookup popCtx implement it; other contexts get a local
+// buffer (one slice per call).
+type grammarBufferer interface {
+	GrammarScratch() *[]byte
+}
+
+// grammarScratch returns a reusable assembly buffer for one grammar draw. For
+// contexts that own a buffer it is reused across rows; otherwise a fresh local
+// slice is returned.
+func grammarScratch(ctx Context) *[]byte {
+	if gb, ok := ctx.(grammarBufferer); ok {
+		return gb.GrammarScratch()
+	}
+
+	var local []byte
+
+	return &local
 }
 
 // drawGrammar implements DrawGrammar — a two-phase template walker.
@@ -101,27 +118,29 @@ func drawGrammar(
 	// second formula.
 	rootKey := rootPRNG.Uint64()
 
+	// buf is a context-owned, reused assembly buffer: after warm-up it holds
+	// capacity across rows and attempts, so each walk appends without
+	// allocating. Only the truncated result string is freshly allocated (at
+	// its exact length) per returned row.
+	buf := grammarScratch(ctx)
+
 	var (
-		out  strings.Builder
-		last string
+		last     string
+		lastRune int64
 	)
 
 	for attempt := range grammarMaxAttempts {
 		walkKey := seed.DeriveGrammarAttempt(rootKey, attempt)
 		prng := grammarPRNG(ctx, walkKey)
 
-		// Reset clears the backing slice; Grow must follow it (not precede
-		// the loop) so each attempt builds into one sized allocation rather
-		// than regrowing geometrically from nil.
-		out.Reset()
-		out.Grow(int(maxLen) + grammarGrowSlack)
+		*buf = (*buf)[:0]
 
-		if walkErr := walkGrammar(ctx, prng, grammar, &out); walkErr != nil {
+		if walkErr := walkGrammar(ctx, prng, grammar, buf); walkErr != nil {
 			return nil, walkErr
 		}
 
-		last = truncateRunes(out.String(), maxLen)
-		if int64(utf8.RuneCountInString(last)) >= minLen {
+		last, lastRune = truncateRunesToString(*buf, maxLen)
+		if lastRune >= minLen {
 			return last, nil
 		}
 	}
@@ -137,7 +156,7 @@ func walkGrammar(
 	ctx Context,
 	prng *rand.Rand,
 	grammar *dgproto.DrawGrammar,
-	out *strings.Builder,
+	out *[]byte,
 ) error {
 	rootDict, err := ctx.LookupDict(grammar.GetRootDict())
 	if err != nil {
@@ -154,14 +173,14 @@ func walkGrammar(
 
 	return forEachField(rootTemplate, func(tok string) error {
 		if !first {
-			out.WriteByte(' ')
+			*out = append(*out, ' ')
 		}
 
 		first = false
 
 		letter, ok := grammarLetter(tok)
 		if !ok {
-			out.WriteString(tok)
+			*out = append(*out, tok...)
 
 			return nil
 		}
@@ -175,7 +194,7 @@ func walkGrammar(
 			return leafErr
 		}
 
-		out.WriteString(leaf)
+		*out = append(*out, leaf...)
 
 		return nil
 	})
@@ -193,7 +212,7 @@ func expandPhrase(
 	grammar *dgproto.DrawGrammar,
 	phraseDictKey string,
 	letter string,
-	out *strings.Builder,
+	out *[]byte,
 ) error {
 	dict, err := ctx.LookupDict(phraseDictKey)
 	if err != nil {
@@ -210,14 +229,14 @@ func expandPhrase(
 
 	return forEachField(template, func(tok string) error {
 		if !first {
-			out.WriteByte(' ')
+			*out = append(*out, ' ')
 		}
 
 		first = false
 
 		subLetter, ok := grammarLetter(tok)
 		if !ok {
-			out.WriteString(tok)
+			*out = append(*out, tok...)
 
 			return nil
 		}
@@ -227,7 +246,7 @@ func expandPhrase(
 			return leafErr
 		}
 
-		out.WriteString(leaf)
+		*out = append(*out, leaf...)
 
 		return nil
 	})
@@ -356,4 +375,29 @@ func truncateRunes(s string, n int64) string {
 	}
 
 	return s
+}
+
+// truncateRunesToString returns the first n runes of buf as a freshly
+// allocated, exactly-sized string, along with that string's rune count
+// (min(n, total runes)). It counts runes rather than bytes so multi-byte dict
+// words are never split mid-rune. The returned string copies buf, so the
+// caller may reuse buf afterward.
+func truncateRunesToString(buf []byte, n int64) (string, int64) {
+	if n <= 0 {
+		return "", 0
+	}
+
+	count := int64(0)
+
+	for i := 0; i < len(buf); {
+		if count == n {
+			return string(buf[:i]), count
+		}
+
+		_, size := utf8.DecodeRune(buf[i:])
+		i += size
+		count++
+	}
+
+	return string(buf), count
 }

--- a/pkg/datagen/expr/grammar.go
+++ b/pkg/datagen/expr/grammar.go
@@ -3,8 +3,9 @@ package expr
 import (
 	"fmt"
 	"math/rand/v2"
-	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/stroppy-io/stroppy/pkg/datagen/dgproto"
 	"github.com/stroppy-io/stroppy/pkg/datagen/seed"
@@ -15,6 +16,25 @@ import (
 // drawGrammar returns the last walk result as-is; the spec does not
 // require padding.
 const grammarMaxAttempts = 8
+
+// keyedDrawer is an optional Context capability: return a PRNG seeded directly
+// from a precomputed sub-stream key, reusing the context's pooled PCG instead
+// of allocating a fresh source per call. The produced stream is identical to
+// seed.PRNG(key) (both route through SeedPCG). evalContext and the lookup
+// popCtx implement it; contexts that do not fall back to seed.PRNG.
+type keyedDrawer interface {
+	DrawKey(key uint64) *rand.Rand
+}
+
+// grammarPRNG returns the PRNG for one grammar walk attempt. It reuses the
+// context's pooled PCG when available so the re-walk loop allocates no PRNG.
+func grammarPRNG(ctx Context, key uint64) *rand.Rand {
+	if kd, ok := ctx.(keyedDrawer); ok {
+		return kd.DrawKey(key)
+	}
+
+	return seed.PRNG(key)
+}
 
 // drawGrammar implements DrawGrammar — a two-phase template walker.
 // The walker picks a template from root_dict, splits it on whitespace,
@@ -76,19 +96,29 @@ func drawGrammar(
 	// second formula.
 	rootKey := rootPRNG.Uint64()
 
-	var last string
+	// out is reused across attempts: each attempt Resets and rebuilds it.
+	// last always views the most recent attempt's backing (no Reset follows
+	// the attempt that produces the returned value), so reuse is safe and
+	// the result costs one backing allocation per row rather than per walk.
+	var (
+		out  strings.Builder
+		last string
+	)
+
+	out.Grow(int(maxLen) + utf8.UTFMax)
 
 	for attempt := range grammarMaxAttempts {
-		walkKey := seed.Derive(rootKey, "grammar", strconv.Itoa(attempt))
-		prng := seed.PRNG(walkKey)
+		walkKey := seed.DeriveGrammarAttempt(rootKey, attempt)
+		prng := grammarPRNG(ctx, walkKey)
 
-		out, walkErr := walkGrammar(ctx, prng, grammar)
-		if walkErr != nil {
+		out.Reset()
+
+		if walkErr := walkGrammar(ctx, prng, grammar, &out); walkErr != nil {
 			return nil, walkErr
 		}
 
-		last = truncateRunes(out, maxLen)
-		if int64(len([]rune(last))) >= minLen {
+		last = truncateRunes(out.String(), maxLen)
+		if int64(utf8.RuneCountInString(last)) >= minLen {
 			return last, nil
 		}
 	}
@@ -96,108 +126,108 @@ func drawGrammar(
 	return last, nil
 }
 
-// walkGrammar picks a root template, then walks its tokens: literal
-// tokens pass through, single-uppercase-letter tokens resolve through
-// phrases (one level) or leaves. Returns ErrBadGrammar when a letter
-// resolves through neither map.
+// walkGrammar picks a root template, then walks its tokens directly into out:
+// literal tokens pass through, single-uppercase-letter tokens resolve through
+// phrases (one level) or leaves. Returns ErrBadGrammar when a letter resolves
+// through neither map.
 func walkGrammar(
 	ctx Context,
 	prng *rand.Rand,
 	grammar *dgproto.DrawGrammar,
-) (string, error) {
+	out *strings.Builder,
+) error {
 	rootDict, err := ctx.LookupDict(grammar.GetRootDict())
 	if err != nil {
-		return "", fmt.Errorf("%w: root_dict %q: %w",
+		return fmt.Errorf("%w: root_dict %q: %w",
 			ErrBadGrammar, grammar.GetRootDict(), err)
 	}
 
 	rootTemplate, err := pickTemplate(prng, rootDict, grammar.GetRootDict())
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	var out strings.Builder
+	first := true
 
-	for i, tok := range strings.Fields(rootTemplate) {
-		if i > 0 {
+	return forEachField(rootTemplate, func(tok string) error {
+		if !first {
 			out.WriteByte(' ')
 		}
+
+		first = false
 
 		letter, ok := grammarLetter(tok)
 		if !ok {
 			out.WriteString(tok)
 
-			continue
+			return nil
 		}
 
 		if dictKey, phraseOK := grammar.GetPhrases()[letter]; phraseOK {
-			expanded, expandErr := expandPhrase(ctx, prng, grammar, dictKey, letter)
-			if expandErr != nil {
-				return "", expandErr
-			}
-
-			out.WriteString(expanded)
-
-			continue
+			return expandPhrase(ctx, prng, grammar, dictKey, letter, out)
 		}
 
 		leaf, leafErr := resolveLeaf(ctx, prng, grammar, letter)
 		if leafErr != nil {
-			return "", leafErr
+			return leafErr
 		}
 
 		out.WriteString(leaf)
-	}
 
-	return out.String(), nil
+		return nil
+	})
 }
 
 // expandPhrase picks a template from the phrase dict referenced by
 // `letter`, splits it into tokens, and resolves every single-letter
-// token through the grammar's leaves map. Only one expansion level is
-// permitted: if an expanded token is itself a nonterminal, it must
-// resolve into leaves — nested phrase references are rejected.
+// token through the grammar's leaves map, writing directly into out.
+// Only one expansion level is permitted: if an expanded token is itself a
+// nonterminal, it must resolve into leaves — nested phrase references are
+// rejected.
 func expandPhrase(
 	ctx Context,
 	prng *rand.Rand,
 	grammar *dgproto.DrawGrammar,
 	phraseDictKey string,
 	letter string,
-) (string, error) {
+	out *strings.Builder,
+) error {
 	dict, err := ctx.LookupDict(phraseDictKey)
 	if err != nil {
-		return "", fmt.Errorf("%w: phrase dict %q for %q: %w",
+		return fmt.Errorf("%w: phrase dict %q for %q: %w",
 			ErrBadGrammar, phraseDictKey, letter, err)
 	}
 
 	template, err := pickTemplate(prng, dict, phraseDictKey)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	var out strings.Builder
+	first := true
 
-	for i, tok := range strings.Fields(template) {
-		if i > 0 {
+	return forEachField(template, func(tok string) error {
+		if !first {
 			out.WriteByte(' ')
 		}
+
+		first = false
 
 		subLetter, ok := grammarLetter(tok)
 		if !ok {
 			out.WriteString(tok)
 
-			continue
+			return nil
 		}
 
 		leaf, leafErr := resolveLeaf(ctx, prng, grammar, subLetter)
 		if leafErr != nil {
-			return "", leafErr
+			return leafErr
 		}
 
 		out.WriteString(leaf)
-	}
 
-	return out.String(), nil
+		return nil
+	})
 }
 
 // resolveLeaf picks a leaf word from the dict referenced by `letter`.
@@ -221,6 +251,39 @@ func resolveLeaf(
 	}
 
 	return pickTemplate(prng, dict, leafKey)
+}
+
+// forEachField invokes fn for each whitespace-delimited field of s, matching
+// strings.Fields semantics (runs of unicode.IsSpace separate fields; leading,
+// trailing, and repeated whitespace are ignored) but without allocating a
+// []string — each token is a sub-slice of s. fn returning a non-nil error
+// stops iteration and is propagated.
+func forEachField(s string, fn func(tok string) error) error {
+	start := -1
+
+	for i, r := range s {
+		if unicode.IsSpace(r) {
+			if start >= 0 {
+				if err := fn(s[start:i]); err != nil {
+					return err
+				}
+
+				start = -1
+			}
+
+			continue
+		}
+
+		if start < 0 {
+			start = i
+		}
+	}
+
+	if start >= 0 {
+		return fn(s[start:])
+	}
+
+	return nil
 }
 
 // pickTemplate draws one row from dict. When the dict declares any
@@ -270,18 +333,24 @@ func grammarLetter(tok string) (string, bool) {
 	return tok, true
 }
 
-// truncateRunes truncates s to at most n Unicode runes. It counts
-// runes rather than bytes because dict contents may carry non-ASCII
-// words (e.g. "sauternes", "Tiresias" in the TPC-H grammar).
+// truncateRunes truncates s to at most n Unicode runes without allocating a
+// []rune: it scans rune boundaries and slices at the n-th one. It counts runes
+// rather than bytes because dict contents may carry non-ASCII words (e.g.
+// "sauternes", "Tiresias" in the TPC-H grammar).
 func truncateRunes(s string, n int64) string {
 	if n <= 0 {
 		return ""
 	}
 
-	runes := []rune(s)
-	if int64(len(runes)) <= n {
-		return s
+	count := int64(0)
+
+	for i := range s {
+		if count == n {
+			return s[:i]
+		}
+
+		count++
 	}
 
-	return string(runes[:n])
+	return s
 }

--- a/pkg/datagen/expr/grammar_bench_test.go
+++ b/pkg/datagen/expr/grammar_bench_test.go
@@ -1,0 +1,73 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stroppy-io/stroppy/pkg/datagen/dgproto"
+)
+
+// benchCommentCtx builds the realistic TPC-H comment grammar used by the e2e
+// lineitem benchmark: single-uppercase-letter nonterminals (J adjective, N
+// noun, V verb, T terminator) resolved through word dicts whose root templates
+// land in the 40..83 char window, so the COMMON walk path is measured rather
+// than the re-walk-exhaustion pathology of a letter-free template.
+func benchCommentCtx() *fakeCtx {
+	ctx := newFakeCtx()
+	ctx.attrPath = "l_comment"
+	ctx.dicts["g_root"] = multiDict(
+		"the J N V the J N T",
+		"J N V about the J N T",
+		"N V according to the J N T",
+		"the J N V quickly the N T",
+		"J N V along the J N V T",
+	)
+	ctx.dicts["g_adj"] = multiDict("furious", "sly", "careful", "blithe", "quick",
+		"final", "ironic", "even", "bold", "express", "regular", "special")
+	ctx.dicts["g_noun"] = multiDict("packages", "requests", "accounts", "deposits",
+		"theodolites", "instructions", "platelets", "foxes", "dolphins",
+		"warthogs", "excuses", "dependencies")
+	ctx.dicts["g_verb"] = multiDict("wake", "sleep", "cajole", "integrate", "haggle",
+		"nag", "sublate", "boost", "detect", "affix", "promise", "snooze")
+	ctx.dicts["g_term"] = multiDict(".", "!")
+
+	return ctx
+}
+
+func benchCommentGrammar() *dgproto.DrawGrammar {
+	return &dgproto.DrawGrammar{
+		RootDict: "g_root",
+		Leaves:   map[string]string{"J": "g_adj", "N": "g_noun", "V": "g_verb", "T": "g_term"},
+		MinLen:   litInt(40),
+		MaxLen:   litInt(83),
+	}
+}
+
+// BenchmarkDrawGrammarComment is the single hottest datagen allocation site
+// (~53% of lineitem alloc_objects in the baseline profile): strings.Fields per
+// walk, a fresh seed.PRNG (NewPCG) per re-walk attempt, a strings.Builder, and
+// []rune truncation. Each iteration generates one comment for a fresh row.
+func BenchmarkDrawGrammarComment(b *testing.B) {
+	ctx := benchCommentCtx()
+	e := grammarExpr(99, benchCommentGrammar())
+
+	b.ReportAllocs()
+
+	var (
+		sink string
+		i    int64
+	)
+
+	for b.Loop() {
+		ctx.rowIndex[dgproto.RowIndex_UNSPECIFIED] = i
+		i++
+
+		v, err := Eval(ctx, e)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		sink, _ = v.(string)
+	}
+
+	_ = sink
+}

--- a/pkg/datagen/expr/slot.go
+++ b/pkg/datagen/expr/slot.go
@@ -1,0 +1,580 @@
+package expr
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/stroppy-io/stroppy/pkg/datagen/dgproto"
+)
+
+// Slot is the evaluator's internal tagged value. Hot scalar arms keep
+// values inline and avoid converting every intermediate result to any.
+type Slot struct {
+	kind SlotKind
+	i64  int64
+	f64  float64
+	str  string
+	ref  any
+}
+
+type SlotKind uint8
+
+const (
+	secondsPerDay = 86_400
+
+	SlotUnset SlotKind = iota
+	SlotNull
+	SlotInt64
+	SlotFloat64
+	SlotBool
+	SlotString
+	SlotTime
+	SlotAny
+)
+
+type SlotContext interface {
+	Context
+	SlotValue(index int) (Slot, bool)
+}
+
+type SlotEval func(ctx SlotContext) (Slot, error)
+
+func SlotFromAny(value any) Slot {
+	switch typed := value.(type) {
+	case nil:
+		return SlotNullValue()
+	case int64:
+		return SlotInt64Value(typed)
+	case int:
+		return SlotInt64Value(int64(typed))
+	case int32:
+		return SlotInt64Value(int64(typed))
+	case int16:
+		return SlotInt64Value(int64(typed))
+	case int8:
+		return SlotInt64Value(int64(typed))
+	case uint8:
+		return SlotInt64Value(int64(typed))
+	case uint16:
+		return SlotInt64Value(int64(typed))
+	case uint32:
+		return SlotInt64Value(int64(typed))
+	case float64:
+		return SlotFloat64Value(typed)
+	case float32:
+		return SlotFloat64Value(float64(typed))
+	case bool:
+		return SlotBoolValue(typed)
+	case string:
+		return SlotStringValue(typed)
+	case time.Time:
+		return SlotTimeValue(typed)
+	default:
+		return Slot{kind: SlotAny, ref: value}
+	}
+}
+
+func SlotNullValue() Slot { return Slot{kind: SlotNull} }
+
+func SlotInt64Value(value int64) Slot { return Slot{kind: SlotInt64, i64: value} }
+
+func SlotFloat64Value(value float64) Slot { return Slot{kind: SlotFloat64, f64: value} }
+
+func SlotBoolValue(value bool) Slot {
+	if value {
+		return Slot{kind: SlotBool, i64: 1}
+	}
+
+	return Slot{kind: SlotBool}
+}
+
+func SlotStringValue(value string) Slot { return Slot{kind: SlotString, str: value} }
+
+func SlotTimeValue(value time.Time) Slot { return Slot{kind: SlotTime, i64: value.UnixNano()} }
+
+func (slot Slot) Any() any {
+	switch slot.kind {
+	case SlotNull, SlotUnset:
+		return nil
+	case SlotInt64:
+		return slot.i64
+	case SlotFloat64:
+		return slot.f64
+	case SlotBool:
+		return slot.i64 != 0
+	case SlotString:
+		return slot.str
+	case SlotTime:
+		return time.Unix(0, slot.i64).UTC()
+	case SlotAny:
+		return slot.ref
+	default:
+		return nil
+	}
+}
+
+// CompileSlot builds a typed fast-path evaluator for node. Unsupported
+// arms fall back to Eval, preserving existing behavior and errors.
+func CompileSlot(node *dgproto.Expr, colIndex map[string]int, dicts map[string]*dgproto.Dict) SlotEval {
+	if node == nil || node.GetKind() == nil {
+		return fallbackSlotEval(node)
+	}
+
+	switch kind := node.GetKind().(type) {
+	case *dgproto.Expr_Lit:
+		return compileSlotLiteral(kind.Lit)
+	case *dgproto.Expr_RowIndex:
+		rowIndex := kind.RowIndex.GetKind()
+
+		return func(ctx SlotContext) (Slot, error) {
+			return SlotInt64Value(ctx.RowIndex(rowIndex)), nil
+		}
+	case *dgproto.Expr_Col:
+		idx, ok := colIndex[kind.Col.GetName()]
+		if !ok {
+			return fallbackSlotEval(node)
+		}
+
+		return func(ctx SlotContext) (Slot, error) {
+			value, set := ctx.SlotValue(idx)
+			if !set {
+				return Slot{}, ErrUnknownCol
+			}
+
+			return value, nil
+		}
+	case *dgproto.Expr_BinOp:
+		return compileSlotBinOp(node, kind.BinOp, colIndex, dicts)
+	case *dgproto.Expr_If_:
+		return compileSlotIf(node, kind.If_, colIndex, dicts)
+	case *dgproto.Expr_DictAt:
+		return compileSlotDictAt(node, kind.DictAt, colIndex, dicts)
+	case *dgproto.Expr_Call:
+		return compileSlotCall(node, kind.Call, colIndex, dicts)
+	default:
+		return fallbackSlotEval(node)
+	}
+}
+
+func fallbackSlotEval(node *dgproto.Expr) SlotEval {
+	return func(ctx SlotContext) (Slot, error) {
+		value, err := Eval(ctx, node)
+		if err != nil {
+			return Slot{}, err
+		}
+
+		return SlotFromAny(value), nil
+	}
+}
+
+func compileSlotLiteral(lit *dgproto.Literal) SlotEval {
+	if lit == nil || lit.GetValue() == nil {
+		return fallbackSlotEval(&dgproto.Expr{Kind: &dgproto.Expr_Lit{Lit: lit}})
+	}
+
+	switch value := lit.GetValue().(type) {
+	case *dgproto.Literal_Int64:
+		out := SlotInt64Value(value.Int64)
+
+		return constSlotEval(out)
+	case *dgproto.Literal_Double:
+		out := SlotFloat64Value(value.Double)
+
+		return constSlotEval(out)
+	case *dgproto.Literal_String_:
+		out := SlotStringValue(value.String_)
+
+		return constSlotEval(out)
+	case *dgproto.Literal_Bool:
+		out := SlotBoolValue(value.Bool)
+
+		return constSlotEval(out)
+	case *dgproto.Literal_Timestamp:
+		out := SlotTimeValue(value.Timestamp.AsTime())
+
+		return constSlotEval(out)
+	case *dgproto.Literal_Null:
+		return constSlotEval(SlotNullValue())
+	default:
+		return func(_ SlotContext) (Slot, error) {
+			value, err := evalLiteral(lit)
+			if err != nil {
+				return Slot{}, err
+			}
+
+			return SlotFromAny(value), nil
+		}
+	}
+}
+
+func constSlotEval(value Slot) SlotEval {
+	return func(_ SlotContext) (Slot, error) { return value, nil }
+}
+
+func compileSlotBinOp(
+	node *dgproto.Expr,
+	binOp *dgproto.BinOp,
+	colIndex map[string]int,
+	dicts map[string]*dgproto.Dict,
+) SlotEval {
+	if binOp == nil {
+		return fallbackSlotEval(node)
+	}
+
+	op := binOp.GetOp()
+	leftEval := CompileSlot(binOp.GetA(), colIndex, dicts)
+	rightEval := CompileSlot(binOp.GetB(), colIndex, dicts)
+
+	switch op {
+	case dgproto.BinOp_AND:
+		return compileSlotAnd(leftEval, rightEval)
+	case dgproto.BinOp_OR:
+		return compileSlotOr(leftEval, rightEval)
+	case dgproto.BinOp_NOT:
+		return compileSlotNot(leftEval)
+	case dgproto.BinOp_ADD, dgproto.BinOp_SUB, dgproto.BinOp_MUL, dgproto.BinOp_DIV, dgproto.BinOp_MOD,
+		dgproto.BinOp_LT, dgproto.BinOp_LE, dgproto.BinOp_GT, dgproto.BinOp_GE:
+		return compileSlotBinaryTyped(op, leftEval, rightEval)
+	case dgproto.BinOp_CONCAT, dgproto.BinOp_EQ, dgproto.BinOp_NE, dgproto.BinOp_OP_UNSPECIFIED:
+		return fallbackSlotEval(node)
+	default:
+		return fallbackSlotEval(node)
+	}
+}
+
+func compileSlotAnd(leftEval, rightEval SlotEval) SlotEval {
+	return func(ctx SlotContext) (Slot, error) {
+		leftBool, err := evalSlotBool(ctx, leftEval, "logical")
+		if err != nil {
+			return Slot{}, err
+		}
+
+		if !leftBool {
+			return SlotBoolValue(false), nil
+		}
+
+		rightBool, err := evalSlotBool(ctx, rightEval, "logical")
+		if err != nil {
+			return Slot{}, err
+		}
+
+		return SlotBoolValue(rightBool), nil
+	}
+}
+
+func compileSlotOr(leftEval, rightEval SlotEval) SlotEval {
+	return func(ctx SlotContext) (Slot, error) {
+		leftBool, err := evalSlotBool(ctx, leftEval, "logical")
+		if err != nil {
+			return Slot{}, err
+		}
+
+		if leftBool {
+			return SlotBoolValue(true), nil
+		}
+
+		rightBool, err := evalSlotBool(ctx, rightEval, "logical")
+		if err != nil {
+			return Slot{}, err
+		}
+
+		return SlotBoolValue(rightBool), nil
+	}
+}
+
+func compileSlotNot(eval SlotEval) SlotEval {
+	return func(ctx SlotContext) (Slot, error) {
+		value, err := evalSlotBool(ctx, eval, "NOT")
+		if err != nil {
+			return Slot{}, err
+		}
+
+		return SlotBoolValue(!value), nil
+	}
+}
+
+func evalSlotBool(ctx SlotContext, eval SlotEval, opName string) (bool, error) {
+	value, err := eval(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	boolValue, ok := value.Bool()
+	if !ok {
+		return false, fmt.Errorf("%w: %s on %T", ErrTypeMismatch, opName, value.Any())
+	}
+
+	return boolValue, nil
+}
+
+func compileSlotBinaryTyped(op dgproto.BinOp_Op, leftEval, rightEval SlotEval) SlotEval {
+	return func(ctx SlotContext) (Slot, error) {
+		left, err := leftEval(ctx)
+		if err != nil {
+			return Slot{}, err
+		}
+
+		right, err := rightEval(ctx)
+		if err != nil {
+			return Slot{}, err
+		}
+
+		switch op {
+		case dgproto.BinOp_ADD, dgproto.BinOp_SUB, dgproto.BinOp_MUL, dgproto.BinOp_DIV, dgproto.BinOp_MOD:
+			return slotArith(op, left, right)
+		case dgproto.BinOp_LT, dgproto.BinOp_LE, dgproto.BinOp_GT, dgproto.BinOp_GE:
+			return slotOrder(op, left, right)
+		default:
+			return Slot{}, fmt.Errorf("%w: op %s", ErrBadExpr, op)
+		}
+	}
+}
+
+func slotArith(op dgproto.BinOp_Op, left, right Slot) (Slot, error) {
+	leftNum, leftFloat, ok := left.Number()
+	if !ok {
+		return Slot{}, fmt.Errorf("%w: number %T", ErrTypeMismatch, left.Any())
+	}
+
+	rightNum, rightFloat, ok := right.Number()
+	if !ok {
+		return Slot{}, fmt.Errorf("%w: number %T", ErrTypeMismatch, right.Any())
+	}
+
+	if leftFloat || rightFloat {
+		return slotFloatArith(op, leftNum, rightNum)
+	}
+
+	return slotIntArith(op, int64(leftNum), int64(rightNum))
+}
+
+func slotFloatArith(op dgproto.BinOp_Op, left, right float64) (Slot, error) {
+	switch op {
+	case dgproto.BinOp_ADD:
+		return SlotFloat64Value(left + right), nil
+	case dgproto.BinOp_SUB:
+		return SlotFloat64Value(left - right), nil
+	case dgproto.BinOp_MUL:
+		return SlotFloat64Value(left * right), nil
+	case dgproto.BinOp_DIV:
+		if right == 0 {
+			return Slot{}, ErrDivByZero
+		}
+
+		return SlotFloat64Value(left / right), nil
+	case dgproto.BinOp_MOD:
+		if right == 0 {
+			return Slot{}, ErrModByZero
+		}
+
+		return SlotFloat64Value(float64(int64(left) % int64(right))), nil
+	default:
+		return Slot{}, fmt.Errorf("%w: arith op %s", ErrBadExpr, op)
+	}
+}
+
+func slotIntArith(op dgproto.BinOp_Op, left, right int64) (Slot, error) {
+	switch op {
+	case dgproto.BinOp_ADD:
+		return SlotInt64Value(left + right), nil
+	case dgproto.BinOp_SUB:
+		return SlotInt64Value(left - right), nil
+	case dgproto.BinOp_MUL:
+		return SlotInt64Value(left * right), nil
+	case dgproto.BinOp_DIV:
+		if right == 0 {
+			return Slot{}, ErrDivByZero
+		}
+
+		return SlotInt64Value(left / right), nil
+	case dgproto.BinOp_MOD:
+		if right == 0 {
+			return Slot{}, ErrModByZero
+		}
+
+		return SlotInt64Value(left % right), nil
+	default:
+		return Slot{}, fmt.Errorf("%w: arith op %s", ErrBadExpr, op)
+	}
+}
+
+func slotOrder(op dgproto.BinOp_Op, left, right Slot) (Slot, error) {
+	if left.kind == SlotString && right.kind == SlotString {
+		return SlotBoolValue(cmpOrder(op, stringCmp(left.str, right.str))), nil
+	}
+
+	leftNum, _, leftOK := left.Number()
+
+	rightNum, _, rightOK := right.Number()
+	if !leftOK || !rightOK {
+		return Slot{}, fmt.Errorf("%w: order %T vs %T", ErrTypeMismatch, left.Any(), right.Any())
+	}
+
+	switch {
+	case leftNum < rightNum:
+		return SlotBoolValue(cmpOrder(op, -1)), nil
+	case leftNum > rightNum:
+		return SlotBoolValue(cmpOrder(op, 1)), nil
+	default:
+		return SlotBoolValue(cmpOrder(op, 0)), nil
+	}
+}
+
+func compileSlotIf(
+	node *dgproto.Expr,
+	ifNode *dgproto.If,
+	colIndex map[string]int,
+	dicts map[string]*dgproto.Dict,
+) SlotEval {
+	if ifNode == nil {
+		return fallbackSlotEval(node)
+	}
+
+	condEval := CompileSlot(ifNode.GetCond(), colIndex, dicts)
+	thenEval := CompileSlot(ifNode.GetThen(), colIndex, dicts)
+	elseEval := CompileSlot(ifNode.GetElse_(), colIndex, dicts)
+
+	return func(ctx SlotContext) (Slot, error) {
+		cond, err := condEval(ctx)
+		if err != nil {
+			return Slot{}, err
+		}
+
+		value, ok := cond.Bool()
+		if !ok {
+			return Slot{}, fmt.Errorf("%w: if cond %T", ErrTypeMismatch, cond.Any())
+		}
+
+		if value {
+			return thenEval(ctx)
+		}
+
+		return elseEval(ctx)
+	}
+}
+
+func compileSlotDictAt(
+	node *dgproto.Expr,
+	dictAt *dgproto.DictAt,
+	colIndex map[string]int,
+	dicts map[string]*dgproto.Dict,
+) SlotEval {
+	if dictAt == nil {
+		return fallbackSlotEval(node)
+	}
+
+	indexEval := CompileSlot(dictAt.GetIndex(), colIndex, dicts)
+	dictKey := dictAt.GetDictKey()
+	compiledDict := dicts[dictKey]
+
+	return func(ctx SlotContext) (Slot, error) {
+		indexSlot, err := indexEval(ctx)
+		if err != nil {
+			return Slot{}, err
+		}
+
+		index, ok := indexSlot.Int64()
+		if !ok {
+			return Slot{}, fmt.Errorf("%w: dict index %T", ErrTypeMismatch, indexSlot.Any())
+		}
+
+		dict := compiledDict
+		if dict == nil {
+			dict, err = ctx.LookupDict(dictKey)
+			if err != nil {
+				return Slot{}, err
+			}
+		}
+
+		value, err := dictAtValue(dict, dictKey, index)
+		if err != nil {
+			return Slot{}, err
+		}
+
+		return SlotStringValue(value), nil
+	}
+}
+
+func dictAtValue(dict *dgproto.Dict, dictKey string, index int64) (string, error) {
+	if len(dict.GetColumns()) > 1 {
+		return "", fmt.Errorf("%w: multi-column dict %q", ErrTypeMismatch, dictKey)
+	}
+
+	rows := dict.GetRows()
+	if len(rows) == 0 {
+		return "", fmt.Errorf("%w: empty dict %q", ErrBadExpr, dictKey)
+	}
+
+	count := int64(len(rows))
+	position := ((index % count) + count) % count
+
+	values := rows[position].GetValues()
+	if len(values) == 0 {
+		return "", fmt.Errorf("%w: dict row empty in %q", ErrBadExpr, dictKey)
+	}
+
+	return values[0], nil
+}
+
+func compileSlotCall(
+	node *dgproto.Expr,
+	call *dgproto.Call,
+	colIndex map[string]int,
+	dicts map[string]*dgproto.Dict,
+) SlotEval {
+	if call == nil || call.GetFunc() != "std.daysToDate" || len(call.GetArgs()) != 1 {
+		return fallbackSlotEval(node)
+	}
+
+	argEval := CompileSlot(call.GetArgs()[0], colIndex, dicts)
+	fallback := fallbackSlotEval(node)
+
+	return func(ctx SlotContext) (Slot, error) {
+		arg, err := argEval(ctx)
+		if err != nil {
+			return Slot{}, err
+		}
+
+		days, ok := arg.Int64()
+		if !ok {
+			return fallback(ctx)
+		}
+
+		return SlotTimeValue(time.Unix(days*secondsPerDay, 0).UTC()), nil
+	}
+}
+
+func (slot Slot) Int64() (int64, bool) {
+	if slot.kind != SlotInt64 {
+		return 0, false
+	}
+
+	return slot.i64, true
+}
+
+func (slot Slot) Bool() (value, ok bool) {
+	if slot.kind != SlotBool {
+		return false, false
+	}
+
+	return slot.i64 != 0, true
+}
+
+func (slot Slot) Number() (value float64, isFloat, ok bool) {
+	switch slot.kind {
+	case SlotInt64:
+		return float64(slot.i64), false, true
+	case SlotFloat64:
+		return slot.f64, true, true
+	case SlotAny:
+		num, anyIsFloat, err := toNumber(slot.ref)
+		if err != nil {
+			return math.NaN(), false, false
+		}
+
+		return num, anyIsFloat, true
+	default:
+		return math.NaN(), false, false
+	}
+}

--- a/pkg/datagen/expr/slot_equiv_test.go
+++ b/pkg/datagen/expr/slot_equiv_test.go
@@ -1,0 +1,576 @@
+package expr
+
+import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"reflect"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/stroppy-io/stroppy/pkg/datagen/dgproto"
+)
+
+// secondsPerDayTest mirrors stdlib's std.daysToDate day length so the
+// fakeCtx Call hook reproduces the real runtime semantics; CompileSlot's
+// typed std.daysToDate arm must match exactly.
+const secondsPerDayTest = 86_400
+
+// fakeDaysToDate mirrors stdlib.daysToDate: UTC midnight at 1970-01-01 +
+// days. Registered into the fakeCtx so Eval routes std.daysToDate to the
+// same value CompileSlot's typed arm computes inline.
+func fakeDaysToDate(args []any) (any, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("%w: std.daysToDate needs 1, got %d", ErrUnknownCall, len(args))
+	}
+
+	days, ok := args[0].(int64)
+	if !ok {
+		return nil, fmt.Errorf("%w: std.daysToDate arg 0: %T", ErrTypeMismatch, args[0])
+	}
+
+	return time.Unix(days*secondsPerDayTest, 0).UTC(), nil
+}
+
+// fakeFormat is a tiny deterministic stand-in for std.format. Both Eval
+// and CompileSlot's fallback route through this same hook, so the value
+// matches by construction; it only needs to be deterministic.
+func fakeFormat(args []any) (any, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("%w: std.format needs >=1 arg", ErrUnknownCall)
+	}
+
+	format, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("%w: std.format arg 0: %T", ErrTypeMismatch, args[0])
+	}
+
+	return fmt.Sprintf(format, args[1:]...), nil
+}
+
+// slotFakeCtx adapts the package's fakeCtx into a SlotContext. Col reads
+// resolve through both paths so CompileSlot (index-based) and Eval
+// (name-based) observe identical column values:
+//   - Eval calls LookupCol(name) -> fakeCtx.cols[name]
+//   - CompileSlot calls SlotValue(index) -> slots[index]
+//
+// colIndex maps name -> index and slots[index] holds the SlotFromAny of
+// the same value stored in cols[name], keeping the two views consistent.
+type slotFakeCtx struct {
+	*fakeCtx
+	slots []Slot
+	set   []bool
+}
+
+func (s *slotFakeCtx) SlotValue(index int) (Slot, bool) {
+	if index < 0 || index >= len(s.slots) || !s.set[index] {
+		return Slot{}, false
+	}
+
+	return s.slots[index], true
+}
+
+// newSlotFakeCtx builds a SlotContext whose columns carry the provided
+// name->value bindings, exposing a colIndex usable by CompileSlot.
+func newSlotFakeCtx(cols map[string]any, rootSeed uint64) (*slotFakeCtx, map[string]int) {
+	base := newFakeCtx()
+	base.rootSeed = rootSeed
+	base.calls["std.daysToDate"] = fakeDaysToDate
+	base.calls["std.format"] = fakeFormat
+
+	colIndex := make(map[string]int, len(cols))
+	slots := make([]Slot, 0, len(cols))
+	set := make([]bool, 0, len(cols))
+
+	for name, value := range cols {
+		base.cols[name] = value
+		colIndex[name] = len(slots)
+		slots = append(slots, SlotFromAny(value))
+		set = append(set, true)
+	}
+
+	return &slotFakeCtx{fakeCtx: base, slots: slots, set: set}, colIndex
+}
+
+// assertSlotEqualsEval is the core equivalence oracle: Eval is the source
+// of truth. For every Expr shape, CompileSlot(e)(ctx).Any() must equal
+// Eval(ctx, e) in both value and dynamic type, and the error behavior
+// (success vs failure) must match.
+func assertSlotEqualsEval(
+	t *testing.T,
+	label string,
+	e *dgproto.Expr,
+	cols map[string]any,
+	dicts map[string]*dgproto.Dict,
+	rootSeed uint64,
+) {
+	t.Helper()
+
+	ctx, colIndex := newSlotFakeCtx(cols, rootSeed)
+	// The runtime feeds one shared dict map to both the evalContext
+	// (consulted by Eval via LookupDict) and CompileSlot. Mirror that so
+	// the two paths resolve dicts identically.
+	for key, dict := range dicts {
+		ctx.dicts[key] = dict
+	}
+
+	want, wantErr := Eval(ctx, e)
+
+	eval := CompileSlot(e, colIndex, dicts)
+
+	gotSlot, gotErr := eval(ctx)
+	got := gotSlot.Any()
+
+	if (wantErr == nil) != (gotErr == nil) {
+		t.Fatalf("%s: error mismatch: Eval err=%v, CompileSlot err=%v", label, wantErr, gotErr)
+	}
+
+	if wantErr != nil {
+		// Both failed; require the same sentinel where Eval produced one.
+		for _, sentinel := range []error{
+			ErrBadExpr, ErrTypeMismatch, ErrUnknownCol, ErrDictMissing,
+			ErrDivByZero, ErrModByZero, ErrUnknownCall,
+		} {
+			if errors.Is(wantErr, sentinel) && !errors.Is(gotErr, sentinel) {
+				t.Fatalf("%s: sentinel mismatch: Eval=%v, CompileSlot=%v", label, wantErr, gotErr)
+			}
+		}
+
+		return
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s: value/type mismatch:\n  Eval        = %#v (%T)\n  CompileSlot = %#v (%T)",
+			label, want, want, got, got)
+	}
+}
+
+// binOp is a small constructor for BinOp expressions.
+func binOp(op dgproto.BinOp_Op, a, b *dgproto.Expr) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_BinOp{BinOp: &dgproto.BinOp{Op: op, A: a, B: b}}}
+}
+
+func unOp(op dgproto.BinOp_Op, a *dgproto.Expr) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_BinOp{BinOp: &dgproto.BinOp{Op: op, A: a}}}
+}
+
+func ifExpr(cond, then, els *dgproto.Expr) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_If_{If_: &dgproto.If{Cond: cond, Then: then, Else_: els}}}
+}
+
+func colExpr(name string) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_Col{Col: &dgproto.ColRef{Name: name}}}
+}
+
+func rowIndexExpr(kind dgproto.RowIndex_Kind) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_RowIndex{RowIndex: &dgproto.RowIndex{Kind: kind}}}
+}
+
+// dictAtExpr is provided by dict_at_test.go in this package.
+
+// callExprArgs builds a Call Expr with arguments (the bare callExpr helper
+// in if_test.go takes only a name).
+func callExprArgs(fn string, args ...*dgproto.Expr) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_Call{Call: &dgproto.Call{Func: fn, Args: args}}}
+}
+
+// TestCompileSlotEquivTable drives a broad fixed table of Expr shapes
+// through the Eval==CompileSlot oracle.
+func TestCompileSlotEquivTable(t *testing.T) {
+	dicts := map[string]*dgproto.Dict{
+		"colors": {
+			Columns: []string{"name"},
+			Rows: []*dgproto.DictRow{
+				{Values: []string{"red"}},
+				{Values: []string{"green"}},
+				{Values: []string{"blue"}},
+			},
+		},
+	}
+
+	cols := map[string]any{
+		"i":    int64(7),
+		"j":    int64(3),
+		"f":    float64(2.5),
+		"g":    float64(4.0),
+		"flag": true,
+		"name": "alpha",
+	}
+
+	ts := timestamppb.New(time.Unix(1_700_000_000, 0).UTC())
+
+	cases := []struct {
+		name string
+		e    *dgproto.Expr
+	}{
+		// Literals across every scalar type.
+		{"lit_int", litInt(42)},
+		{"lit_int_neg", litInt(-9)},
+		{"lit_float", litFloat(3.14)},
+		{"lit_float_whole", litFloat(8.0)},
+		{"lit_bool_true", litBool(true)},
+		{"lit_bool_false", litBool(false)},
+		{"lit_str", litStr("hello")},
+		{"lit_str_empty", litStr("")},
+		{
+			"lit_timestamp",
+			&dgproto.Expr{Kind: &dgproto.Expr_Lit{Lit: &dgproto.Literal{
+				Value: &dgproto.Literal_Timestamp{Timestamp: ts},
+			}}},
+		},
+		{
+			"lit_null",
+			&dgproto.Expr{Kind: &dgproto.Expr_Lit{Lit: &dgproto.Literal{
+				Value: &dgproto.Literal_Null{Null: &dgproto.NullMarker{}},
+			}}},
+		},
+
+		// RowIndex (all kinds collapse onto the same axis in fakeCtx).
+		{"row_index_global", rowIndexExpr(dgproto.RowIndex_GLOBAL)},
+		{"row_index_unspecified", rowIndexExpr(dgproto.RowIndex_UNSPECIFIED)},
+		{"row_index_entity", rowIndexExpr(dgproto.RowIndex_ENTITY)},
+		{"row_index_line", rowIndexExpr(dgproto.RowIndex_LINE)},
+
+		// Column refs of every value type.
+		{"col_int", colExpr("i")},
+		{"col_float", colExpr("f")},
+		{"col_bool", colExpr("flag")},
+		{"col_str", colExpr("name")},
+
+		// Integer arithmetic.
+		{"add_ii", binOp(dgproto.BinOp_ADD, litInt(2), litInt(3))},
+		{"sub_ii", binOp(dgproto.BinOp_SUB, litInt(10), litInt(4))},
+		{"mul_ii", binOp(dgproto.BinOp_MUL, litInt(6), litInt(7))},
+		{"div_ii", binOp(dgproto.BinOp_DIV, litInt(20), litInt(6))},
+		{"mod_ii", binOp(dgproto.BinOp_MOD, litInt(20), litInt(6))},
+		{"add_cols_ii", binOp(dgproto.BinOp_ADD, colExpr("i"), colExpr("j"))},
+
+		// Float arithmetic.
+		{"add_ff", binOp(dgproto.BinOp_ADD, litFloat(1.5), litFloat(2.25))},
+		{"sub_ff", binOp(dgproto.BinOp_SUB, litFloat(5.5), litFloat(1.25))},
+		{"mul_ff", binOp(dgproto.BinOp_MUL, litFloat(2.0), litFloat(3.5))},
+		{"div_ff", binOp(dgproto.BinOp_DIV, litFloat(7.0), litFloat(2.0))},
+		{"mod_ff", binOp(dgproto.BinOp_MOD, litFloat(7.0), litFloat(3.0))},
+
+		// Mixed int x float (promotes to float in both paths).
+		{"add_if", binOp(dgproto.BinOp_ADD, litInt(3), litFloat(0.5))},
+		{"add_fi", binOp(dgproto.BinOp_ADD, litFloat(0.5), litInt(3))},
+		{"mul_if", binOp(dgproto.BinOp_MUL, litInt(4), litFloat(2.5))},
+		{"div_if", binOp(dgproto.BinOp_DIV, litInt(9), litFloat(2.0))},
+		{"add_col_if", binOp(dgproto.BinOp_ADD, colExpr("i"), colExpr("f"))},
+
+		// Numeric comparisons.
+		{"lt_true", binOp(dgproto.BinOp_LT, litInt(2), litInt(3))},
+		{"lt_false", binOp(dgproto.BinOp_LT, litInt(3), litInt(2))},
+		{"le_eq", binOp(dgproto.BinOp_LE, litInt(3), litInt(3))},
+		{"gt_true", binOp(dgproto.BinOp_GT, litFloat(3.5), litFloat(2.5))},
+		{"ge_true", binOp(dgproto.BinOp_GE, litInt(5), litInt(5))},
+		{"lt_mixed", binOp(dgproto.BinOp_LT, litInt(2), litFloat(2.5))},
+		{"gt_cols", binOp(dgproto.BinOp_GT, colExpr("i"), colExpr("j"))},
+
+		// String ordering comparisons.
+		{"lt_str", binOp(dgproto.BinOp_LT, litStr("apple"), litStr("banana"))},
+		{"gt_str", binOp(dgproto.BinOp_GT, litStr("zebra"), litStr("ant"))},
+
+		// Logical AND/OR/NOT, including short-circuit shapes.
+		{"and_tt", binOp(dgproto.BinOp_AND, litBool(true), litBool(true))},
+		{"and_tf", binOp(dgproto.BinOp_AND, litBool(true), litBool(false))},
+		{"and_ff", binOp(dgproto.BinOp_AND, litBool(false), litBool(true))},
+		{"or_ff", binOp(dgproto.BinOp_OR, litBool(false), litBool(false))},
+		{"or_tf", binOp(dgproto.BinOp_OR, litBool(true), litBool(false))},
+		{"not_t", unOp(dgproto.BinOp_NOT, litBool(true))},
+		{"not_f", unOp(dgproto.BinOp_NOT, litBool(false))},
+		{"and_cmp", binOp(dgproto.BinOp_AND,
+			binOp(dgproto.BinOp_LT, litInt(1), litInt(2)),
+			binOp(dgproto.BinOp_GT, litInt(5), litInt(4)))},
+
+		// If across branch types.
+		{"if_true_int", ifExpr(litBool(true), litInt(1), litInt(2))},
+		{"if_false_int", ifExpr(litBool(false), litInt(1), litInt(2))},
+		{"if_str", ifExpr(litBool(false), litStr("yes"), litStr("no"))},
+		{"if_cond_expr", ifExpr(binOp(dgproto.BinOp_LT, colExpr("j"), colExpr("i")),
+			litStr("j<i"), litStr("j>=i"))},
+		{"if_float_branch", ifExpr(litBool(true), litFloat(1.5), litFloat(2.5))},
+
+		// DictAt, including modular wraparound (positive and negative).
+		{"dict_at_0", dictAtExpr("colors", litInt(0))},
+		{"dict_at_1", dictAtExpr("colors", litInt(1))},
+		{"dict_at_wrap", dictAtExpr("colors", litInt(4))},
+		{"dict_at_neg", dictAtExpr("colors", litInt(-1))},
+		{"dict_at_expr_index", dictAtExpr("colors", binOp(dgproto.BinOp_ADD, colExpr("i"), litInt(1)))},
+
+		// Call: typed fast-path (std.daysToDate) and fallback (std.format).
+		{"call_days_to_date", callExprArgs("std.daysToDate", litInt(100))},
+		{"call_days_to_date_expr", callExprArgs("std.daysToDate", binOp(dgproto.BinOp_ADD, litInt(50), litInt(50)))},
+
+		// Deeply nested arithmetic + comparison + branch.
+		{
+			"nested",
+			ifExpr(
+				binOp(dgproto.BinOp_GT,
+					binOp(dgproto.BinOp_ADD, colExpr("i"), binOp(dgproto.BinOp_MUL, colExpr("j"), litInt(2))),
+					litInt(10)),
+				binOp(dgproto.BinOp_SUB, colExpr("f"), litFloat(0.5)),
+				binOp(dgproto.BinOp_ADD, colExpr("f"), litFloat(0.5)),
+			),
+		},
+	}
+
+	rootSeeds := []uint64{0, 1, 0xDEADBEEF}
+
+	for _, seed := range rootSeeds {
+		for _, tc := range cases {
+			assertSlotEqualsEval(t, tc.name, tc.e, cols, dicts, seed)
+		}
+	}
+}
+
+// TestCompileSlotEquivFallbackArms covers arms that MUST route through
+// fallbackSlotEval: BinOp_CONCAT, BinOp_EQ, BinOp_NE, and a non-typed
+// Call. Their values must still round-trip identically to Eval.
+func TestCompileSlotEquivFallbackArms(t *testing.T) {
+	cols := map[string]any{
+		"a": "foo",
+		"b": "bar",
+		"i": int64(5),
+	}
+
+	// std.format is registered by stdlib; concat/eq/ne route through the
+	// expr concat/compare kernels. CompileSlot routes all of these to
+	// fallbackSlotEval, so equivalence must hold by construction.
+	cases := []struct {
+		name string
+		e    *dgproto.Expr
+	}{
+		{"concat", binOp(dgproto.BinOp_CONCAT, litStr("a-"), litStr("b"))},
+		{"concat_cols", binOp(dgproto.BinOp_CONCAT, colExpr("a"), colExpr("b"))},
+		{"eq_int", binOp(dgproto.BinOp_EQ, litInt(3), litInt(3))},
+		{"ne_int", binOp(dgproto.BinOp_NE, litInt(3), litInt(4))},
+		{"eq_str", binOp(dgproto.BinOp_EQ, colExpr("a"), litStr("foo"))},
+		{"call_format", callExprArgs("std.format", litStr("%d!"), colExpr("i"))},
+	}
+
+	dicts := map[string]*dgproto.Dict{}
+
+	for _, tc := range cases {
+		// newSlotFakeCtx registers std.format/std.daysToDate so Eval and
+		// CompileSlot's fallback route through the same Call hook.
+		ctx, colIndex := newSlotFakeCtx(cols, 0)
+
+		want, wantErr := Eval(ctx, tc.e)
+
+		gotSlot, gotErr := CompileSlot(tc.e, colIndex, dicts)(ctx)
+		got := gotSlot.Any()
+
+		if (wantErr == nil) != (gotErr == nil) {
+			t.Fatalf("%s: error mismatch: Eval err=%v, CompileSlot err=%v", tc.name, wantErr, gotErr)
+		}
+
+		if wantErr != nil {
+			continue
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s: fallback value/type mismatch:\n  Eval        = %#v (%T)\n  CompileSlot = %#v (%T)",
+				tc.name, want, want, got, got)
+		}
+	}
+}
+
+// TestCompileSlotEquivRandomized fuzzes random arithmetic/comparison/logic
+// trees against the Eval oracle across many row indices and a couple of
+// root seeds. Any divergence is a CompileSlot bug, never a test weakness.
+func TestCompileSlotEquivRandomized(t *testing.T) {
+	dicts := map[string]*dgproto.Dict{
+		"d": {
+			Columns: []string{"v"},
+			Rows: []*dgproto.DictRow{
+				{Values: []string{"zero"}},
+				{Values: []string{"one"}},
+				{Values: []string{"two"}},
+				{Values: []string{"three"}},
+			},
+		},
+	}
+
+	for _, rootSeed := range []uint64{0x1234, 0xABCDEF, 99} {
+		rng := rand.New(rand.NewPCG(rootSeed, rootSeed^0x9E3779B97F4A7C15))
+
+		for iter := 0; iter < 4000; iter++ {
+			rowIdx := int64(rng.Uint64() % 1_000_003)
+
+			cols := map[string]any{
+				"i": int64(rng.Int64N(2001) - 1000),
+				"j": int64(rng.Int64N(2001) - 1000),
+				"f": float64(rng.Int64N(20001)-10000) / 100.0,
+				"g": float64(rng.Int64N(20001)-10000) / 100.0,
+				"b": rng.Uint64()&1 == 0,
+				"c": rng.Uint64()&1 == 0,
+			}
+
+			e := randExpr(rng, 4)
+
+			ctx, colIndex := newSlotFakeCtxRow(cols, rootSeed, rowIdx)
+			for key, dict := range dicts {
+				ctx.dicts[key] = dict
+			}
+
+			want, wantErr := Eval(ctx, e)
+
+			gotSlot, gotErr := CompileSlot(e, colIndex, dicts)(ctx)
+			got := gotSlot.Any()
+
+			if (wantErr == nil) != (gotErr == nil) {
+				t.Fatalf("seed %d iter %d: error mismatch: Eval=%v CompileSlot=%v\nexpr=%v",
+					rootSeed, iter, wantErr, gotErr, e)
+			}
+
+			if wantErr != nil {
+				continue
+			}
+
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("seed %d iter %d row %d: mismatch:\n  Eval        = %#v (%T)\n  CompileSlot = %#v (%T)\n  expr        = %v",
+					rootSeed, iter, rowIdx, want, want, got, got, e)
+			}
+		}
+	}
+}
+
+// newSlotFakeCtxRow is like newSlotFakeCtx but also pins the row counter
+// so RowIndex arms in fuzzed trees resolve deterministically.
+func newSlotFakeCtxRow(cols map[string]any, rootSeed uint64, rowIdx int64) (*slotFakeCtx, map[string]int) {
+	ctx, colIndex := newSlotFakeCtx(cols, rootSeed)
+	for _, kind := range []dgproto.RowIndex_Kind{
+		dgproto.RowIndex_UNSPECIFIED,
+		dgproto.RowIndex_ENTITY,
+		dgproto.RowIndex_LINE,
+		dgproto.RowIndex_GLOBAL,
+	} {
+		ctx.rowIndex[kind] = rowIdx
+	}
+
+	return ctx, colIndex
+}
+
+// randExpr builds a random scalar Expr tree of bounded depth using only
+// arms whose Eval result type survives the SlotFromAny round-trip
+// (int64/float64/bool/string/time.Time). It deliberately includes both
+// CompileSlot-typed arms and at least the DictAt arm.
+func randExpr(rng *rand.Rand, depth int) *dgproto.Expr {
+	if depth <= 0 {
+		return randLeaf(rng)
+	}
+
+	switch rng.IntN(10) {
+	case 0: // ADD/SUB/MUL on arbitrary numeric operands
+		ops := []dgproto.BinOp_Op{
+			dgproto.BinOp_ADD, dgproto.BinOp_SUB, dgproto.BinOp_MUL,
+		}
+		op := ops[rng.IntN(len(ops))]
+
+		return binOp(op, randNumExpr(rng, depth-1), randNumExpr(rng, depth-1))
+	case 1: // DIV/MOD: divisor is a nonzero int literal.
+		// Both Eval and CompileSlot compute float MOD as
+		// float64(int64(left) % int64(right)); a divisor whose int64
+		// truncation is zero panics in BOTH (pre-existing, identical),
+		// so keep |divisor| >= 1 to stay in the defined domain.
+		op := []dgproto.BinOp_Op{dgproto.BinOp_DIV, dgproto.BinOp_MOD}[rng.IntN(2)]
+		divisor := rng.Int64N(1000) + 1
+		if rng.IntN(2) == 0 {
+			divisor = -divisor
+		}
+
+		return binOp(op, randNumExpr(rng, depth-1), litInt(divisor))
+	case 2, 3: // comparison
+		ops := []dgproto.BinOp_Op{
+			dgproto.BinOp_LT, dgproto.BinOp_LE, dgproto.BinOp_GT, dgproto.BinOp_GE,
+		}
+		op := ops[rng.IntN(len(ops))]
+
+		return binOp(op, randNumExpr(rng, depth-1), randNumExpr(rng, depth-1))
+	case 4: // AND
+		return binOp(dgproto.BinOp_AND, randBoolExpr(rng, depth-1), randBoolExpr(rng, depth-1))
+	case 5: // OR
+		return binOp(dgproto.BinOp_OR, randBoolExpr(rng, depth-1), randBoolExpr(rng, depth-1))
+	case 6: // NOT
+		return unOp(dgproto.BinOp_NOT, randBoolExpr(rng, depth-1))
+	case 7: // If
+		return ifExpr(randBoolExpr(rng, depth-1), randExpr(rng, depth-1), randExpr(rng, depth-1))
+	case 8: // DictAt
+		return dictAtExpr("d", randNumExpr(rng, depth-1))
+	default: // std.daysToDate (typed Call arm)
+		// Bound the day count to the range where time.Time has a valid
+		// UnixNano representation. SlotTime stores UnixNano, so out-of-range
+		// dates round-trip lossily through Slot.Any(); that is an inherent
+		// property of the ported Slot design, not an equivalence violation,
+		// and the runtime never produces such dates. Keep inputs in-domain.
+		return callExprArgs("std.daysToDate", litInt(rng.Int64N(80_000)-30_000))
+	}
+}
+
+func randNumExpr(rng *rand.Rand, depth int) *dgproto.Expr {
+	if depth <= 0 || rng.IntN(2) == 0 {
+		switch rng.IntN(4) {
+		case 0:
+			return litInt(rng.Int64N(2001) - 1000)
+		case 1:
+			return litFloat(float64(rng.Int64N(20001)-10000) / 100.0)
+		case 2:
+			return colExpr([]string{"i", "j"}[rng.IntN(2)])
+		default:
+			return colExpr([]string{"f", "g"}[rng.IntN(2)])
+		}
+	}
+
+	ops := []dgproto.BinOp_Op{
+		dgproto.BinOp_ADD, dgproto.BinOp_SUB, dgproto.BinOp_MUL,
+	}
+
+	return binOp(ops[rng.IntN(len(ops))], randNumExpr(rng, depth-1), randNumExpr(rng, depth-1))
+}
+
+func randBoolExpr(rng *rand.Rand, depth int) *dgproto.Expr {
+	if depth <= 0 || rng.IntN(2) == 0 {
+		switch rng.IntN(3) {
+		case 0:
+			return litBool(rng.IntN(2) == 0)
+		case 1:
+			return colExpr([]string{"b", "c"}[rng.IntN(2)])
+		default:
+			ops := []dgproto.BinOp_Op{
+				dgproto.BinOp_LT, dgproto.BinOp_LE, dgproto.BinOp_GT, dgproto.BinOp_GE,
+			}
+
+			return binOp(ops[rng.IntN(len(ops))], randNumExpr(rng, 1), randNumExpr(rng, 1))
+		}
+	}
+
+	switch rng.IntN(3) {
+	case 0:
+		return binOp(dgproto.BinOp_AND, randBoolExpr(rng, depth-1), randBoolExpr(rng, depth-1))
+	case 1:
+		return binOp(dgproto.BinOp_OR, randBoolExpr(rng, depth-1), randBoolExpr(rng, depth-1))
+	default:
+		return unOp(dgproto.BinOp_NOT, randBoolExpr(rng, depth-1))
+	}
+}
+
+func randLeaf(rng *rand.Rand) *dgproto.Expr {
+	switch rng.IntN(6) {
+	case 0:
+		return litInt(rng.Int64N(2001) - 1000)
+	case 1:
+		return litFloat(float64(rng.Int64N(20001)-10000) / 100.0)
+	case 2:
+		return litBool(rng.IntN(2) == 0)
+	case 3:
+		return colExpr([]string{"i", "j", "f", "g"}[rng.IntN(4)])
+	case 4:
+		return colExpr([]string{"b", "c"}[rng.IntN(2)])
+	default:
+		return rowIndexExpr(dgproto.RowIndex_GLOBAL)
+	}
+}

--- a/pkg/datagen/expr/slot_equiv_test.go
+++ b/pkg/datagen/expr/slot_equiv_test.go
@@ -152,8 +152,8 @@ func binOp(op dgproto.BinOp_Op, a, b *dgproto.Expr) *dgproto.Expr {
 	return &dgproto.Expr{Kind: &dgproto.Expr_BinOp{BinOp: &dgproto.BinOp{Op: op, A: a, B: b}}}
 }
 
-func unOp(op dgproto.BinOp_Op, a *dgproto.Expr) *dgproto.Expr {
-	return &dgproto.Expr{Kind: &dgproto.Expr_BinOp{BinOp: &dgproto.BinOp{Op: op, A: a}}}
+func notOp(a *dgproto.Expr) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_BinOp{BinOp: &dgproto.BinOp{Op: dgproto.BinOp_NOT, A: a}}}
 }
 
 func ifExpr(cond, then, els *dgproto.Expr) *dgproto.Expr {
@@ -280,8 +280,8 @@ func TestCompileSlotEquivTable(t *testing.T) {
 		{"and_ff", binOp(dgproto.BinOp_AND, litBool(false), litBool(true))},
 		{"or_ff", binOp(dgproto.BinOp_OR, litBool(false), litBool(false))},
 		{"or_tf", binOp(dgproto.BinOp_OR, litBool(true), litBool(false))},
-		{"not_t", unOp(dgproto.BinOp_NOT, litBool(true))},
-		{"not_f", unOp(dgproto.BinOp_NOT, litBool(false))},
+		{"not_t", notOp(litBool(true))},
+		{"not_f", notOp(litBool(false))},
 		{"and_cmp", binOp(dgproto.BinOp_AND,
 			binOp(dgproto.BinOp_LT, litInt(1), litInt(2)),
 			binOp(dgproto.BinOp_GT, litInt(5), litInt(4)))},
@@ -398,12 +398,12 @@ func TestCompileSlotEquivRandomized(t *testing.T) {
 	for _, rootSeed := range []uint64{0x1234, 0xABCDEF, 99} {
 		rng := rand.New(rand.NewPCG(rootSeed, rootSeed^0x9E3779B97F4A7C15))
 
-		for iter := 0; iter < 4000; iter++ {
+		for iter := range 4000 {
 			rowIdx := int64(rng.Uint64() % 1_000_003)
 
 			cols := map[string]any{
-				"i": int64(rng.Int64N(2001) - 1000),
-				"j": int64(rng.Int64N(2001) - 1000),
+				"i": rng.Int64N(2001) - 1000,
+				"j": rng.Int64N(2001) - 1000,
 				"f": float64(rng.Int64N(20001)-10000) / 100.0,
 				"g": float64(rng.Int64N(20001)-10000) / 100.0,
 				"b": rng.Uint64()&1 == 0,
@@ -432,7 +432,8 @@ func TestCompileSlotEquivRandomized(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(got, want) {
-				t.Fatalf("seed %d iter %d row %d: mismatch:\n  Eval        = %#v (%T)\n  CompileSlot = %#v (%T)\n  expr        = %v",
+				t.Fatalf("seed %d iter %d row %d: mismatch:\n"+
+					"  Eval        = %#v (%T)\n  CompileSlot = %#v (%T)\n  expr        = %v",
 					rootSeed, iter, rowIdx, want, want, got, got, e)
 			}
 		}
@@ -478,6 +479,7 @@ func randExpr(rng *rand.Rand, depth int) *dgproto.Expr {
 		// truncation is zero panics in BOTH (pre-existing, identical),
 		// so keep |divisor| >= 1 to stay in the defined domain.
 		op := []dgproto.BinOp_Op{dgproto.BinOp_DIV, dgproto.BinOp_MOD}[rng.IntN(2)]
+
 		divisor := rng.Int64N(1000) + 1
 		if rng.IntN(2) == 0 {
 			divisor = -divisor
@@ -496,7 +498,7 @@ func randExpr(rng *rand.Rand, depth int) *dgproto.Expr {
 	case 5: // OR
 		return binOp(dgproto.BinOp_OR, randBoolExpr(rng, depth-1), randBoolExpr(rng, depth-1))
 	case 6: // NOT
-		return unOp(dgproto.BinOp_NOT, randBoolExpr(rng, depth-1))
+		return notOp(randBoolExpr(rng, depth-1))
 	case 7: // If
 		return ifExpr(randBoolExpr(rng, depth-1), randExpr(rng, depth-1), randExpr(rng, depth-1))
 	case 8: // DictAt
@@ -554,7 +556,7 @@ func randBoolExpr(rng *rand.Rand, depth int) *dgproto.Expr {
 	case 1:
 		return binOp(dgproto.BinOp_OR, randBoolExpr(rng, depth-1), randBoolExpr(rng, depth-1))
 	default:
-		return unOp(dgproto.BinOp_NOT, randBoolExpr(rng, depth-1))
+		return notOp(randBoolExpr(rng, depth-1))
 	}
 }
 

--- a/pkg/datagen/expr/stream_draw.go
+++ b/pkg/datagen/expr/stream_draw.go
@@ -86,8 +86,18 @@ func evalInt64Pair(ctx Context, a, b *dgproto.Expr) (lo, hi int64, err error) {
 	return lo, hi, nil
 }
 
-// evalInt64 evaluates expr and requires its result to be int64.
+// evalInt64 evaluates expr and requires its result to be int64. A literal
+// int64 bound (the common case for draw min/max) is read directly, skipping
+// the Eval boxing round-trip; this is value-identical to evalLiteral's Int64
+// arm. Non-int64 literals fall through to Eval so the type-mismatch error path
+// is unchanged.
 func evalInt64(ctx Context, e *dgproto.Expr) (int64, error) {
+	if lit := e.GetLit(); lit != nil {
+		if v, ok := lit.GetValue().(*dgproto.Literal_Int64); ok {
+			return v.Int64, nil
+		}
+	}
+
 	value, err := Eval(ctx, e)
 	if err != nil {
 		return 0, err
@@ -118,8 +128,19 @@ func evalFloat64Pair(ctx Context, a, b *dgproto.Expr) (lo, hi float64, err error
 }
 
 // evalFloat64 evaluates expr and requires its result to be float64 or
-// int64 (promoted).
+// int64 (promoted). Literal double/int64 bounds are read directly, skipping
+// the Eval boxing round-trip; this matches evalLiteral's Double/Int64 arms
+// (int64 promoted to float64). Other literals fall through to Eval.
 func evalFloat64(ctx Context, e *dgproto.Expr) (float64, error) {
+	if lit := e.GetLit(); lit != nil {
+		switch v := lit.GetValue().(type) {
+		case *dgproto.Literal_Double:
+			return v.Double, nil
+		case *dgproto.Literal_Int64:
+			return float64(v.Int64), nil
+		}
+	}
+
 	value, err := Eval(ctx, e)
 	if err != nil {
 		return 0, err

--- a/pkg/datagen/lookup/lookup.go
+++ b/pkg/datagen/lookup/lookup.go
@@ -431,12 +431,7 @@ func (c *popCtx) Draw(streamID uint32, attrPath string, rowIdx int64) *rand.Rand
 		c.drawPRNG = seed.NewReusablePRNG()
 	}
 
-	key := seed.Derive(
-		c.reg.rootSeed,
-		attrPath,
-		"s"+strconv.FormatUint(uint64(streamID), 10),
-		strconv.FormatInt(rowIdx, 10),
-	)
+	key := seed.DeriveDraw(c.reg.rootSeed, attrPath, streamID, rowIdx)
 	c.drawPRNG.Seed(key)
 
 	return c.drawPRNG.Rand()

--- a/pkg/datagen/lookup/lookup.go
+++ b/pkg/datagen/lookup/lookup.go
@@ -437,6 +437,19 @@ func (c *popCtx) Draw(streamID uint32, attrPath string, rowIdx int64) *rand.Rand
 	return c.drawPRNG.Rand()
 }
 
+// DrawKey returns a PRNG seeded directly from a precomputed sub-stream key,
+// reusing the pooled drawPRNG. It satisfies the expr keyedDrawer optimization
+// (grammar re-walks); the stream is identical to seed.PRNG(key).
+func (c *popCtx) DrawKey(key uint64) *rand.Rand {
+	if c.drawPRNG == nil {
+		c.drawPRNG = seed.NewReusablePRNG()
+	}
+
+	c.drawPRNG.Seed(key)
+
+	return c.drawPRNG.Rand()
+}
+
 // AttrPath returns the pop-qualified attr path currently under
 // evaluation.
 func (c *popCtx) AttrPath() string {

--- a/pkg/datagen/runtime/context.go
+++ b/pkg/datagen/runtime/context.go
@@ -17,11 +17,13 @@ import (
 // scratch, indices, and active block cache between evaluations rather
 // than allocating a fresh context each row.
 //
-// The flat runtime (no relationships) uses the fields scratch, rowIdx,
+// The flat runtime (no relationships) uses the fields slots, rowIdx,
 // and dicts. The relationship runtime additionally populates blocks,
 // registry, iter, outerPop, and the entity/line/global indices.
 type evalContext struct {
-	scratch  map[string]any
+	slots    []expr.Slot
+	set      []bool
+	attrIdx  map[string]int
 	dicts    map[string]*dgproto.Dict
 	registry *lookup.LookupRegistry
 	cohorts  *cohort.Registry
@@ -75,15 +77,23 @@ type evalContext struct {
 }
 
 // LookupCol resolves a ColRef by consulting the current row's scratch
-// map, returning expr.ErrUnknownCol when the referenced attr has not yet
+// slots, returning expr.ErrUnknownCol when the referenced attr has not yet
 // been evaluated (for example, a forward reference or a DAG bug).
 func (c *evalContext) LookupCol(name string) (any, error) {
-	value, ok := c.scratch[name]
-	if !ok {
+	idx, ok := c.attrIdx[name]
+	if !ok || !c.set[idx] {
 		return nil, expr.ErrUnknownCol
 	}
 
-	return value, nil
+	return c.slots[idx].Any(), nil
+}
+
+func (c *evalContext) SlotValue(index int) (expr.Slot, bool) {
+	if index < 0 || index >= len(c.slots) || !c.set[index] {
+		return expr.Slot{}, false
+	}
+
+	return c.slots[index], true
 }
 
 // RowIndex returns the counter matching the requested kind. In flat
@@ -151,12 +161,12 @@ func (c *evalContext) Lookup(popName, attrName string, entityIdx int64) (any, er
 			)
 		}
 
-		value, ok := c.scratch[attrName]
-		if !ok {
+		idx, ok := c.attrIdx[attrName]
+		if !ok || !c.set[idx] {
 			return nil, expr.ErrUnknownCol
 		}
 
-		return value, nil
+		return c.slots[idx].Any(), nil
 	}
 
 	if c.registry == nil {

--- a/pkg/datagen/runtime/context.go
+++ b/pkg/datagen/runtime/context.go
@@ -74,6 +74,18 @@ type evalContext struct {
 	// drawPRNG is lazily allocated and re-seeded on every Draw call so
 	// StreamDraw / Choose avoid a fresh rand.New per sample.
 	drawPRNG *seed.ReusablePRNG
+
+	// grammarBuf is the reused assembly buffer lent to grammar draws via
+	// GrammarScratch. It holds capacity across rows so a grammar walk
+	// appends without allocating; only the result string is fresh.
+	grammarBuf []byte
+}
+
+// GrammarScratch lends the per-runtime grammar assembly buffer to the expr
+// grammar walker (the expr grammarBufferer optimization), so grammar output is
+// built into a buffer reused across rows rather than a fresh per-attempt one.
+func (c *evalContext) GrammarScratch() *[]byte {
+	return &c.grammarBuf
 }
 
 // LookupCol resolves a ColRef by consulting the current row's scratch

--- a/pkg/datagen/runtime/context.go
+++ b/pkg/datagen/runtime/context.go
@@ -183,6 +183,19 @@ func (c *evalContext) Draw(streamID uint32, attrPath string, rowIdx int64) *rand
 	return c.drawPRNG.Rand()
 }
 
+// DrawKey returns a PRNG seeded directly from a precomputed sub-stream key,
+// reusing the per-runtime drawPRNG. It satisfies the expr keyedDrawer
+// optimization (grammar re-walks); the stream is identical to seed.PRNG(key).
+func (c *evalContext) DrawKey(key uint64) *rand.Rand {
+	if c.drawPRNG == nil {
+		c.drawPRNG = seed.NewReusablePRNG()
+	}
+
+	c.drawPRNG.Seed(key)
+
+	return c.drawPRNG.Rand()
+}
+
 // AttrPath returns the attr currently being evaluated. Empty when no
 // attr is active (e.g. a test harness that bypasses Runtime).
 func (c *evalContext) AttrPath() string {

--- a/pkg/datagen/runtime/context.go
+++ b/pkg/datagen/runtime/context.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"fmt"
 	"math/rand/v2"
-	"strconv"
 
 	"github.com/stroppy-io/stroppy/pkg/datagen/cohort"
 	"github.com/stroppy-io/stroppy/pkg/datagen/dgproto"
@@ -169,20 +168,16 @@ func (c *evalContext) Lookup(popName, attrName string, entityIdx int64) (any, er
 }
 
 // Draw returns a PRNG seeded deterministically from (rootSeed,
-// attrPath, streamID, rowIdx) via seed.Derive. The stream_id is
-// serialized with an "s" prefix so the hash input for a same-row
-// draw never collides with an attrPath that happens to be numeric.
+// attrPath, streamID, rowIdx) via seed.DeriveDraw, which is byte-identical
+// to the historical seed.Derive(rootSeed, attrPath, "s"+streamID, rowIdx)
+// formula but allocates nothing. The stream_id keeps its "s" prefix so the
+// hash input for a same-row draw never collides with a numeric attrPath.
 func (c *evalContext) Draw(streamID uint32, attrPath string, rowIdx int64) *rand.Rand {
 	if c.drawPRNG == nil {
 		c.drawPRNG = seed.NewReusablePRNG()
 	}
 
-	key := seed.Derive(
-		c.rootSeed,
-		attrPath,
-		"s"+strconv.FormatUint(uint64(streamID), 10),
-		strconv.FormatInt(rowIdx, 10),
-	)
+	key := seed.DeriveDraw(c.rootSeed, attrPath, streamID, rowIdx)
 	c.drawPRNG.Seed(key)
 
 	return c.drawPRNG.Rand()

--- a/pkg/datagen/runtime/context_test.go
+++ b/pkg/datagen/runtime/context_test.go
@@ -10,7 +10,11 @@ import (
 )
 
 func TestContextLookupColPresent(t *testing.T) {
-	ctx := &evalContext{scratch: map[string]any{"a": int64(7)}}
+	ctx := &evalContext{
+		slots:   []expr.Slot{expr.SlotInt64Value(7)},
+		set:     []bool{true},
+		attrIdx: map[string]int{"a": 0},
+	}
 
 	got, err := ctx.LookupCol("a")
 	if err != nil {
@@ -23,7 +27,7 @@ func TestContextLookupColPresent(t *testing.T) {
 }
 
 func TestContextLookupColMissing(t *testing.T) {
-	ctx := &evalContext{scratch: map[string]any{}}
+	ctx := &evalContext{attrIdx: map[string]int{}}
 	if _, err := ctx.LookupCol("absent"); !errors.Is(err, expr.ErrUnknownCol) {
 		t.Fatalf("want ErrUnknownCol, got %v", err)
 	}

--- a/pkg/datagen/runtime/flat.go
+++ b/pkg/datagen/runtime/flat.go
@@ -22,8 +22,10 @@ import (
 // Runtimes built from the same InsertSpec.
 type Runtime struct {
 	dag     *compile.DAG
+	evals   []expr.SlotEval
 	columns []string
 	emit    []emitSlot
+	rowOut  []any
 	size    int64
 	row     int64
 	ctx     *evalContext
@@ -103,7 +105,9 @@ func NewRuntime(spec *dgproto.InsertSpec) (*Runtime, error) {
 	}
 
 	ctx := &evalContext{
-		scratch:          make(map[string]any, len(dag.Order)),
+		slots:            make([]expr.Slot, len(dag.Order)),
+		set:              make([]bool, len(dag.Order)),
+		attrIdx:          dag.Index,
 		dicts:            spec.GetDicts(),
 		registry:         registry,
 		cohorts:          cohorts,
@@ -114,8 +118,10 @@ func NewRuntime(spec *dgproto.InsertSpec) (*Runtime, error) {
 
 	runtime := &Runtime{
 		dag:     dag,
+		evals:   compileSlotEvals(dag, spec.GetDicts()),
 		columns: columns,
 		emit:    emit,
+		rowOut:  make([]any, len(emit)),
 		size:    size,
 		ctx:     ctx,
 	}
@@ -178,6 +184,15 @@ func relSides(rel *dgproto.Relationship, iterPop string) (outer, inner *dgproto.
 	return first, second
 }
 
+func compileSlotEvals(dag *compile.DAG, dicts map[string]*dgproto.Dict) []expr.SlotEval {
+	evals := make([]expr.SlotEval, len(dag.Order))
+	for idx, attr := range dag.Order {
+		evals[idx] = expr.CompileSlot(attr.GetExpr(), dag.Index, dicts)
+	}
+
+	return evals
+}
+
 // Columns returns the emitted column order. The slice is owned by the
 // Runtime; callers must not mutate it.
 func (r *Runtime) Columns() []string {
@@ -205,13 +220,17 @@ func (r *Runtime) TotalRows() int64 {
 func (r *Runtime) Clone() *Runtime {
 	clone := &Runtime{
 		dag:     r.dag,
+		evals:   r.evals,
 		columns: r.columns,
 		emit:    r.emit,
+		rowOut:  make([]any, len(r.emit)),
 		size:    r.size,
 		row:     0,
 		scd2:    r.scd2,
 		ctx: &evalContext{
-			scratch:          make(map[string]any, len(r.dag.Order)),
+			slots:            make([]expr.Slot, len(r.dag.Order)),
+			set:              make([]bool, len(r.dag.Order)),
+			attrIdx:          r.dag.Index,
 			dicts:            r.ctx.dicts,
 			registry:         r.ctx.registry.CloneRegistry(),
 			rootSeed:         r.ctx.rootSeed,
@@ -315,27 +334,27 @@ func (r *Runtime) nextFlat() ([]any, error) {
 	}
 
 	r.ctx.rowIdx = r.row
-	for key := range r.ctx.scratch {
-		delete(r.ctx.scratch, key)
-	}
+	clear(r.ctx.set)
 
-	for _, attrNode := range r.dag.Order {
+	for attrIdx, attrNode := range r.dag.Order {
 		name := attrNode.GetName()
 
 		if null := attrNode.GetNull(); null != nil && nullProbabilityHit(null, name, r.row) {
-			r.ctx.scratch[name] = nil
+			r.ctx.slots[attrIdx] = expr.SlotNullValue()
+			r.ctx.set[attrIdx] = true
 
 			continue
 		}
 
 		r.ctx.attrPath = name
 
-		value, err := expr.Eval(r.ctx, attrNode.GetExpr())
+		value, err := r.evals[attrIdx](r.ctx)
 		if err != nil {
 			return nil, fmt.Errorf("runtime: attr %q at row %d: %w", name, r.row, err)
 		}
 
-		r.ctx.scratch[name] = value
+		r.ctx.slots[attrIdx] = value
+		r.ctx.set[attrIdx] = true
 	}
 
 	out := r.assembleRow(r.row)
@@ -349,12 +368,12 @@ func (r *Runtime) nextFlat() ([]any, error) {
 // consulting the DAG scratch for emitAttr slots and the SCD2 state for
 // emitSCD2Start / emitSCD2End slots.
 func (r *Runtime) assembleRow(rowIdx int64) []any {
-	out := make([]any, len(r.emit))
+	out := r.rowOut
 
 	for i, slot := range r.emit {
 		switch slot.kind {
 		case emitAttr:
-			out[i] = r.ctx.scratch[r.dag.Order[slot.ref].GetName()]
+			out[i] = r.ctx.slots[slot.ref].Any()
 		case emitSCD2Start:
 			out[i] = r.scd2.startFor(rowIdx)
 		case emitSCD2End:

--- a/pkg/datagen/runtime/flat_test.go
+++ b/pkg/datagen/runtime/flat_test.go
@@ -103,7 +103,7 @@ func collect(t *testing.T, r *Runtime) [][]any {
 			t.Fatalf("Next: %v", err)
 		}
 
-		rows = append(rows, row)
+		rows = append(rows, append([]any(nil), row...))
 	}
 }
 
@@ -274,7 +274,7 @@ func TestFlatSeekDeterminism(t *testing.T) {
 			t.Fatalf("Next: %v", err)
 		}
 
-		baseline = append(baseline, row)
+		baseline = append(baseline, append([]any(nil), row...))
 	}
 
 	// SeekRow(0) on a fresh Runtime must match.
@@ -295,7 +295,7 @@ func TestFlatSeekDeterminism(t *testing.T) {
 			t.Fatalf("Next: %v", err)
 		}
 
-		replayed = append(replayed, row)
+		replayed = append(replayed, append([]any(nil), row...))
 	}
 
 	if !reflect.DeepEqual(baseline, replayed) {

--- a/pkg/datagen/runtime/relationship.go
+++ b/pkg/datagen/runtime/relationship.go
@@ -390,28 +390,28 @@ func (rt *Runtime) nextRelationship() ([]any, error) {
 	rt.ctx.lineIdx = lineIdx
 	rt.ctx.rowIdx = rt.row
 
-	for key := range rt.ctx.scratch {
-		delete(rt.ctx.scratch, key)
-	}
+	clear(rt.ctx.set)
 
-	for _, attr := range rel.dag.Order {
+	for attrIdx, attr := range rel.dag.Order {
 		name := attr.GetName()
 
 		if null := attr.GetNull(); null != nil && nullProbabilityHit(null, name, rt.row) {
-			rt.ctx.scratch[name] = nil
+			rt.ctx.slots[attrIdx] = expr.SlotNullValue()
+			rt.ctx.set[attrIdx] = true
 
 			continue
 		}
 
 		rt.ctx.attrPath = name
 
-		value, err := expr.Eval(rt.ctx, attr.GetExpr())
+		value, err := rt.evals[attrIdx](rt.ctx)
 		if err != nil {
 			return nil, fmt.Errorf("runtime: attr %q at (e=%d,i=%d): %w",
 				name, entityIdx, lineIdx, err)
 		}
 
-		rt.ctx.scratch[name] = value
+		rt.ctx.slots[attrIdx] = value
+		rt.ctx.set[attrIdx] = true
 	}
 
 	out := rt.assembleRow(rt.row)

--- a/pkg/datagen/runtime/relationship_test.go
+++ b/pkg/datagen/runtime/relationship_test.go
@@ -127,7 +127,7 @@ func drainRel(t *testing.T, r *Runtime) [][]any {
 			t.Fatalf("Next: %v", err)
 		}
 
-		rows = append(rows, row)
+		rows = append(rows, append([]any(nil), row...))
 	}
 }
 

--- a/pkg/datagen/seed/derive_draw_test.go
+++ b/pkg/datagen/seed/derive_draw_test.go
@@ -1,0 +1,52 @@
+package seed
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+// TestDeriveDrawMatchesDerive locks DeriveDraw to the historical string-based
+// formula across roots, attr paths, stream ids, and row indices (including
+// zero, large, negative, and the int64/uint32 extremes). If this fails, the
+// alloc-free path has diverged and every StreamDraw byte would change.
+func TestDeriveDrawMatchesDerive(t *testing.T) {
+	t.Parallel()
+
+	roots := []uint64{0, 1, 42, 0xA35F1C2D9E3779B9, math.MaxUint64}
+	attrs := []string{"", "l_comment", "l_extendedprice", "a/b", "s12", "ünïcödé"}
+	streams := []uint32{0, 1, 9, 10, 12, 99, uint32(1) << 31, math.MaxUint32}
+	rows := []int64{0, 1, 7, 9, 10, 99, 1_000_000, math.MaxInt64, -1, -1_000_000, math.MinInt64}
+
+	for _, root := range roots {
+		for _, attr := range attrs {
+			for _, sid := range streams {
+				for _, row := range rows {
+					want := Derive(root, attr,
+						"s"+strconv.FormatUint(uint64(sid), 10),
+						strconv.FormatInt(row, 10))
+
+					got := DeriveDraw(root, attr, sid, row)
+					if got != want {
+						t.Fatalf("DeriveDraw(%#x, %q, %d, %d) = %#x, want %#x",
+							root, attr, sid, row, got, want)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestDeriveDrawRootSensitive guards against the rootSeed-dropping regression
+// seen on the datagen-performance branch: changing root must change the key, so
+// the global seed actually influences generated data.
+func TestDeriveDrawRootSensitive(t *testing.T) {
+	t.Parallel()
+
+	a := DeriveDraw(1, "x", 7, 42)
+	b := DeriveDraw(2, "x", 7, 42)
+
+	if a == b {
+		t.Fatalf("DeriveDraw ignores root: both %#x", a)
+	}
+}

--- a/pkg/datagen/seed/derive_draw_test.go
+++ b/pkg/datagen/seed/derive_draw_test.go
@@ -37,6 +37,26 @@ func TestDeriveDrawMatchesDerive(t *testing.T) {
 	}
 }
 
+// TestDeriveGrammarAttemptMatchesDerive locks the alloc-free grammar re-walk
+// key to the historical Derive(root, "grammar", strconv.Itoa(attempt)).
+func TestDeriveGrammarAttemptMatchesDerive(t *testing.T) {
+	t.Parallel()
+
+	roots := []uint64{0, 1, 42, 0xA35F1C2D9E3779B9, math.MaxUint64}
+
+	for _, root := range roots {
+		for attempt := range 8 {
+			want := Derive(root, "grammar", strconv.Itoa(attempt))
+
+			got := DeriveGrammarAttempt(root, attempt)
+			if got != want {
+				t.Fatalf("DeriveGrammarAttempt(%#x, %d) = %#x, want %#x",
+					root, attempt, got, want)
+			}
+		}
+	}
+}
+
 // TestDeriveDrawRootSensitive guards against the rootSeed-dropping regression
 // seen on the datagen-performance branch: changing root must change the key, so
 // the global seed actually influences generated data.

--- a/pkg/datagen/seed/seed.go
+++ b/pkg/datagen/seed/seed.go
@@ -93,30 +93,30 @@ func fnv1aByte(h, b uint64) uint64 {
 	return h
 }
 
-// fnv1aUint folds the ASCII decimal digits of v (most-significant first) into
-// an in-progress FNV-1a accumulator, matching strconv.FormatUint(v, 10).
-func fnv1aUint(h, v uint64) uint64 {
+// fnv1aUint folds the ASCII decimal digits of value (most-significant first)
+// into an in-progress FNV-1a accumulator, matching strconv.FormatUint(value, 10).
+func fnv1aUint(hash, value uint64) uint64 {
 	var buf [maxUint64Digits]byte
 
 	pos := len(buf)
 
-	if v == 0 {
+	if value == 0 {
 		pos--
 		buf[pos] = '0'
 	} else {
-		for v > 0 {
+		for value > 0 {
 			pos--
-			buf[pos] = byte('0' + v%decimalBase)
-			v /= decimalBase
+			buf[pos] = byte('0' + value%decimalBase)
+			value /= decimalBase
 		}
 	}
 
 	for ; pos < len(buf); pos++ {
-		h ^= uint64(buf[pos])
-		h *= fnvPrime64
+		hash ^= uint64(buf[pos])
+		hash *= fnvPrime64
 	}
 
-	return h
+	return hash
 }
 
 // fnv1aInt folds the ASCII decimal digits of v (with a leading '-' for negative

--- a/pkg/datagen/seed/seed.go
+++ b/pkg/datagen/seed/seed.go
@@ -30,6 +30,96 @@ func Derive(root uint64, path ...string) uint64 {
 	return SplitMix64(root ^ FNV1a64(strings.Join(path, pathSep)))
 }
 
+// fnv1a64 constants (offset basis and prime).
+const (
+	fnvOffset64     uint64 = 0xCBF29CE484222325
+	fnvPrime64      uint64 = 0x100000001B3
+	decimalBase     uint64 = 10
+	maxUint64Digits        = 20 // len("18446744073709551615")
+)
+
+// DeriveDraw is the allocation-free stream key for a StreamDraw on one row.
+// It is byte-identical to the historical formula
+//
+//	Derive(root, attrPath, "s"+strconv.FormatUint(streamID,10), strconv.FormatInt(rowIdx,10))
+//
+// i.e. SplitMix64(root ^ FNV1a64(attrPath + "/s" + dec(streamID) + "/" + dec(rowIdx))),
+// but hashes attrPath's bytes and the decimal digits of streamID/rowIdx inline
+// rather than building the joined string, so it allocates nothing.
+//
+// It folds root into the mix (the historical formula does) and emits decimal
+// digits most-significant-first (as strconv does). Reimplementations that drop
+// root or reverse digit order silently change every draw — DeriveDraw must stay
+// equivalent to Derive; TestDeriveDrawMatchesDerive locks this.
+func DeriveDraw(root uint64, attrPath string, streamID uint32, rowIdx int64) uint64 {
+	h := fnvOffset64
+	h = fnv1aString(h, attrPath)
+	h = fnv1aByte(h, '/')
+	h = fnv1aByte(h, 's')
+	h = fnv1aUint(h, uint64(streamID))
+	h = fnv1aByte(h, '/')
+	h = fnv1aInt(h, rowIdx)
+
+	return SplitMix64(root ^ h)
+}
+
+// fnv1aString folds s's bytes into an in-progress FNV-1a accumulator.
+func fnv1aString(h uint64, s string) uint64 {
+	for i := range len(s) {
+		h ^= uint64(s[i])
+		h *= fnvPrime64
+	}
+
+	return h
+}
+
+// fnv1aByte folds a single byte into an in-progress FNV-1a accumulator.
+func fnv1aByte(h, b uint64) uint64 {
+	h ^= b
+	h *= fnvPrime64
+
+	return h
+}
+
+// fnv1aUint folds the ASCII decimal digits of v (most-significant first) into
+// an in-progress FNV-1a accumulator, matching strconv.FormatUint(v, 10).
+func fnv1aUint(h, v uint64) uint64 {
+	var buf [maxUint64Digits]byte
+
+	pos := len(buf)
+
+	if v == 0 {
+		pos--
+		buf[pos] = '0'
+	} else {
+		for v > 0 {
+			pos--
+			buf[pos] = byte('0' + v%decimalBase)
+			v /= decimalBase
+		}
+	}
+
+	for ; pos < len(buf); pos++ {
+		h ^= uint64(buf[pos])
+		h *= fnvPrime64
+	}
+
+	return h
+}
+
+// fnv1aInt folds the ASCII decimal digits of v (with a leading '-' for negative
+// values) into an in-progress FNV-1a accumulator, matching strconv.FormatInt.
+// uint64(-v) recovers the magnitude even for math.MinInt64 (two's complement).
+func fnv1aInt(h uint64, v int64) uint64 {
+	if v < 0 {
+		h = fnv1aByte(h, '-')
+
+		return fnv1aUint(h, uint64(-v))
+	}
+
+	return fnv1aUint(h, uint64(v))
+}
+
 // FNV1a64 is the 64-bit FNV-1a hash of s. It is the single source of
 // truth for string-to-uint64 hashing in the datagen framework; null
 // injection, dict salting, and any future component that needs a stable

--- a/pkg/datagen/seed/seed.go
+++ b/pkg/datagen/seed/seed.go
@@ -63,6 +63,18 @@ func DeriveDraw(root uint64, attrPath string, streamID uint32, rowIdx int64) uin
 	return SplitMix64(root ^ h)
 }
 
+// DeriveGrammarAttempt is the allocation-free sub-stream key for grammar
+// re-walk attempt n, byte-identical to Derive(root, "grammar", strconv.Itoa(n))
+// for n >= 0 (i.e. SplitMix64(root ^ FNV1a64("grammar/" + dec(n)))).
+func DeriveGrammarAttempt(root uint64, attempt int) uint64 {
+	h := fnvOffset64
+	h = fnv1aString(h, "grammar")
+	h = fnv1aByte(h, '/')
+	h = fnv1aInt(h, int64(attempt))
+
+	return SplitMix64(root ^ h)
+}
+
 // fnv1aString folds s's bytes into an in-progress FNV-1a accumulator.
 func fnv1aString(h uint64, s string) uint64 {
 	for i := range len(s) {

--- a/pkg/datagen/seed/seed_bench_test.go
+++ b/pkg/datagen/seed/seed_bench_test.go
@@ -1,0 +1,55 @@
+package seed
+
+import (
+	"strconv"
+	"testing"
+)
+
+// BenchmarkDeriveDrawKey mirrors the per-draw key derivation the runtime does
+// for every StreamDraw on every row (runtime.evalContext.Draw):
+//
+//	Derive(rootSeed, attrPath, "s"+streamID, rowIdx)
+//
+// including the two strconv conversions and the strings.Join inside Derive. A
+// lineitem row issues ~12 of these, so this is the second-largest datagen
+// allocation site (strconv.FormatInt + the join buffer) after grammar.
+func BenchmarkDeriveDrawKey(b *testing.B) {
+	const (
+		root     = uint64(0xA35F1C2D9E3779B9)
+		streamID = uint32(12)
+	)
+
+	b.ReportAllocs()
+
+	var (
+		sink uint64
+		row  int64
+	)
+
+	for b.Loop() {
+		sink = Derive(root, "l_extendedprice",
+			"s"+strconv.FormatUint(uint64(streamID), 10),
+			strconv.FormatInt(row, 10))
+		row++
+	}
+
+	_ = sink
+}
+
+// BenchmarkDerivePure isolates Derive's own allocation (the strings.Join and
+// fnv struct) from the caller's strconv, with pre-built path parts.
+func BenchmarkDerivePure(b *testing.B) {
+	const root = uint64(0xA35F1C2D9E3779B9)
+
+	parts := []string{"l_extendedprice", "s12", "1048576"}
+
+	b.ReportAllocs()
+
+	var sink uint64
+
+	for b.Loop() {
+		sink = Derive(root, parts...)
+	}
+
+	_ = sink
+}

--- a/pkg/driver/sqldriver/insert_spec.go
+++ b/pkg/driver/sqldriver/insert_spec.go
@@ -142,13 +142,11 @@ func RunBulkInsert[T any](
 		if filled >= batchSize {
 			generatedProgress.Flush()
 
-			if fullBatchQuery == "" {
-				fullBatchQuery = buildBulkInsertQuery(dialect, table, columns, batchSize)
-			}
+			var err error
 
-			args = appendFlatArgs(args, batch[:filled])
-
-			if err := execProgressBulkBatch(ctx, db, table, fullBatchQuery, args, int64(filled)); err != nil {
+			args, err = flushBulkInsertBatch(
+				ctx, db, table, columns, batch[:filled], dialect, args, &fullBatchQuery)
+			if err != nil {
 				return err
 			}
 
@@ -156,18 +154,59 @@ func RunBulkInsert[T any](
 		}
 	}
 
-	if filled > 0 {
-		generatedProgress.Flush()
+	return flushBulkInsertRemainder(
+		ctx, db, table, columns, batch[:filled], dialect, args, &fullBatchQuery, generatedProgress)
+}
 
-		query := buildBulkInsertQuery(dialect, table, columns, filled)
-		args = appendFlatArgs(args, batch[:filled])
-
-		if err := execProgressBulkBatch(ctx, db, table, query, args, int64(filled)); err != nil {
-			return err
-		}
+func flushBulkInsertRemainder[T any](
+	ctx context.Context,
+	db ExecContext[T],
+	table string,
+	columns []string,
+	rows [][]any,
+	dialect queries.Dialect,
+	args []any,
+	fullBatchQuery *string,
+	generatedProgress insertprogress.RowCounter,
+) error {
+	if len(rows) == 0 {
+		return nil
 	}
 
-	return nil
+	generatedProgress.Flush()
+
+	_, err := flushBulkInsertBatch(ctx, db, table, columns, rows, dialect, args, fullBatchQuery)
+
+	return err
+}
+
+func flushBulkInsertBatch[T any](
+	ctx context.Context,
+	db ExecContext[T],
+	table string,
+	columns []string,
+	rows [][]any,
+	dialect queries.Dialect,
+	args []any,
+	fullBatchQuery *string,
+) ([]any, error) {
+	rowCount := len(rows)
+
+	query := buildBulkInsertQuery(dialect, table, columns, rowCount)
+	if rowCount == cap(rows) {
+		if *fullBatchQuery == "" {
+			*fullBatchQuery = query
+		}
+
+		query = *fullBatchQuery
+	}
+
+	args = appendFlatArgs(args, rows)
+	if err := execProgressBulkBatch(ctx, db, table, query, args, int64(rowCount)); err != nil {
+		return args, err
+	}
+
+	return args, nil
 }
 
 func execProgressBulkBatch[T any](
@@ -277,7 +316,7 @@ func buildBulkInsertQuery(dialect queries.Dialect, table string, columns []strin
 
 		sb.WriteByte('(')
 
-		for colIdx := 0; colIdx < colCount; colIdx++ {
+		for colIdx := range colCount {
 			if colIdx > 0 {
 				sb.WriteString(", ")
 			}

--- a/pkg/driver/sqldriver/insert_spec.go
+++ b/pkg/driver/sqldriver/insert_spec.go
@@ -87,12 +87,30 @@ func RunBulkInsert[T any](
 	}
 
 	columns := rt.Columns()
-	if len(columns) == 0 {
+
+	colCount := len(columns)
+	if colCount == 0 {
 		return fmt.Errorf("%w: table %q", ErrEmptyColumnOrder, table)
 	}
 
-	batch := make([][]any, 0, batchSize)
+	// Buffers reused across this worker's batches: a fixed pool of row slices
+	// (filled in place by convertRowInto), the flattened args slice, and the
+	// cached full-batch INSERT statement (byte-identical for every
+	// batchSize-row batch). database/sql consumes the query and args
+	// synchronously inside ExecContext, so reusing them after a batch flush is
+	// safe; this turns the per-row slice, per-batch SQL string, and per-batch
+	// args allocations into one-time-per-worker costs.
+	batch := make([][]any, batchSize)
+	for i := range batch {
+		batch[i] = make([]any, colCount)
+	}
+
+	args := make([]any, 0, batchSize*colCount)
+
+	var fullBatchQuery string
+
 	remaining := limit
+	filled := 0
 
 	generatedProgress := insertprogress.NewGeneratedRowCounter(ctx)
 	defer generatedProgress.Flush()
@@ -109,12 +127,11 @@ func RunBulkInsert[T any](
 			return fmt.Errorf("sqldriver: runtime.Next: %w", err)
 		}
 
-		rowCopy, err := convertRow(row, dialect)
-		if err != nil {
+		if err := convertRowInto(batch[filled], row, dialect); err != nil {
 			return fmt.Errorf("sqldriver: convert row: %w", err)
 		}
 
-		batch = append(batch, rowCopy)
+		filled++
 
 		generatedProgress.Add(1)
 
@@ -122,21 +139,30 @@ func RunBulkInsert[T any](
 			remaining--
 		}
 
-		if len(batch) >= batchSize {
+		if filled >= batchSize {
 			generatedProgress.Flush()
 
-			if err := execProgressBulkBatch(ctx, db, table, columns, batch, dialect); err != nil {
+			if fullBatchQuery == "" {
+				fullBatchQuery = buildBulkInsertQuery(dialect, table, columns, batchSize)
+			}
+
+			args = appendFlatArgs(args, batch[:filled])
+
+			if err := execProgressBulkBatch(ctx, db, table, fullBatchQuery, args, int64(filled)); err != nil {
 				return err
 			}
 
-			batch = batch[:0]
+			filled = 0
 		}
 	}
 
-	if len(batch) > 0 {
+	if filled > 0 {
 		generatedProgress.Flush()
 
-		if err := execProgressBulkBatch(ctx, db, table, columns, batch, dialect); err != nil {
+		query := buildBulkInsertQuery(dialect, table, columns, filled)
+		args = appendFlatArgs(args, batch[:filled])
+
+		if err := execProgressBulkBatch(ctx, db, table, query, args, int64(filled)); err != nil {
 			return err
 		}
 	}
@@ -148,17 +174,15 @@ func execProgressBulkBatch[T any](
 	ctx context.Context,
 	db ExecContext[T],
 	table string,
-	columns []string,
-	batch [][]any,
-	dialect queries.Dialect,
+	query string,
+	args []any,
+	rows int64,
 ) error {
-	rows := int64(len(batch))
-
 	insertprogress.SetStage(ctx, insertprogress.StageSQLBulkInsertExec)
 
 	start := time.Now()
 
-	if err := execBulkBatch(ctx, db, table, columns, batch, dialect); err != nil {
+	if err := execBulkBatch(ctx, db, table, query, args); err != nil {
 		return err
 	}
 
@@ -193,38 +217,33 @@ func RunInsertSpecStats[T any](
 	return &stats.Query{Elapsed: time.Since(start), Rows: rows}, nil
 }
 
-// convertRow runs dialect.Convert over every value in row, copying into a
-// fresh slice (the runtime reuses its scratch slice across Next calls,
-// so the caller must detach before batching).
-func convertRow(row []any, dialect queries.Dialect) ([]any, error) {
-	out := make([]any, len(row))
-
+// convertRowInto runs dialect.Convert over every value in row, writing the
+// results into dst (which must have len >= len(row)). dst is a caller-owned,
+// reused slice — the runtime reuses its scratch slice across Next calls and
+// the batch reuses its row slices across flushes, so values are detached by
+// the conversion copy here rather than by allocating a fresh slice per row.
+func convertRowInto(dst, row []any, dialect queries.Dialect) error {
 	for i, v := range row {
 		conv, err := dialect.Convert(v)
 		if err != nil {
-			return nil, fmt.Errorf("column %d: %w", i, err)
+			return fmt.Errorf("column %d: %w", i, err)
 		}
 
-		out[i] = conv
+		dst[i] = conv
 	}
 
-	return out, nil
+	return nil
 }
 
-// execBulkBatch formats a multi-row INSERT and executes it. Identifiers
-// (table + column names) pass through unquoted — workload specs already
-// supply dialect-legal names. Placeholders come from dialect.Placeholder
-// in left-to-right row-major order.
+// execBulkBatch executes a prebuilt multi-row INSERT. The query and args are
+// owned (and reused) by the caller; ExecContext consumes them synchronously.
 func execBulkBatch[T any](
 	ctx context.Context,
 	db ExecContext[T],
 	table string,
-	columns []string,
-	rows [][]any,
-	dialect queries.Dialect,
+	query string,
+	args []any,
 ) error {
-	query, args := buildBulkInsertSQL(dialect, table, columns, rows)
-
 	if _, err := db.ExecContext(ctx, query, args...); err != nil {
 		return fmt.Errorf("sqldriver: bulk INSERT %q: %w", table, err)
 	}
@@ -232,15 +251,13 @@ func execBulkBatch[T any](
 	return nil
 }
 
-// buildBulkInsertSQL returns the multi-row INSERT statement for the
-// given table, column list, and row batch, along with the flattened
-// argument slice. Placeholders are numbered left-to-right, row-major.
-func buildBulkInsertSQL(
-	dialect queries.Dialect,
-	table string,
-	columns []string,
-	rows [][]any,
-) (query string, args []any) {
+// buildBulkInsertQuery returns the multi-row INSERT statement for nRows rows of
+// len(columns) columns each. Placeholders are numbered left-to-right,
+// row-major, so a full batch produces a byte-identical statement every time —
+// callers cache the full-batch query and rebuild only the final short batch.
+// Identifiers (table + column names) pass through unquoted; workload specs
+// already supply dialect-legal names.
+func buildBulkInsertQuery(dialect queries.Dialect, table string, columns []string, nRows int) string {
 	var sb strings.Builder
 
 	colCount := len(columns)
@@ -251,17 +268,16 @@ func buildBulkInsertSQL(
 	sb.WriteString(strings.Join(columns, ", "))
 	sb.WriteString(") VALUES ")
 
-	args = make([]any, 0, len(rows)*colCount)
 	placeholder := 0
 
-	for rowIdx, row := range rows {
+	for rowIdx := range nRows {
 		if rowIdx > 0 {
 			sb.WriteString(", ")
 		}
 
 		sb.WriteByte('(')
 
-		for colIdx := range row {
+		for colIdx := 0; colIdx < colCount; colIdx++ {
 			if colIdx > 0 {
 				sb.WriteString(", ")
 			}
@@ -271,9 +287,33 @@ func buildBulkInsertSQL(
 		}
 
 		sb.WriteByte(')')
-
-		args = append(args, row...)
 	}
 
-	return sb.String(), args
+	return sb.String()
+}
+
+// appendFlatArgs resets dst and appends every row's values in row-major order,
+// reusing dst's backing array across batches.
+func appendFlatArgs(dst []any, rows [][]any) []any {
+	dst = dst[:0]
+	for _, row := range rows {
+		dst = append(dst, row...)
+	}
+
+	return dst
+}
+
+// buildBulkInsertSQL returns the multi-row INSERT statement and flattened args
+// for a row batch. Retained for callers/tests that build both at once; the
+// hot path uses buildBulkInsertQuery + appendFlatArgs to reuse buffers.
+func buildBulkInsertSQL(
+	dialect queries.Dialect,
+	table string,
+	columns []string,
+	rows [][]any,
+) (query string, args []any) {
+	query = buildBulkInsertQuery(dialect, table, columns, len(rows))
+	args = appendFlatArgs(make([]any, 0, len(rows)*len(columns)), rows)
+
+	return query, args
 }

--- a/test/bench/tpch_lineitem_bulk_test.go
+++ b/test/bench/tpch_lineitem_bulk_test.go
@@ -1,0 +1,99 @@
+package bench
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stroppy-io/stroppy/pkg/datagen/runtime"
+	"github.com/stroppy-io/stroppy/pkg/driver/common"
+	"github.com/stroppy-io/stroppy/pkg/driver/sqldriver"
+	"github.com/stroppy-io/stroppy/pkg/driver/sqldriver/queries"
+)
+
+// benchExecResult / benchConn is a no-I/O ExecContext: it drives the full
+// sqldriver bulk-insert emit path (convertRow, the [][]any batch, multi-row
+// INSERT string build, flattened args) but discards the statement, isolating
+// real-driver row-materialization overhead from network/database latency. This
+// is the path postgres/ydb/mysql/csv share; the generation-only BenchmarkLineitem
+// (noop driver, NATIVE) never exercises it.
+type benchExecResult struct{}
+
+type benchConn struct{}
+
+func (benchConn) ExecContext(_ context.Context, _ string, _ ...any) (benchExecResult, error) {
+	return benchExecResult{}, nil
+}
+
+var _ sqldriver.ExecContext[benchExecResult] = benchConn{}
+
+// benchDialect is a "?"-placeholder, pass-through dialect — the cheapest
+// dialect, so the benchmark measures the floor of bulk emit cost. Numbered
+// placeholders (postgres "$1".."$N") allocate more in the SQL string build.
+type benchDialect struct{}
+
+func (benchDialect) Placeholder(_ int) string   { return "?" }
+func (benchDialect) Deduplicate() bool          { return false }
+func (benchDialect) Convert(v any) (any, error) { return v, nil }
+
+var _ queries.Dialect = benchDialect{}
+
+// benchBulkBatchSize matches the noop driver's defaultBulkSize so the batch
+// depth (and thus the count of simultaneously-live row slices and boxed
+// values) reflects production.
+const benchBulkBatchSize = 2500
+
+// BenchmarkLineitemBulkInsert measures the real SQL bulk-insert emit path end
+// to end, minus network: per-worker generation + convertRow + batch buffering +
+// multi-row INSERT build + flattened args, fanned out via the same
+// common.RunParallelByWorkers chunking the real drivers use. Compare
+// rows/s/worker against BenchmarkLineitem (generation only) to quantify what
+// materializing rows for a real driver costs, and watch alloc/op: this is the
+// path where the []any row slice + per-scalar interface boxing actually land.
+func BenchmarkLineitemBulkInsert(b *testing.B) {
+	size := benchRows()
+	conn := benchConn{}
+	dialect := benchDialect{}
+
+	for _, workers := range workerCounts {
+		b.Run(fmt.Sprintf("workers=%d", workers), func(b *testing.B) {
+			spec := lineitemSpec(size, workers)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			var (
+				totalRows    int64
+				totalSeconds float64
+			)
+
+			for b.Loop() {
+				start := time.Now()
+
+				rows, err := common.RunParallelByWorkers(ctx, spec, int(workers),
+					func(wctx context.Context, chunk common.Chunk, rt *runtime.Runtime) error {
+						return sqldriver.RunBulkInsert(
+							wctx, conn, spec.GetTable(), rt, dialect, chunk.Count, benchBulkBatchSize)
+					})
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				if rows != size {
+					b.Fatalf("rows = %d, want %d", rows, size)
+				}
+
+				totalRows += rows
+				totalSeconds += time.Since(start).Seconds()
+			}
+
+			if totalSeconds > 0 {
+				rps := float64(totalRows) / totalSeconds
+				b.ReportMetric(rps, "rows/s")
+				b.ReportMetric(rps/float64(workers), "rows/s/worker")
+			}
+		})
+	}
+}

--- a/test/bench/tpch_lineitem_test.go
+++ b/test/bench/tpch_lineitem_test.go
@@ -56,6 +56,7 @@ var workerCounts = []int32{1, 2, 4, 8, 16}
 // rounded down to a multiple of relationshipDegree so orders*degree == rows.
 func benchRows() int64 {
 	rows := defaultBenchRows
+
 	if v := os.Getenv("STROPPY_BENCH_ROWS"); v != "" {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
 			rows = n

--- a/test/bench/tpch_lineitem_test.go
+++ b/test/bench/tpch_lineitem_test.go
@@ -8,6 +8,8 @@
 // stress test for the per-row hot path and for worker scaling.
 //
 // Knobs:
+//   - STROPPY_RUN_BENCH_TESTS=1 enables the correctness test in this package.
+//     It is skipped by default because it drains the full SF=1 lineitem spec.
 //   - STROPPY_BENCH_ROWS overrides the row count (default 6,000,000 = SF=1).
 //     The value is rounded down to a multiple of 16 so the orders->lineitem
 //     relationship tiles exactly.
@@ -51,6 +53,8 @@ const relationshipDegree = 16
 
 // workerCounts is the scaling sweep shared by every benchmark.
 var workerCounts = []int32{1, 2, 4, 8, 16}
+
+const envRunBenchTests = "STROPPY_RUN_BENCH_TESTS"
 
 // benchRows returns the lineitem row count, overridable via STROPPY_BENCH_ROWS,
 // rounded down to a multiple of relationshipDegree so orders*degree == rows.
@@ -294,6 +298,10 @@ func newMetricsTracker() *insertprogress.Tracker {
 // number is trusted.
 func TestLineitemSpec_SingleWorker(t *testing.T) {
 	t.Parallel()
+
+	if os.Getenv(envRunBenchTests) != "1" {
+		t.Skipf("skipping bench correctness test: set %s=1 to enable", envRunBenchTests)
+	}
 
 	size := benchRows()
 	ctx := context.Background()

--- a/test/bench/tpch_lineitem_test.go
+++ b/test/bench/tpch_lineitem_test.go
@@ -1,0 +1,375 @@
+// Package bench hosts end-to-end data-generation benchmarks that exercise the
+// full stroppy generation pipeline (InsertSpec -> runtime -> driver) through the
+// noop driver, isolating framework/generation cost from real database latency.
+//
+// The TPC-H lineitem table is the heaviest generator in the suite: a 1:16
+// orders->lineitem relationship, a suppliers lookup, grammar-based comment text,
+// and a mix of integer/float/decimal/date StreamDraw columns. It is the natural
+// stress test for the per-row hot path and for worker scaling.
+//
+// Knobs:
+//   - STROPPY_BENCH_ROWS overrides the row count (default 6,000,000 = SF=1).
+//     The value is rounded down to a multiple of 16 so the orders->lineitem
+//     relationship tiles exactly.
+//
+// Profiling (single worker count at a time keeps the profile attributable):
+//
+//	go test ./test/bench -run x -bench 'BenchmarkLineitem/workers=8$' \
+//	    -benchtime 3x -cpuprofile cpu.out -memprofile mem.out -trace trace.out
+//
+// Scaling diagnosis axes:
+//   - workers: every benchmark sweeps {1,2,4,8,16} and reports rows/s/worker,
+//     which is flat under linear scaling and decays under contention.
+//   - metrics atomics: BenchmarkLineitem runs with NO progress tracker (the
+//     atomics are no-op'd); BenchmarkLineitemTracked attaches a real Tracker so
+//     the generatedRows/confirmedRows/lastProgress atomics are exercised. The
+//     gap between the two isolates progress-tracking contention.
+//   - GC: run either benchmark with GOGC=off to see whether GC mark-assist is
+//     the scaling limiter.
+package bench
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	"github.com/stroppy-io/stroppy/pkg/datagen/dgproto"
+	"github.com/stroppy-io/stroppy/pkg/driver"
+	"github.com/stroppy-io/stroppy/pkg/driver/insertprogress"
+	"github.com/stroppy-io/stroppy/pkg/driver/noop"
+)
+
+// defaultBenchRows is TPC-H SF=1 (~6M lineitem rows).
+const defaultBenchRows = int64(6_000_000)
+
+// relationshipDegree is the fixed orders->lineitem fan-out (TPC-H averages 4,
+// but a fixed 16 keeps the relationship deterministic and the row math exact).
+const relationshipDegree = 16
+
+// workerCounts is the scaling sweep shared by every benchmark.
+var workerCounts = []int32{1, 2, 4, 8, 16}
+
+// benchRows returns the lineitem row count, overridable via STROPPY_BENCH_ROWS,
+// rounded down to a multiple of relationshipDegree so orders*degree == rows.
+func benchRows() int64 {
+	rows := defaultBenchRows
+	if v := os.Getenv("STROPPY_BENCH_ROWS"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			rows = n
+		}
+	}
+
+	return (rows / relationshipDegree) * relationshipDegree
+}
+
+// --- proto builders (mirror noop/driver_test.go patterns). ---
+
+func litInt(n int64) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_Lit{Lit: &dgproto.Literal{
+		Value: &dgproto.Literal_Int64{Int64: n},
+	}}}
+}
+
+func litFloat(f float64) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_Lit{Lit: &dgproto.Literal{
+		Value: &dgproto.Literal_Double{Double: f},
+	}}}
+}
+
+func rowIndexKind(kind dgproto.RowIndex_Kind) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_RowIndex{RowIndex: &dgproto.RowIndex{Kind: kind}}}
+}
+
+func binOp(op dgproto.BinOp_Op, a, b *dgproto.Expr) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_BinOp{BinOp: &dgproto.BinOp{
+		Op: op, A: a, B: b,
+	}}}
+}
+
+func lookupExpr(pop, attrName string, idx *dgproto.Expr) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_Lookup{Lookup: &dgproto.Lookup{
+		TargetPop: pop, AttrName: attrName, EntityIndex: idx,
+	}}}
+}
+
+func fixedDegree(count int64) *dgproto.Degree {
+	return &dgproto.Degree{Kind: &dgproto.Degree_Fixed{Fixed: &dgproto.DegreeFixed{
+		Count: count,
+	}}}
+}
+
+// --- Draw helpers (StreamDraw arms). ---
+
+func drawIntUniform(lo, hi int64) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_StreamDraw{StreamDraw: &dgproto.StreamDraw{
+		Draw: &dgproto.StreamDraw_IntUniform{IntUniform: &dgproto.DrawIntUniform{
+			Min: litInt(lo), Max: litInt(hi),
+		}},
+	}}}
+}
+
+func drawDecimal(lo, hi float64, scale uint32) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_StreamDraw{StreamDraw: &dgproto.StreamDraw{
+		Draw: &dgproto.StreamDraw_Decimal{Decimal: &dgproto.DrawDecimal{
+			Min: litFloat(lo), Max: litFloat(hi), Scale: scale,
+		}},
+	}}}
+}
+
+// drawDateUniform uses epoch days (TPC-H: 1995-01-01 = 8927, 1998-12-31 = 10456).
+func drawDateUniform(minDays, maxDays int64) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_StreamDraw{StreamDraw: &dgproto.StreamDraw{
+		Draw: &dgproto.StreamDraw_Date{Date: &dgproto.DrawDate{
+			MinDaysEpoch: minDays, MaxDaysEpoch: maxDays,
+		}},
+	}}}
+}
+
+// commentGrammarExpr builds a TPC-H-style comment generator (spec §4.2):
+// single-uppercase-letter nonterminals (J adjective, N noun, V verb, T
+// terminator) resolved through word dicts. The root templates are multi-token
+// sentences that land inside the [minLen,maxLen] window within one or two
+// walks, so the benchmark exercises the COMMON grammar path. (A template whose
+// tokens never resolve to letters — e.g. "[N] [V]" — would emit ~7 chars and
+// re-walk grammarMaxAttempts times every row, measuring the re-walk-exhaustion
+// pathology instead of real text generation.)
+func commentGrammarExpr(minLen, maxLen int64) *dgproto.Expr {
+	return &dgproto.Expr{Kind: &dgproto.Expr_StreamDraw{StreamDraw: &dgproto.StreamDraw{
+		Draw: &dgproto.StreamDraw_Grammar{Grammar: &dgproto.DrawGrammar{
+			RootDict: "g_root",
+			Leaves: map[string]string{
+				"J": "g_adj", "N": "g_noun", "V": "g_verb", "T": "g_term",
+			},
+			MinLen: litInt(minLen),
+			MaxLen: litInt(maxLen),
+		}},
+	}}}
+}
+
+// commentGrammarDicts returns the word dicts for commentGrammarExpr. Root
+// templates average ~55 chars so most rows satisfy minLen=40 on the first walk.
+func commentGrammarDicts() map[string]*dgproto.Dict {
+	return map[string]*dgproto.Dict{
+		"g_root": multiRowDict(
+			"the J N V the J N T",
+			"J N V about the J N T",
+			"N V according to the J N T",
+			"the J N V quickly the N T",
+			"J N V along the J N V T",
+		),
+		"g_adj": multiRowDict("furious", "sly", "careful", "blithe", "quick",
+			"final", "ironic", "even", "bold", "express", "regular", "special"),
+		"g_noun": multiRowDict("packages", "requests", "accounts", "deposits",
+			"theodolites", "instructions", "platelets", "foxes", "dolphins",
+			"warthogs", "excuses", "dependencies"),
+		"g_verb": multiRowDict("wake", "sleep", "cajole", "integrate", "haggle",
+			"nag", "sublate", "boost", "detect", "affix", "promise", "snooze"),
+		"g_term": multiRowDict(".", "!"),
+	}
+}
+
+// multiRowDict builds a uniform-weight Dict from one-value rows.
+func multiRowDict(values ...string) *dgproto.Dict {
+	rows := make([]*dgproto.DictRow, len(values))
+	for i, v := range values {
+		rows[i] = &dgproto.DictRow{Values: []string{v}}
+	}
+
+	return &dgproto.Dict{Rows: rows}
+}
+
+// --- TPC-H lineitem spec (SF=1 ≈ 6M rows). ---
+
+func lineitemSpec(size int64, workers int32) *dgproto.InsertSpec {
+	supplierAttrs := []*dgproto.Attr{
+		{Name: "s_id", Expr: rowIndexKind(dgproto.RowIndex_ENTITY)},
+	}
+
+	orderAttrs := []*dgproto.Attr{
+		{Name: "o_id", Expr: rowIndexKind(dgproto.RowIndex_ENTITY)},
+	}
+
+	lineAttrs := []*dgproto.Attr{
+		{Name: "order_idx", Expr: rowIndexKind(dgproto.RowIndex_ENTITY)},
+		{Name: "line_idx", Expr: rowIndexKind(dgproto.RowIndex_LINE)},
+		{Name: "global_idx", Expr: rowIndexKind(dgproto.RowIndex_GLOBAL)},
+
+		{Name: "l_orderkey", Expr: binOp(dgproto.BinOp_ADD,
+			rowIndexKind(dgproto.RowIndex_ENTITY), litInt(1))},
+
+		{Name: "l_partkey", Expr: drawIntUniform(1, 200_000)},
+
+		{Name: "l_suppkey", Expr: binOp(dgproto.BinOp_ADD,
+			lookupExpr("suppliers", "s_id", drawIntUniform(0, 999)),
+			litInt(1))},
+
+		{Name: "l_quantity", Expr: drawIntUniform(1, 25)},
+
+		{Name: "l_extendedprice", Expr: drawDecimal(0.01, 99999.99, 2)},
+
+		{Name: "l_discount", Expr: binOp(dgproto.BinOp_MUL,
+			drawIntUniform(0, 10), litFloat(0.01))},
+
+		{Name: "l_tax", Expr: binOp(dgproto.BinOp_MUL,
+			drawIntUniform(0, 7), litFloat(0.025))},
+
+		{Name: "l_returnflag", Expr: drawIntUniform(0, 2)},
+
+		{Name: "l_linestatus", Expr: drawIntUniform(0, 1)},
+
+		{Name: "l_shipdate", Expr: drawDateUniform(8927, 10456)},
+
+		{Name: "l_shipinstruct", Expr: drawIntUniform(0, 6)},
+
+		{Name: "l_shipmode", Expr: drawIntUniform(0, 6)},
+
+		{Name: "l_comment", Expr: commentGrammarExpr(40, 83)},
+	}
+
+	return &dgproto.InsertSpec{
+		Table:       "lineitem",
+		Method:      dgproto.InsertMethod_NATIVE,
+		Parallelism: &dgproto.Parallelism{Workers: workers},
+		Dicts:       commentGrammarDicts(),
+		Source: &dgproto.RelSource{
+			Population:  &dgproto.Population{Name: "lineitem", Size: size},
+			Attrs:       lineAttrs,
+			ColumnOrder: columnOrder(),
+			LookupPops: []*dgproto.LookupPop{
+				{
+					Population:  &dgproto.Population{Name: "suppliers", Size: 1000},
+					Attrs:       supplierAttrs,
+					ColumnOrder: []string{"s_id"},
+				},
+				{
+					Population:  &dgproto.Population{Name: "orders", Size: size / relationshipDegree},
+					Attrs:       orderAttrs,
+					ColumnOrder: []string{"o_id"},
+				},
+			},
+			Relationships: []*dgproto.Relationship{{
+				Name: "orders_lineitem",
+				Sides: []*dgproto.Side{
+					{Population: "orders", Degree: fixedDegree(1)},
+					{Population: "lineitem", Degree: fixedDegree(relationshipDegree)},
+				},
+			}},
+			Iter: "orders_lineitem",
+		},
+	}
+}
+
+func columnOrder() []string {
+	return []string{
+		"order_idx", "line_idx", "global_idx",
+		"l_orderkey", "l_partkey", "l_suppkey",
+		"l_quantity", "l_extendedprice", "l_discount", "l_tax",
+		"l_returnflag", "l_linestatus", "l_shipdate",
+		"l_shipinstruct", "l_shipmode", "l_comment",
+	}
+}
+
+// newMetricsTracker builds a tracker whose Add* path exercises the shared
+// atomics. Mode is metrics-only with a no-op sink so emit() is cheap; the
+// per-flush generatedRows/confirmedRows/lastProgress atomics still fire.
+func newMetricsTracker() *insertprogress.Tracker {
+	return insertprogress.NewTracker(&insertprogress.Config{
+		Enabled:  true,
+		Mode:     insertprogress.ModeMetrics,
+		Table:    "lineitem",
+		Method:   "native",
+		OnSample: func(insertprogress.Snapshot) {},
+	})
+}
+
+// --- Correctness gate. ---
+
+// TestLineitemSpec_SingleWorker drains the full relationship spec and asserts
+// the runtime emits exactly `size` rows. Keeps the bench spec honest: if the
+// relationship math or seek logic drifts, this fails before any benchmark
+// number is trusted.
+func TestLineitemSpec_SingleWorker(t *testing.T) {
+	t.Parallel()
+
+	size := benchRows()
+	ctx := context.Background()
+
+	d := noop.NewDriver(driver.Options{Config: &stroppy.DriverConfig{}})
+	spec := lineitemSpec(size, 1)
+
+	stat, err := d.InsertSpec(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stat.Rows != size {
+		t.Fatalf("rows = %d, want %d", stat.Rows, size)
+	}
+
+	t.Logf("elapsed: %v  rows/s: %.0f", stat.Elapsed, float64(stat.Rows)/stat.Elapsed.Seconds())
+}
+
+// --- Benchmarks. ---
+
+// BenchmarkLineitem measures pure generation throughput across worker counts
+// with NO progress tracker attached (metrics atomics no-op'd). rows/s/worker
+// is the scaling signal.
+func BenchmarkLineitem(b *testing.B) {
+	runLineitemBench(b, false)
+}
+
+// BenchmarkLineitemTracked is identical but attaches a live metrics tracker, so
+// the per-flush shared atomics are exercised. Compare rows/s/worker against
+// BenchmarkLineitem to isolate progress-tracking contention.
+func BenchmarkLineitemTracked(b *testing.B) {
+	runLineitemBench(b, true)
+}
+
+func runLineitemBench(b *testing.B, tracked bool) {
+	b.Helper()
+
+	size := benchRows()
+	d := noop.NewDriver(driver.Options{Config: &stroppy.DriverConfig{}})
+
+	for _, workers := range workerCounts {
+		b.Run(fmt.Sprintf("workers=%d", workers), func(b *testing.B) {
+			spec := lineitemSpec(size, workers)
+
+			ctx := context.Background()
+			if tracked {
+				ctx = insertprogress.ContextWithTracker(ctx, newMetricsTracker())
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			var (
+				totalRows    int64
+				totalSeconds float64
+			)
+
+			for b.Loop() {
+				stat, err := d.InsertSpec(ctx, spec)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				if stat.Rows != size {
+					b.Fatalf("rows = %d, want %d", stat.Rows, size)
+				}
+
+				totalRows += stat.Rows
+				totalSeconds += stat.Elapsed.Seconds()
+			}
+
+			if totalSeconds > 0 {
+				rps := float64(totalRows) / totalSeconds
+				b.ReportMetric(rps, "rows/s")
+				b.ReportMetric(rps/float64(workers), "rows/s/worker")
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request

## Description of Changes

This PR optimizes the datagen hot path and SQL bulk insert emission path.

Main changes:
- Add an internal typed `expr.Slot` evaluator fast path for common scalar expressions, avoiding repeated `any` boxing during per-row evaluation.
- Replace runtime per-row scratch maps with indexed slot storage and reusable emitted row buffers.
- Add allocation-free seed derivation for StreamDraw and grammar re-walk keys while preserving byte-identical output.
- Rework grammar generation to reuse context-owned buffers, avoid `strings.Fields` allocations, avoid `[]rune` truncation, and reuse PRNG state.
- Optimize SQL bulk insert emission by reusing row slices, flattened args buffers, and cached full-batch INSERT statements.
- Add focused equivalence tests and benchmarks for the optimized paths.
- Ignore local datagen profiling artifacts.

## Motivation and Context

TPC-H-style data generation, especially `lineitem`, spends a large amount of time and allocation budget in per-row expression evaluation, StreamDraw seed derivation, grammar comment generation, and SQL bulk insert materialization.

This branch keeps generated data stable while reducing allocation pressure in those hot paths. The new seed derivation helpers are locked against the historical string-based formulas, and the new typed evaluator is checked against the existing `Eval` behavior.

## How Has This Been Tested?

Added coverage includes:
- `pkg/datagen/expr/slot_equiv_test.go` for table-driven and randomized `CompileSlot` vs `Eval` equivalence.
- `pkg/datagen/seed/derive_draw_test.go` to verify allocation-free seed derivation stays byte-identical to the historical formula.
- Runtime test updates for reusable row buffers.
- `test/bench` TPC-H `lineitem` generation and bulk-insert benchmarks.
- Microbenchmarks for grammar generation and seed derivation.

Not run in this drafting pass:
- `make linter_fix`
- `make linter`
- `make tests`

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [x] Refactoring
- [x] Other: performance optimization

## Checklist

- [ ] I have read the CONTRIBUTING.md
- [ ] I have checked build and tests
- [ ] I have updated documentation if needed