### PR TITLE
fix(workloads): scenario-branch bugs (maxDuration / iter<vus / tpcds drop) + CI smoke tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,47 +49,33 @@ jobs:
       - name: Run TS tests
         run: make ts-test
 
-  build:
+  # Integration builds stroppy once, runs the smoke tiers, and uploads the
+  # binary artifact. Build is gated behind it — the published binary is the one
+  # the integration tests actually exercised, and we never build twice.
+  integration:
     needs: [golang-ci, typescript-ci]
+    uses: ./.github/workflows/integration.yml
+
+  # Publish the integration-built binary as a per-commit nightly pre-release.
+  # No rebuild: it downloads the artifact integration produced. Main only.
+  publish:
+    needs: [integration]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Install xk6 (k6 builder)
-        run: make install-xk6
-
       - name: Compute short SHA
         id: sha
         run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
-      - name: Build
-        env:
-          CGO_ENABLED: "0"
-          XK6_RACE_DETECTOR: "0"
-          GOOS: linux
-          GOARCH: amd64
-          VERSION: nightly-${{ steps.sha.outputs.short }}
-        run: make build
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v7
+      - name: Download binary artifact
+        uses: actions/download-artifact@v8
         with:
           name: stroppy-linux-amd64
-          path: build/stroppy
-          if-no-files-found: error
-          retention-days: 7
+          path: build
 
       - name: Pre-release per commit
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: nightly-${{ steps.sha.outputs.short }}
@@ -99,7 +85,3 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  integration:
-    needs: [golang-ci, typescript-ci]
-    uses: ./.github/workflows/integration.yml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,11 +35,41 @@ jobs:
       - name: Install xk6
         run: make install-xk6
 
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      # Build once here; the publish job consumes this same binary via artifact,
+      # so the pipeline never builds twice or tests a binary it didn't gate.
       - name: Build stroppy
+        env:
+          CGO_ENABLED: "0"
+          XK6_RACE_DETECTOR: "0"
+          GOOS: linux
+          GOARCH: amd64
+          VERSION: nightly-${{ steps.sha.outputs.short }}
         run: make build
 
-      - name: Run k6 integration tests
+      # Tier 0: scenario-branch smoke on the noop driver — no database, exercises
+      # both executor archetypes (constant-vus / shared-iterations) for every
+      # workload. Fast and catches k6 options/executor regressions for ~free.
+      - name: Scenario smoke (noop, no DB)
+        run: make run-scenario-smoke
+
+      - name: Run k6 SQL API integration tests
         run: make run-k6-tests
 
-      - name: Run TPC-B smoke test
+      - name: Run TPC-B procs smoke test
         run: make run-tpcb-test
+
+      # Tier 1: real-Postgres smoke of both scenario branches for every workload.
+      - name: Run workload branch tests (Postgres)
+        run: make run-workload-branches
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: stroppy-linux-amd64
+          path: build/stroppy
+          if-no-files-found: error
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ revision: # Recreate git tag with version tag=<semver>
 ## Local K6 fast tests
 ##
 
-.PHONY: run-simple-test run-tpcb-test run-tpcc-test run-tpcc-mysql-test run-tpcds-test run-k6-tests
+.PHONY: run-simple-test run-tpcb-test run-tpcc-test run-tpcc-mysql-test run-tpcds-test run-k6-tests run-scenario-smoke run-workload-branches
 
 WORKDIR=dev
 
@@ -378,6 +378,54 @@ run-k6-tests: # Run SQL API integration tests
 	./build/stroppy run tests/sqlapi_test -- -q        || rc=1; \
 	./build/stroppy run tests/multi_drivers_test -- -q || rc=1; \
 	./build/stroppy run tests/transaction_test -- -q   || rc=1; \
