### PR TITLE
Add aarch64 to arch list in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ ifeq ($(UNAME_M),x86_64)
   ARCH := x86_64
 else ifeq ($(UNAME_M),arm64)
   ARCH := aarch_64
+else ifeq ($(UNAME_M), aarch64)
+  ARCH := aarch_64
 else
   $(error Unsupported architecture: $(UNAME_M))
 endif


### PR DESCRIPTION
# Pull Request

## Description of Changes
Add aarch64 to arch list in Makefile

## Motivation and Context
Build is broken for aarch64 linux

## Type of Changes
Bug fix