### PR TITLE
fix(ydb): make TPC-H loadable on YDB (BulkUpsert type coercion) + lift tpch maxDuration

### DIFF
--- a/pkg/driver/ydb/insert_spec.go
+++ b/pkg/driver/ydb/insert_spec.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
+	"github.com/ydb-platform/ydb-go-sdk/v3/table/options"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/types"
 
 	"github.com/stroppy-io/stroppy/pkg/datagen/dgproto"
@@ -101,7 +102,23 @@ type bulkUpsertWriter struct {
 	fieldsBuf  []types.StructValueOption
 	batchLen   int
 	bulkSize   int
+	// colKind[i] coerces cell i to the type the table declares: the generator
+	// emits dates as strings and integral quantities as int64, but the YDB
+	// schema may want Timestamp / Double, and BulkUpsert does not coerce.
+	// Resolved once via DescribeTable on the first row.
+	colKind   []colKind
+	described bool
 }
+
+// colKind is the schema-driven coercion applied to a generated cell before
+// BulkUpsert type inference.
+type colKind uint8
+
+const (
+	kindPassthrough colKind = iota // type already matches; leave as-is
+	kindTimestamp                  // date string -> *time.Time
+	kindDouble                     // int64 -> float64
+)
 
 func newBulkUpsertWriter(
 	ydbDriver *Driver,
@@ -132,7 +149,15 @@ func newBulkUpsertWriter(
 }
 
 func (w *bulkUpsertWriter) appendRowCtx(ctx context.Context, row []any) error {
-	if err := convertRowInto(w.d.dialect, w.columns, w.rowCells[w.batchLen], row); err != nil {
+	if !w.described {
+		if err := w.resolveColumnKinds(ctx); err != nil {
+			return err
+		}
+
+		w.described = true
+	}
+
+	if err := convertRowInto(w.d.dialect, w.columns, w.colKind, w.rowCells[w.batchLen], row); err != nil {
 		return err
 	}
 
@@ -231,19 +256,95 @@ func (d *Driver) bulkUpsertRuntime(
 	return writer.flush(ctx)
 }
 
-// convertRowInto runs each cell through the dialect.Convert hook into
-// dest, which must be sized to the row width.
-func convertRowInto(dialect queries.Dialect, columns []string, dest, row []any) error {
+// dateLayout is the ISO date string the dbgen generators emit (misc.go
+// makeAscDate: "%4d-%02d-%02d").
+const dateLayout = "2006-01-02"
+
+// convertRowInto runs each cell through the dialect.Convert hook into dest,
+// which must be sized to the row width, then coerces it to the type the table
+// declares (kinds[idx]) so BulkUpsert's type inference matches the column:
+// date strings -> *time.Time (Timestamp), int64 -> float64 (Double).
+func convertRowInto(dialect queries.Dialect, columns []string, kinds []colKind, dest, row []any) error {
 	for idx, col := range columns {
 		conv, err := dialect.Convert(row[idx])
 		if err != nil {
 			return fmt.Errorf("ydb: convert col %q: %w", col, err)
 		}
 
+		kind := kindPassthrough
+		if idx < len(kinds) {
+			kind = kinds[idx]
+		}
+
+		switch kind {
+		case kindTimestamp:
+			if s, ok := conv.(string); ok && s != "" {
+				t, perr := time.Parse(dateLayout, s)
+				if perr != nil {
+					return fmt.Errorf("ydb: parse timestamp col %q value %q: %w", col, s, perr)
+				}
+
+				conv = &t
+			}
+		case kindDouble:
+			if n, ok := conv.(int64); ok {
+				conv = float64(n)
+			}
+		case kindPassthrough:
+		}
+
 		dest[idx] = conv
 	}
 
 	return nil
+}
+
+// resolveColumnKinds describes the target table once and records, per writer
+// column, the coercion needed to match the declared type (see colKind). The
+// generator emits a single representation for all dialects (dates as strings,
+// quantities as int64); YDB BulkUpsert is strict, so we adapt here.
+func (w *bulkUpsertWriter) resolveColumnKinds(ctx context.Context) error {
+	var desc options.Description
+
+	err := w.d.nativeDB.Table().Do(ctx, func(ctx context.Context, s table.Session) error {
+		var e error
+
+		desc, e = s.DescribeTable(ctx, w.tablePath)
+
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("ydb: describe table %q: %w", w.tableName, err)
+	}
+
+	kindByName := make(map[string]colKind, len(desc.Columns))
+	for _, c := range desc.Columns {
+		kindByName[c.Name] = columnKind(c.Type)
+	}
+
+	w.colKind = make([]colKind, len(w.columns))
+	for i, col := range w.columns {
+		w.colKind[i] = kindByName[col]
+	}
+
+	return nil
+}
+
+// columnKind maps a declared YDB column type (unwrapping a nullable
+// Optional<T>) to the coercion the generated cell needs.
+func columnKind(t types.Type) colKind {
+	if optional, inner := types.IsOptional(t); optional {
+		t = inner
+	}
+
+	switch {
+	case types.Equal(t, types.TypeTimestamp):
+		return kindTimestamp
+	case types.Equal(t, types.TypeDouble):
+		return kindDouble
+	default:
+		return kindPassthrough
+	}
 }
 
 // columnsWithNulls returns a boolean mask: mask[i] is true iff any row

--- a/pkg/driver/ydb/insert_spec_test.go
+++ b/pkg/driver/ydb/insert_spec_test.go
@@ -102,7 +102,7 @@ func TestConvertRowInto(t *testing.T) {
 	columns := []string{"w_id", "w_tax"}
 	dest := make([]any, 2)
 
-	err := convertRowInto(ydbDialect{}, columns, dest, []any{int64(1), 0.05})
+	err := convertRowInto(ydbDialect{}, columns, nil, dest, []any{int64(1), 0.05})
 	if err != nil {
 		t.Fatalf("convertRowInto: %v", err)
 	}
@@ -113,6 +113,43 @@ func TestConvertRowInto(t *testing.T) {
 
 	if dest[1] != 0.05 {
 		t.Fatalf("dest[1] = %v", dest[1])
+	}
+}
+
+func TestConvertRowIntoKinds(t *testing.T) {
+	t.Parallel()
+
+	// Timestamp column: date string -> *time.Time. Double column: int64 ->
+	// float64. Passthrough string column is left untouched.
+	columns := []string{"l_orderkey", "l_shipdate", "l_quantity", "l_comment"}
+	kinds := []colKind{kindPassthrough, kindTimestamp, kindDouble, kindPassthrough}
+	dest := make([]any, 4)
+
+	err := convertRowInto(ydbDialect{}, columns, kinds, dest,
+		[]any{int64(7), "1996-01-02", int64(17), "not-a-date"})
+	if err != nil {
+		t.Fatalf("convertRowInto: %v", err)
+	}
+
+	if dest[0] != int64(7) {
+		t.Fatalf("dest[0] = %v (%T), want int64 7", dest[0], dest[0])
+	}
+
+	ts, ok := dest[1].(*time.Time)
+	if !ok {
+		t.Fatalf("dest[1] type = %T, want *time.Time", dest[1])
+	}
+
+	if ts.Year() != 1996 || ts.Month() != time.January || ts.Day() != 2 {
+		t.Fatalf("dest[1] = %v, want 1996-01-02", ts)
+	}
+
+	if dest[2] != float64(17) {
+		t.Fatalf("dest[2] = %v (%T), want float64 17", dest[2], dest[2])
+	}
+
+	if dest[3] != "not-a-date" {
+		t.Fatalf("dest[3] = %v, want string untouched", dest[3])
 	}
 }
 

--- a/workloads/tpch/tx.ts
+++ b/workloads/tpch/tx.ts
@@ -185,8 +185,22 @@ const SEED_LINEITEM = 0x7EC108;
 // Date windows live in tpch_helpers.ts (tpchOrderdateExpr). Lineitem
 // dates are derived from o_orderdate — see lineitemSpec().
 
+// A full load + 22-query pass on a slow loader (e.g. YDB BulkUpsert at SF>=1)
+// far exceeds k6's 10m default for the vus/iterations shorthand, which would
+// interrupt the iteration mid-load. Declaring a scenario lets maxDuration lift
+// that cap; override with MAX_DURATION if needed.
+const MAX_DURATION = ENV("MAX_DURATION", "24h", "Max wall-clock for the run (k6 duration)");
+
 export const options: Options = {
   summaryTrendStats: ["avg", "min", "med", "max", "p(90)", "p(95)", "p(99)"],
+  scenarios: {
+    tpch: {
+      executor: "shared-iterations",
+      vus: 1,
+      iterations: 1,
+      maxDuration: MAX_DURATION,
+    },
+  },
 };
 
 const TPCH_QUERY_NAMES = Array.from({ length: 22 }, (_, i) => "q" + String(i + 1));


### PR DESCRIPTION
# Pull Request

## Description of Changes
- **ydb driver**: the bulk-upsert writer now describes the target table once
  (`DescribeTable`) and coerces each generated cell to the declared column type
  before `BulkUpsert` — date strings → `*time.Time` for `Timestamp` columns,
  `int64` → `float64` for `Double` columns; all other types pass through
  unchanged (`pkg/driver/ydb/insert_spec.go` + tests).
- **tpch workload**: the run declares a `shared-iterations` scenario so
  `MAX_DURATION` (default 24h) governs the wall-clock cap instead of k6's 10m
  default (`workloads/tpch/tx.ts`).

## Motivation and Context
TPC-H could not load on YDB: `orders`/`lineitem` aborted with
`Type mismatch, got type Utf8 ... expected Timestamp` (o_orderdate) and
`got type Int64 ... expected Double` (l_quantity). YDB `BulkUpsert` is strict and
does not coerce, but the data generators emit one representation for all dialects
(dates as ISO strings, integral quantities as `int64`) which PostgreSQL/MySQL cast
implicitly. The fix is schema-driven, so existing tpcb/tpcc `InsertSpec` loads are
unaffected — only columns the table declares as Timestamp/Double are touched.

The 10m default `maxDuration` separately interrupted slow YDB loads (SF>=1) before
the index/query steps could run, so it is lifted to match the tpcds workload.

## How Has This Been Tested?
- `go test ./pkg/driver/ydb/` — coercion unit tests (10 pass).
- TPC-H on `ghcr.io/ydb-platform/local-ydb`:
  - **SF=0.01** — load 0 errors, 22/22 queries OK.
  - **SF=1** — all 8 tables load 0 errors, post-load steps run, **22/22 queries OK**,
    1 complete / 0 interrupted iterations.
- PostgreSQL and MySQL TPC-H runs unchanged (22/22).

## Type of Changes
- [x] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [ ] Refactoring
- [ ] Other

## Checklist
- [ ] I have read the CONTRIBUTING.md
- [x] I have checked build and tests
- [ ] I have updated documentation if needed