+	exit $$rc
+
+# Gate one smoke run: fail on a non-zero exit OR any k6 `level=error` line.
+# k6/stroppy exit 0 even when every iteration errors (e.g. a failed GlobalOnce
+# load), so the exit code alone is not a reliable signal; default error mode
+# logs every error at level=error, which this catches. $(1)=label, rest=command.
+define smoke_run
+	echo "== $(1) =="; \
+	out=$$($(2) 2>&1); code=$$?; printf '%s\n' "$$out"; \
+	if [ $$code -ne 0 ] || printf '%s' "$$out" | grep -q 'level=error'; then \
+		echo "FAIL ($(1)): exit=$$code"; rc=1; \
+	fi
+endef
+
+# Scenario-branch smoke on the noop driver (NO database). Every workload has
+# two executor archetypes behind declareScenario — constant-vus (DURATION set,
+# throughput) and shared-iterations (power test) — which are distinct k6 option
+# JSON paths that only fail at init. The noop driver runs the full lifecycle
+# without a DB, so this catches executor/options regressions for ~free. The
+# VUS=2/ITER=1 case also guards the shared-iterations "iterations < VUs" floor.
+# Third field skips each workload's data-validation step (noop has no data to
+# check, so those steps would flood the log); "-" means nothing to skip.
+run-scenario-smoke:
+	@rc=0;                                                                          \
+	for spec in "tpcb/tx 1 -" "tpcc/tx 1 validate_population" "tpcds 0.01 -" "tpch/tx 0.01 validate_answers"; do \
+		set -- $$spec; wl=$$1; sf=$$2; skip=$$3; ns=""; [ "$$skip" = "-" ] || ns="--no-steps $$skip"; \
+		$(call smoke_run,noop constant-vus: $$wl,./build/stroppy run $$wl -d noop -e SCALE_FACTOR=$$sf -e DURATION=2s -e VUS=2 $$ns); \
+		$(call smoke_run,noop shared-iters: $$wl,./build/stroppy run $$wl -d noop -e SCALE_FACTOR=$$sf -e VUS=2 -e ITER=1 $$ns); \
+	done;                                                                           \
+	exit $$rc
+
+# Real-Postgres smoke of BOTH scenario branches for the light workloads at tiny
+# scale (default pg preset = localhost:5432). Complements run-scenario-smoke by
+# exercising the actual DB path (load + run) in throughput and power modes.
+# tpch's validate_answers golden set is SF=1 only, so it is skipped at smoke
+# scale (answer correctness is a heavier, separate concern); validate_population
+# stays on for tpcc since it passes at SF=1.
+# tpcds is intentionally NOT here: its fixed-cardinality dimensions (e.g.
+# customer_demographics ~1.92M rows) do not shrink with SF, so even SF=0.01 is a
+# multi-million-row load+index — too heavy for a free CI runner's Postgres. Its
+# scenario branches are covered DB-free by run-scenario-smoke (noop) instead.
+run-workload-branches:
+	@rc=0;                                                                          \
+	for spec in "tpcb/tx 1 -" "tpcc/tx 1 -" "tpch/tx 0.01 validate_answers"; do \
+		set -- $$spec; wl=$$1; sf=$$2; skip=$$3; ns=""; [ "$$skip" = "-" ] || ns="--no-steps $$skip"; \
+		$(call smoke_run,pg constant-vus: $$wl,./build/stroppy run $$wl -e SCALE_FACTOR=$$sf -e DURATION=2s -e VUS=2 $$ns -- -q); \
+		$(call smoke_run,pg shared-iters: $$wl,./build/stroppy run $$wl -e SCALE_FACTOR=$$sf -e VUS=2 -e ITER=1 $$ns -- -q); \
+	done;                                                                           \
 	exit $$rc
 
 ##

--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ revision: # Recreate git tag with version tag=<semver>
 
 WORKDIR=dev
 
-run-simple-test:
+run-simple-test: # Smoke: run the simple preset
 	rm -rf $(WORKDIR)
 	./build/stroppy gen --workdir $(WORKDIR) --preset=simple
 	cd $(WORKDIR) && ./stroppy run simple.ts
@@ -355,19 +355,19 @@ run-simple-test:
 #   knobs: VUS, DURATION (set => constant-vus throughput), ITER (power test),
 #          MAX_DURATION (default 24h), PG_UNLOGGED=false to disable the pg
 #          UNLOGGED bulk-load dance. The targets below are single-pass smoke runs.
-run-tpcb-test:
+run-tpcb-test: # Smoke: TPC-B procs workload (single pass)
 	LOG_LEVEL=DEBUG STROPPY_ERROR_MODE=throw \
 		./build/stroppy run tpcb/procs.ts
 
