### PR TITLE
feat(steps): per-step timing, per-statement DDL logs, silent workload step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Newest on top. Everything under `## [Unreleased]` is not yet released.
 Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 `([#NN](https://github.com/stroppy-io/stroppy/pull/NN))` when the change had one.
 
+## [Unreleased]
+
+### Added
+
+- Each completed step now reports how long it took, e.g. `End of 'create_schema' step (took 1.23s)`. ([#83](https://github.com/stroppy-io/stroppy/pull/83))
+- The `create_indexes` and `set_logged` steps now log one progress line per statement, with elapsed time, so you can see which index or table flip is slow instead of waiting on one opaque step boundary. ([#83](https://github.com/stroppy-io/stroppy/pull/83))
+
+### Changed
+
+- The per-iteration `workload` step no longer prints a `Start/End of 'workload' step` line on every transaction — that pair was flooding the log. The step still runs and reports its status as before; it is just silent on the console. ([#83](https://github.com/stroppy-io/stroppy/pull/83))
+
 ## [5.5.2] - 2026-06-30
 
 ### Fixed

--- a/internal/static/helpers.ts
+++ b/internal/static/helpers.ts
@@ -824,38 +824,93 @@ function isStepEnabled(name: string): boolean {
   return true;
 }
 
+export interface StepOpts {
+  /** Suppress the per-invocation "Start/End of step" console lines. Use for
+   *  steps run once per iteration (e.g. "workload") that would otherwise spam
+   *  the log. The step's status notification to the host still fires. */
+  silent?: boolean;
+}
+
+// Wall-clock start of each running step, keyed by name, so end() can report
+// how long the step took. Cleared on end so it never leaks across iterations.
+const _stepStart = new Map<string, number>();
+
+/** Format a millisecond duration compactly: "850ms", "12.34s", "3m04s". */
+export function fmtDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(2)}s`;
+  const m = Math.floor(ms / 60000);
+  const s = Math.floor((ms % 60000) / 1000);
+  return `${m}m${s.toString().padStart(2, "0")}s`;
+}
+
 export const Step = Object.assign(
-  (name: string, step: () => void): void => {
+  (name: string, step: () => void, opts?: StepOpts): void => {
     if (!isStepEnabled(name)) {
       console.log(`Skipping step '${name}'`);
       return;
     }
-    Step.begin(name);
+    Step.begin(name, opts);
     let completed = false;
     try {
       step();
       completed = true;
     } finally {
       if (completed) {
-        Step.end(name);
+        Step.end(name, opts);
       } else {
         ClearStepTag(name);
       }
     }
   },
   {
-    begin: (name: string): void => {
+    begin: (name: string, opts?: StepOpts): void => {
       SetStepTag(name);
       NotifyStep(name, StroppyRun_Status.STATUS_RUNNING);
-      console.log(`Start of '${name}' step`);
+      if (!opts?.silent) {
+        _stepStart.set(name, Date.now());
+        console.log(`Start of '${name}' step`);
+      }
     },
-    end: (name: string): void => {
-      console.log(`End of '${name}' step`);
+    end: (name: string, opts?: StepOpts): void => {
+      if (!opts?.silent) {
+        const t0 = _stepStart.get(name);
+        _stepStart.delete(name);
+        const took = t0 !== undefined ? ` (took ${fmtDuration(Date.now() - t0)})` : "";
+        console.log(`End of '${name}' step${took}`);
+      }
       NotifyStep(name, StroppyRun_Status.STATUS_COMPLETED);
       ClearStepTag(name);
     },
   }
 );
+
+/** Run each item of a list, logging when every statement starts and ends with
+ *  its elapsed time. For slow DDL phases (create_indexes, set_logged) where one
+ *  progress line per statement beats a single opaque step boundary. Items are
+ *  usually parsed SQL queries (labelled by their name or SQL text) but may be
+ *  anything when an explicit `label` is supplied (e.g. per-table ALTERs). */
+export function execEachLogged<T>(
+  items: ReadonlyArray<T> | undefined,
+  exec: (item: T) => void,
+  label?: (item: T) => string,
+): void {
+  const list = items ?? [];
+  list.forEach((item, i) => {
+    const text = label ? label(item) : defaultLabel(item);
+    const tag = `[${i + 1}/${list.length}]`;
+    console.log(`  ${tag} start: ${text}`);
+    const t0 = Date.now();
+    exec(item);
+    console.log(`  ${tag} done (${fmtDuration(Date.now() - t0)}): ${text}`);
+  });
+}
+
+function defaultLabel(item: unknown): string {
+  const q = item as Partial<ParsedQuery>;
+  const raw = q?.name || (typeof q?.sql === "string" ? q.sql : String(item));
+  return raw.replace(/\s+/g, " ").trim().slice(0, 80);
+}
 
 
 /** Wrap a function so it executes only once per VU.

--- a/internal/static/helpers.ts
+++ b/internal/static/helpers.ts
@@ -897,7 +897,7 @@ export function execEachLogged<T>(
 ): void {
   const list = items ?? [];
   list.forEach((item, i) => {
-    const text = label ? label(item) : defaultLabel(item);
+    const text = label ? label(item) : stmtLabel(item);
     const tag = `[${i + 1}/${list.length}]`;
     console.log(`  ${tag} start: ${text}`);
     const t0 = Date.now();
@@ -906,7 +906,7 @@ export function execEachLogged<T>(
   });
 }
 
-function defaultLabel(item: unknown): string {
+function stmtLabel(item: unknown): string {
   const q = item as Partial<ParsedQuery>;
   const raw = q?.name || (typeof q?.sql === "string" ? q.sql : String(item));
   return raw.replace(/\s+/g, " ").trim().slice(0, 80);

--- a/workloads/tpcb/procs.ts
+++ b/workloads/tpcb/procs.ts
@@ -41,5 +41,5 @@ export default function (): void {
       p_delta: deltaGen.next(),
       p_hid: nextHid(),
     });
-  });
+  }, { silent: true });
 }

--- a/workloads/tpcb/tpcb_common.ts
+++ b/workloads/tpcb/tpcb_common.ts
@@ -7,6 +7,7 @@ import { Teardown } from "k6/x/stroppy";
 import {
   DriverX,
   Step,
+  execEachLogged,
   ENV,
   GlobalOnce,
   TxIsolationName,
@@ -186,9 +187,9 @@ function prepareDatabase(procedures: boolean): void {
     driver.insertSpec(tellersSpec());
     driver.insertSpec(accountsSpec());
   });
-  Step("create_indexes", () => runSection("create_indexes"));
+  Step("create_indexes", () => execEachLogged(sql("create_indexes"), (q) => driver.exec(q, {})));
   if (useUnlogged) {
-    Step("set_logged", () => runSection("set_logged"));
+    Step("set_logged", () => execEachLogged(sql("set_logged"), (q) => driver.exec(q, {})));
   }
   // pgbench --foreign-keys semantics: FK constraints added post-load, once the
   // referenced rows exist, and backed by the bid indexes built above. Added AFTER

--- a/workloads/tpcb/tx.ts
+++ b/workloads/tpcb/tx.ts
@@ -49,5 +49,5 @@ export default function (): void {
       tx.exec(sql("workload_tx_tpcb", "update_branch")!, { bid, delta });
       tx.exec(sql("workload_tx_tpcb", "insert_history")!, { hid, tid, bid, aid, delta });
     });
-  });
+  }, { silent: true });
 }

--- a/workloads/tpcc/procs.ts
+++ b/workloads/tpcc/procs.ts
@@ -1,5 +1,5 @@
 import { Teardown, NewPicker } from "k6/x/stroppy";
-import { Step, DriverX, ENV, GlobalOnce, TxIsolationName, declareDriverSetup, retry, isSerializationError } from "./helpers.ts";
+import { Step, execEachLogged, DriverX, ENV, GlobalOnce, TxIsolationName, declareDriverSetup, retry, isSerializationError } from "./helpers.ts";
 import { DrawRT } from "./datagen.ts";
 import { C_LAST_DICT } from "./tpcc_helpers.ts";
 import { parse_sql_with_sections } from "./parse_sql.js";
@@ -117,9 +117,9 @@ function prepareDatabase(): void {
   Step("load_data", () => loadData(driver));
   // Secondary indexes built post-load (spec-permitted; serve the C_LAST by-name
   // and customer's-latest-order access paths). Cheaper one-shot than per-row.
-  Step("create_indexes", () => runSection("create_indexes"));
+  Step("create_indexes", () => execEachLogged(sql("create_indexes"), (q) => driver.exec(q, {})));
   if (useUnlogged) {
-    Step("set_logged", () => runSection("set_logged"));
+    Step("set_logged", () => execEachLogged(sql("set_logged"), (q) => driver.exec(q, {})));
   }
   // FK constraints post-load, AFTER set_logged (pg checks FK persistence both
   // directions, so they can't exist during the UNLOGGED load/flips). No-op on
@@ -337,7 +337,7 @@ export default function (): void {
       [45,        43,      4,            4,        4],
     ) as () => void;
     workload();
-  });
+  }, { silent: true });
 }
 
 export function teardown() {

--- a/workloads/tpcc/tx.ts
+++ b/workloads/tpcc/tx.ts
@@ -1,6 +1,6 @@
 import { sleep } from "k6";
 import { Teardown, NewPicker } from "k6/x/stroppy";
-import { Counter, Step, DriverX, ENV, GlobalOnce, TxIsolationName, declareDriverSetup, retryWithPolicy, txRetryPolicy } from "./helpers.ts";
+import { Counter, Step, execEachLogged, DriverX, ENV, GlobalOnce, TxIsolationName, declareDriverSetup, retryWithPolicy, txRetryPolicy } from "./helpers.ts";
 import { Alphabet, DrawRT } from "./datagen.ts";
 import { C_LAST_DICT } from "./tpcc_helpers.ts";
 import { parse_sql_with_sections } from "./parse_sql.js";
@@ -229,14 +229,10 @@ function prepareDatabase() {
   // Secondary indexes built post-load (spec-permitted; serve the C_LAST by-name
   // and customer's-latest-order access paths) on pg/mysql/ydb. A one-shot build
   // is cheaper than per-row maintenance, and cheaper still while UNLOGGED.
-  Step("create_indexes", () => {
-    (sql("create_indexes") ?? []).forEach((query) => driver.exec(query, {}));
-  });
+  Step("create_indexes", () => execEachLogged(sql("create_indexes"), (q) => driver.exec(q, {})));
 
   if (useUnlogged) {
-    Step("set_logged", () => {
-      (sql("set_logged") ?? []).forEach((query) => driver.exec(query, {}));
-    });
+    Step("set_logged", () => execEachLogged(sql("set_logged"), (q) => driver.exec(q, {})));
   }
 
   // FK constraints added post-load, AFTER set_logged, on logged tables. PG checks
@@ -923,7 +919,7 @@ export default function (): void {
     keyingTime(txName);
     workload();
     thinkTime(txName);
-  });
+  }, { silent: true });
 }
 
 export function teardown() {

--- a/workloads/tpcds/tpcds.ts
+++ b/workloads/tpcds/tpcds.ts
@@ -1,7 +1,7 @@
 import { Options } from "k6/options";
 import exec from "k6/execution";
 import { Teardown, GenerateTpcdsQueries } from "k6/x/stroppy";
-import { DriverX, Step, ENV, GlobalOnce, declareDriverSetup, declareScenario } from "./helpers.ts";
+import { DriverX, Step, execEachLogged, ENV, GlobalOnce, declareDriverSetup, declareScenario } from "./helpers.ts";
 import { parse_sql, parse_sql_with_sections } from "./parse_sql.js";
 import type { SqlQuery } from "./helpers.ts";
 import {
@@ -179,11 +179,11 @@ function prepareDatabase(): void {
   // restores durability after. Driven from the TPCDS_TABLES list (like ANALYZE
   // below) rather than per-table SQL, since the schema lives in schema.*.sql.
   if (useUnlogged) {
-    Step("set_unlogged", () => {
-      for (const table of TPCDS_TABLES) {
-        driver.exec(`ALTER TABLE ${table} SET UNLOGGED` as unknown as { name: string }, {});
-      }
-    });
+    Step("set_unlogged", () => execEachLogged(
+      TPCDS_TABLES,
+      (table) => driver.exec(`ALTER TABLE ${table} SET UNLOGGED` as unknown as { name: string }, {}),
+      (table) => `SET UNLOGGED ${table}`,
+    ));
   }
 
   Step("load_data", () => {
@@ -197,19 +197,14 @@ function prepareDatabase(): void {
   // maintaining them per-insert, and cheaper still while tables are UNLOGGED).
   // Without them the unindexed multi-way joins are unrunnable at scale,
   // especially on MySQL's nested-loop joins.
-  Step("create_indexes", () => {
-    const stmts = schema("create_indexes");
-    if (stmts) {
-      stmts.forEach((q) => driver.exec(q, {}));
-    }
-  });
+  Step("create_indexes", () => execEachLogged(schema("create_indexes"), (q) => driver.exec(q, {})));
 
   if (useUnlogged) {
-    Step("set_logged", () => {
-      for (const table of TPCDS_TABLES) {
-        driver.exec(`ALTER TABLE ${table} SET LOGGED` as unknown as { name: string }, {});
-      }
-    });
+    Step("set_logged", () => execEachLogged(
+      TPCDS_TABLES,
+      (table) => driver.exec(`ALTER TABLE ${table} SET LOGGED` as unknown as { name: string }, {}),
+      (table) => `SET LOGGED ${table}`,
+    ));
   }
 
   // Bulk load leaves the planner with no statistics; without ANALYZE pg/mysql
@@ -241,7 +236,7 @@ export default function (): void {
       resolveQueries().forEach((query) => {
         driver.exec(query, {});
       });
-    });
+    }, { silent: true });
   }
 
   const named = (): NamedQuery[] =>

--- a/workloads/tpch/tx.ts
+++ b/workloads/tpch/tx.ts
@@ -1,6 +1,6 @@
 import { Options } from "k6/options";
 import { Teardown } from "k6/x/stroppy";
-import { Counter, DriverX, Step, ENV, GlobalOnce, Trend, TxIsolationName, declareDriverSetup, declareScenario } from "./helpers.ts";
+import { Counter, DriverX, Step, execEachLogged, ENV, GlobalOnce, Trend, TxIsolationName, declareDriverSetup, declareScenario } from "./helpers.ts";
 import {
   Alphabet,
   Attr,
@@ -824,15 +824,11 @@ function prepareDatabase(): void {
 
   // Build indexes after the bulk load (and while still UNLOGGED on pg — a
   // one-shot build is far cheaper than per-row maintenance).
-  Step("create_indexes", () => {
-    runSection("create_indexes");
-  });
+  Step("create_indexes", () => execEachLogged(sql("create_indexes"), (q) => driver.exec(q, {})));
 
   // pg-only: restore durability after the UNLOGGED bulk load.
   if (useUnlogged) {
-    Step("set_logged", () => {
-      runSection("set_logged");
-    });
+    Step("set_logged", () => execEachLogged(sql("set_logged"), (q) => driver.exec(q, {})));
   }
 
   // Refresh planner statistics post-load so Q20/Q21 pick sane plans instead of
@@ -873,7 +869,7 @@ export default function (): void {
 
   Step("workload", () => {
     runTpchQueries();
-  });
+  }, { silent: true });
 }
 
 export function teardown(): void {


### PR DESCRIPTION
## What

Three logging improvements to the workload step machinery (`internal/static/helpers.ts`, the embedded TS framework), plus call-site wiring across all workloads.

1. **Step duration.** `Step.end` now reports elapsed wall-clock: `End of 'create_schema' step (took 1.23s)`. New `fmtDuration()` (`850ms` / `12.34s` / `3m04s`).
2. **Per-statement DDL logs.** `create_indexes` and `set_logged` (and tpcds `set_unlogged` / per-table `SET LOGGED`) now log one line per statement with start + done+elapsed, via a new generic `execEachLogged(items, exec, label?)`:
   ```
     [1/3] start: CREATE INDEX idx_customer_name ON customer (...)
     [1/3] done (4.52s): CREATE INDEX idx_customer_name ON customer (...)
   ```
3. **Silent steps.** New `Step(name, fn, { silent: true })` option suppresses the `Start/End of step` console lines (status notify to host unchanged). Applied to the per-iteration `workload` step in tpcc / tpch / tpcds / tpcb — kills the `Start of 'workload' step` / `End of 'workload' step` flood.

`simple.ts` left non-silent on purpose: its `Step.begin/end("workload")` brackets the whole run, so it now prints one total-duration line.

## Verify

- `make ts-typecheck` (`tsc --noEmit` on `internal/static`) clean.
- All edited workloads bundle through esbuild with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)