### PR TITLE
fix(tpcc): abort test on validate_population failure so exit code is non-zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 - The per-iteration `workload` step no longer prints a `Start/End of 'workload' step` line on every transaction — that pair was flooding the log. The step still runs and reports its status as before; it is just silent on the console. ([#83](https://github.com/stroppy-io/stroppy/pull/83))
 
+### Fixed
+
+- A failed TPC-C `validate_population` check now makes the run exit non-zero instead of reporting success. The check detected a bad population and logged every failed assertion, but `stroppy run` still exited `0`, so CI and matrix runs that gate on the exit code saw a false pass. The run now aborts with a dedicated exit code (108) on any population mismatch; a skipped check (`--no-steps validate_population`) still exits `0`. ([#92](https://github.com/stroppy-io/stroppy/pull/92))
+
 ## [5.5.2] - 2026-06-30
 
 ### Fixed

--- a/workloads/tpcc/tpcc_common.ts
+++ b/workloads/tpcc/tpcc_common.ts
@@ -19,6 +19,7 @@ import {
 } from "./datagen.ts";
 import { C_LAST_DICT, tpccOriginalOr } from "./tpcc_helpers.ts";
 import type { Options } from "k6/options";
+import exec from "k6/execution";
 
 declare const __VU: number;
 
@@ -492,7 +493,7 @@ export function validatePopulation(driver: DriverX): void {
     cc4OSum  = Number(driver.queryValue(`SELECT SUM(o_ol_cnt) FROM orders ${wWhere("o_w_id")}`));
     cc4OlCnt = Number(driver.queryValue(`SELECT COUNT(*) FROM order_line ${wWhere("ol_w_id")}`));
   } catch (e) {
-    throw new Error(`validate_population: prefetch failed: ${e}`);
+    exec.test.abort(`validate_population: prefetch failed: ${e}`);
   }
 
   const evalCc2a = (): { ok: boolean; detail: string } => {
@@ -631,7 +632,7 @@ export function validatePopulation(driver: DriverX): void {
     }
   }
   if (failures.length > 0) {
-    throw new Error(
+    exec.test.abort(
       `validate_population: ${failures.length} check(s) failed:\n${failures.join("\n")}`,
     );
   }


### PR DESCRIPTION
## Problem

`stroppy run` exits **0** even when `validate_population` detects a bad population — a silent false-pass for any caller that gates on the exit code (CI, the #89 workload × target matrix). Fixes #91.

Root cause: `validatePopulation()` threw a plain `Error`. It runs inside `GlobalOnce("tpcc.prepare")` → `prepare()` → `default()` — i.e. **inside a k6 iteration**, not `setup()`. k6 turns an iteration exception into a failed iteration, not a non-zero process exit (no threshold crosses, no `test.abort()`). stroppy mirrors k6's exit code, so it returned 0. `STROPPY_ERROR_MODE` is orthogonal (driver-query knob, not JS throws).

## Fix

Replace both throws in `validatePopulation` with `exec.test.abort(...)` → k6 exit **108**. Applies to both `tpcc/tx` and `tpcc/procs` (shared function). 3 lines + one import.

## Verified on postgres:17

| case | before | after |
|---|---|---|
| `tpcc/tx --steps validate_population`, mismatch (sf2 vs sf1 data) | rc **0** (bug) | rc **108** |
| `tpcc/procs`, same mismatch | — | rc **108** |
| validate against matching data (sf1 vs sf1) | — | rc **0** (no false abort) |
| `--no-steps validate_population` (step skipped) | — | rc **0** |

Abort log: `test aborted: validate_population: 7 check(s) failed: …`

## Audit (per #91)

Only `validatePopulation` was affected:
- **tpch / tpcds `validate_answers`** — best-effort log-only *by design* ("deltas are logged, not thrown"); not the swallow bug. They cannot gate CI at all — a separate design question, left untouched.
- **`procs.ts` driverType guard** — throws at module init → already fails non-zero.
- **tx.ts transaction-body throws** — measured-iteration / rollback signals, not validation.