-run-tpcc-test:
+run-tpcc-test: # Smoke: TPC-C procs workload (single pass)
 	LOG_LEVEL=DEBUG STROPPY_ERROR_MODE=throw \
 		./build/stroppy run tpcc/procs.ts
 
-run-tpcc-mysql-test:
+run-tpcc-mysql-test: # Smoke: TPC-C procs workload on MySQL
 	LOG_LEVEL=DEBUG STROPPY_ERROR_MODE=throw \
 		./build/stroppy run tpcc/procs.ts -d mysql -- -q
 
-run-tpcds-test:
+run-tpcds-test: # Smoke: TPC-DS workload at SF=0.01
 	LOG_LEVEL=DEBUG STROPPY_ERROR_MODE=throw \
 		./build/stroppy run tpcds/tpcds -e SCALE_FACTOR=0.01
 
@@ -400,7 +400,7 @@ endef
 # VUS=2/ITER=1 case also guards the shared-iterations "iterations < VUs" floor.
 # Third field skips each workload's data-validation step (noop has no data to
 # check, so those steps would flood the log); "-" means nothing to skip.
-run-scenario-smoke:
+run-scenario-smoke: # Tier 0: scenario-branch smoke on noop (no DB), all workloads x both branches
 	@rc=0;                                                                          \
 	for spec in "tpcb/tx 1 -" "tpcc/tx 1 validate_population" "tpcds 0.01 -" "tpch/tx 0.01 validate_answers"; do \
 		set -- $$spec; wl=$$1; sf=$$2; skip=$$3; ns=""; [ "$$skip" = "-" ] || ns="--no-steps $$skip"; \
@@ -419,7 +419,7 @@ run-scenario-smoke:
 # customer_demographics ~1.92M rows) do not shrink with SF, so even SF=0.01 is a
 # multi-million-row load+index — too heavy for a free CI runner's Postgres. Its
 # scenario branches are covered DB-free by run-scenario-smoke (noop) instead.
-run-workload-branches:
+run-workload-branches: # Tier 1: real-Postgres smoke of both branches (tpcb/tpcc/tpch)
 	@rc=0;                                                                          \
 	for spec in "tpcb/tx 1 -" "tpcc/tx 1 -" "tpch/tx 0.01 validate_answers"; do \
 		set -- $$spec; wl=$$1; sf=$$2; skip=$$3; ns=""; [ "$$skip" = "-" ] || ns="--no-steps $$skip"; \

--- a/internal/static/helpers.ts
+++ b/internal/static/helpers.ts
@@ -608,14 +608,17 @@ export function declareScenario(
     defaults.iterations ?? 1,
     "Power-test iteration count (shared-iterations) used when DURATION is unset",
   ) as number;
+  // maxDuration only valid on iteration-based executors, where it lifts k6's
+  // 10m default cap. constant-vus has no such cap (bounded by duration) and
+  // k6 rejects the field with `json: unknown field "maxDuration"`.
   const maxDuration = ENV(
     "MAX_DURATION",
     "24h",
-    "Max wall-clock per scenario; lifts k6's 10m iteration cap for long loads",
+    "Max wall-clock for the iterations (power) run; lifts k6's 10m iteration cap",
   );
 
   const scenario = duration
-    ? { executor: "constant-vus", vus, duration, maxDuration }
+    ? { executor: "constant-vus", vus, duration }
     : { executor: "shared-iterations", vus, iterations, maxDuration };
 
   return { [name]: scenario } as Options["scenarios"];

--- a/internal/static/helpers.ts
+++ b/internal/static/helpers.ts
@@ -603,11 +603,15 @@ export function declareScenario(
     defaults.duration ?? "",
     "Throughput run length (Go duration, e.g. 1h); when set selects constant-vus, result is TPS",
   );
-  const iterations = ENV(
+  const iterationsEnv = ENV(
     "ITER",
     defaults.iterations ?? 1,
     "Power-test iteration count (shared-iterations) used when DURATION is unset",
   ) as number;
+  // shared-iterations rejects iterations < vus at init ("the number of
+  // iterations can't be less than the number of VUs"). Clamp to vus so a
+  // power test run with VUS>1 (and default ITER) starts instead of crashing.
+  const iterations = Math.max(iterationsEnv, vus);
   // maxDuration only valid on iteration-based executors, where it lifts k6's
   // 10m default cap. constant-vus has no such cap (bounded by duration) and
   // k6 rejects the field with `json: unknown field "maxDuration"`.

--- a/workloads/tpcds/tpcds.ts
+++ b/workloads/tpcds/tpcds.ts
@@ -157,11 +157,14 @@ function resolveQueries(): Array<{ name: string }> {
 // prepareDatabase creates the schema, then generates and bulk-loads every table
 // with the ported dsdgen generator. Runs once per process via GlobalOnce.
 function prepareDatabase(): void {
-  // Drop in reverse load order (fact tables before their dimensions); tpcds has
-  // no FK constraints so IF EXISTS is enough, but reverse order is tidy.
+  // Drop in reverse load order (fact tables before their dimensions). CASCADE is
+  // required for idempotent re-runs: a prior run leaves dependents (e.g. views or
+  // any cross-table object) that make a plain DROP fail with SQLSTATE 2BP01
+  // "cannot drop table ... because other objects depend on it". MySQL accepts and
+  // ignores the CASCADE keyword, so the same statement is portable.
   Step("drop_schema", () => {
     for (const table of [...TPCDS_TABLES].reverse()) {
-      driver.exec(`DROP TABLE IF EXISTS ${table}` as unknown as { name: string }, {});
+      driver.exec(`DROP TABLE IF EXISTS ${table} CASCADE` as unknown as { name: string }, {});
     }
   });
 


### PR DESCRIPTION
## What

Fixes three scenario bugs in `declareScenario`/tpcds and closes the CI gaps that let them ship.

### Bug fixes
- **`maxDuration` on constant-vus** (`a0301c8`) — k6 strict-parses scenario options; `constant-vus` has no `maxDuration` field, so any `DURATION`-set (throughput) run died at k6 init with `json: unknown field "maxDuration"`. Now only the iterations-based branch carries it.
- **shared-iterations `iterations < vus`** (`5b21063`) — a power-test run with `VUS>1` and default `ITER` crashed at init (`the number of iterations can't be less than the number of VUs`). Clamp `iterations = max(ITER, VUS)`.
- **tpcds `drop_schema` not idempotent** (`3233d7a`) — re-running tpcds failed with `SQLSTATE 2BP01 cannot drop table item because other objects depend on it`. Added `CASCADE` (matches tpcb/tpch; MySQL accepts+ignores it).

### Why CI missed them
The integration job only ran **tpcb at default scale** (shared-iterations, VUS=1) — never the constant-vus branch, never VUS>1. The two scenario archetypes (`DURATION` set vs unset) are distinct k6 option-JSON paths; only one was ever exercised. (`stroppy probe` can't help — it doesn't thread env into `__ENV`, so it always reports shared-iterations.)

### CI changes (`7649fdf`)
- **Tier 0 — `make run-scenario-smoke`**: `noop` driver, **no database**. Every workload × both branches. Catches options/executor regressions for ~free.
- **Tier 1 — `make run-workload-branches`**: real Postgres, both branches, light workloads (tpcb/tpcc/tpch). **tpcds excluded** — its fixed-cardinality dims (`customer_demographics` ~1.92M) don't shrink with SF, so even SF=0.01 is too heavy for a free runner; it stays covered DB-free in Tier 0.
- **Gate**: fail on non-zero exit **or** any `level=error` line — k6/stroppy exit 0 even when every iteration errors.
- **Pipeline reshape**: `integration.yml` builds stroppy **once**, runs Tier 0 → Tier 1, uploads the artifact; `ci.yml`'s `build` job becomes a `publish` job **gated behind integration** (no second build, no test→build→test).
- `chore` (`b2528fa`): inline `make help` comments so the `run-*` targets are discoverable.

## Test
- Tier 0 (noop, local): all 4 workloads × both branches green, gate clean.
- Tier 1 (real Postgres): tpcb ✓✓, tpcc ✓✓, tpch ✓✓ (constant-vus + shared-iterations each).
