### PR TITLE
feat(probe): expose per-driver supported insert methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
-- `stroppy probe` (no arguments) now also lists which insert methods each driver supports — `plain_query`, `plain_bulk`, `columnar`, `native` per database — as a `DRIVERS` block in the human output and a `drivers` key in `-o json`, so external tooling can discover valid `defaultInsertMethod` values per target without reading stroppy source.
+- `stroppy probe` (no arguments) now also lists which insert methods each driver supports — `plain_query`, `plain_bulk`, `columnar`, `native` per database — as a `DRIVERS` block in the human output and a `drivers` key in `-o json`, so external tooling can discover valid `defaultInsertMethod` values per target without reading stroppy source. ([#96](https://github.com/stroppy-io/stroppy/pull/96))
 
 ## [5.6.0] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ## [Unreleased]
 
+### Added
+
+- `stroppy probe` (no arguments) now also lists which insert methods each driver supports — `plain_query`, `plain_bulk`, `columnar`, `native` per database — as a `DRIVERS` block in the human output and a `drivers` key in `-o json`, so external tooling can discover valid `defaultInsertMethod` values per target without reading stroppy source.
+
 ## [5.6.0] - 2026-07-01
 
 ### Added

--- a/cmd/stroppy/commands/help/topic_probe.go
+++ b/cmd/stroppy/commands/help/topic_probe.go
@@ -20,7 +20,8 @@ func init() {
 CATALOG (no script argument)
 
   Run probe with no script to list the embedded presets and which of their
-  scripts are runnable, plus the SQL dialects/variants each ships with:
+  scripts are runnable, plus the SQL dialects/variants each ships with, and
+  the insert methods each driver supports ("drivers" key in JSON):
 
     stroppy probe            # human-readable catalog
     stroppy probe -o json    # machine-readable catalog

--- a/cmd/stroppy/commands/probe/probe.go
+++ b/cmd/stroppy/commands/probe/probe.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
+	"github.com/stroppy-io/stroppy/pkg/driver"
 	"github.com/stroppy-io/stroppy/pkg/probe"
 	"github.com/stroppy-io/stroppy/workloads"
 )
@@ -47,8 +48,9 @@ var (
 without executing the actual benchmark. Shows configuration, k6 options,
 SQL structure, steps, environment variables, and driver setup.
 
-With no script argument, probe lists the embedded presets and which of
-their scripts are runnable (-o json for machine output).
+With no script argument, probe lists the embedded presets, which of
+their scripts are runnable, and the insert methods each driver
+supports (-o json for machine output).
 
 Use section flags (--config, --options, --sql, --steps, --envs, --drivers)
 to filter output. See 'stroppy help probe' for section descriptions.
@@ -189,30 +191,64 @@ func buildSections(cmd *cobra.Command) runner.ExplainSection {
 	return sections
 }
 
-// printCatalog renders the embedded preset catalog in the requested format.
+// printCatalog renders the embedded preset catalog and the driver
+// insert-method matrix in the requested format.
 func printCatalog(format string) error {
 	catalog, err := workloads.Catalog()
 	if err != nil {
 		return fmt.Errorf("failed to build workloads catalog: %w", err)
 	}
 
+	drivers := driverCatalog()
+
 	switch format {
 	case jsonFormat:
-		bytes, err := json.Marshal(map[string]any{"presets": catalog})
+		bytes, err := json.Marshal(map[string]any{"presets": catalog, "drivers": drivers})
 		if err != nil {
 			return fmt.Errorf("can't marshal catalog: %w", err)
 		}
 
 		fmt.Fprintf(os.Stdout, "%s\n", string(bytes))
 	case humanFormat:
-		fmt.Fprint(os.Stdout, formatCatalog(catalog))
+		fmt.Fprint(os.Stdout, formatCatalog(catalog, drivers))
 	}
 
 	return nil
 }
 
-// formatCatalog builds the human-readable preset listing.
-func formatCatalog(catalog []workloads.PresetInfo) string {
+// driverEntry is one row of the driver capability matrix in catalog output.
+type driverEntry struct {
+	Type          string   `json:"type"`
+	InsertMethods []string `json:"insert_methods"`
+}
+
+// driverCatalog converts the static driver→insert-method matrix to
+// lowercase names ("postgres", "plain_bulk") for catalog output.
+func driverCatalog() []driverEntry {
+	capabilities := driver.InsertCapabilities()
+
+	entries := make([]driverEntry, 0, len(capabilities))
+
+	for _, capability := range capabilities {
+		methods := make([]string, 0, len(capability.InsertMethods))
+		for _, method := range capability.InsertMethods {
+			methods = append(methods, strings.ToLower(method.String()))
+		}
+
+		entries = append(entries, driverEntry{
+			Type: strings.ToLower(
+				strings.TrimPrefix(capability.Type.String(), "DRIVER_TYPE_"),
+			),
+			InsertMethods: methods,
+		})
+	}
+
+	return entries
+}
+
+// formatCatalog builds the human-readable preset listing and driver
+// insert-method matrix.
+func formatCatalog(catalog []workloads.PresetInfo, drivers []driverEntry) string {
 	var builder strings.Builder
 
 	builder.WriteString("\nPRESETS (embedded workloads)\n\n")
@@ -247,7 +283,19 @@ func formatCatalog(catalog []workloads.PresetInfo) string {
 		builder.WriteString("\n")
 	}
 
-	builder.WriteString("Probe any script for details:  stroppy probe <preset>/<script>\n")
+	builder.WriteString("DRIVERS (supported insert methods)\n\n")
+
+	typeWidth := 0
+	for _, entry := range drivers {
+		typeWidth = max(typeWidth, len(entry.Type))
+	}
+
+	for _, entry := range drivers {
+		fmt.Fprintf(&builder, "  %-*s  %s\n",
+			typeWidth, entry.Type, strings.Join(entry.InsertMethods, ", "))
+	}
+
+	builder.WriteString("\nProbe any script for details:  stroppy probe <preset>/<script>\n")
 
 	return builder.String()
 }

--- a/pkg/driver/insert_methods.go
+++ b/pkg/driver/insert_methods.go
@@ -1,0 +1,78 @@
+package driver
+
+import (
+	"slices"
+
+	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	"github.com/stroppy-io/stroppy/pkg/datagen/dgproto"
+)
+
+// InsertCapability pairs a driver type with the InsertSpec methods its
+// implementation serves.
+type InsertCapability struct {
+	Type          stroppy.DriverConfig_DriverType
+	InsertMethods []dgproto.InsertMethod
+}
+
+// insertMethodsByDriver is the static driver→insert-method matrix. It is
+// declared here rather than registered from the driver packages because the
+// stroppy CLI links only this package — probe must answer offline without
+// pulling driver implementations (and their database clients) into the
+// binary. Keep each row in sync with the method switch in
+// pkg/driver/<type>/insert_spec.go.
+//
+//nolint:exhaustive // DRIVER_TYPE_UNSPECIFIED deliberately has no capability row.
+var insertMethodsByDriver = map[stroppy.DriverConfig_DriverType][]dgproto.InsertMethod{
+	stroppy.DriverConfig_DRIVER_TYPE_POSTGRES: {
+		dgproto.InsertMethod_PLAIN_QUERY,
+		dgproto.InsertMethod_PLAIN_BULK,
+		dgproto.InsertMethod_COLUMNAR,
+		dgproto.InsertMethod_NATIVE,
+	},
+	stroppy.DriverConfig_DRIVER_TYPE_MYSQL: {
+		dgproto.InsertMethod_PLAIN_QUERY,
+		dgproto.InsertMethod_PLAIN_BULK,
+		dgproto.InsertMethod_NATIVE,
+	},
+	stroppy.DriverConfig_DRIVER_TYPE_PICODATA: {
+		dgproto.InsertMethod_PLAIN_QUERY,
+		dgproto.InsertMethod_PLAIN_BULK,
+		dgproto.InsertMethod_NATIVE,
+	},
+	stroppy.DriverConfig_DRIVER_TYPE_YDB: {
+		dgproto.InsertMethod_PLAIN_QUERY,
+		dgproto.InsertMethod_PLAIN_BULK,
+		dgproto.InsertMethod_NATIVE,
+	},
+	stroppy.DriverConfig_DRIVER_TYPE_NOOP: {
+		dgproto.InsertMethod_PLAIN_QUERY,
+		dgproto.InsertMethod_PLAIN_BULK,
+		dgproto.InsertMethod_COLUMNAR,
+		dgproto.InsertMethod_NATIVE,
+	},
+	stroppy.DriverConfig_DRIVER_TYPE_CSV: {
+		dgproto.InsertMethod_NATIVE,
+	},
+}
+
+// InsertCapabilities returns the driver→insert-method matrix ordered by
+// driver enum value. Method lists follow enum value order too, so output
+// is deterministic for machine consumers.
+func InsertCapabilities() []InsertCapability {
+	types := make([]stroppy.DriverConfig_DriverType, 0, len(insertMethodsByDriver))
+	for driverType := range insertMethodsByDriver {
+		types = append(types, driverType)
+	}
+
+	slices.Sort(types)
+
+	capabilities := make([]InsertCapability, 0, len(types))
+	for _, driverType := range types {
+		capabilities = append(capabilities, InsertCapability{
+			Type:          driverType,
+			InsertMethods: slices.Clone(insertMethodsByDriver[driverType]),
+		})
+	}
+
+	return capabilities
+}

--- a/pkg/driver/insert_methods_test.go
+++ b/pkg/driver/insert_methods_test.go
@@ -1,0 +1,73 @@
+package driver
+
+import (
+	"slices"
+	"testing"
+
+	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	"github.com/stroppy-io/stroppy/pkg/datagen/dgproto"
+)
+
+// TestInsertMethodsCoverAllDriverTypes guards the matrix against new driver
+// types landing in the proto enum without a capability row.
+func TestInsertMethodsCoverAllDriverTypes(t *testing.T) {
+	t.Parallel()
+
+	for value, name := range stroppy.DriverConfig_DriverType_name {
+		driverType := stroppy.DriverConfig_DriverType(value)
+		if driverType == stroppy.DriverConfig_DRIVER_TYPE_UNSPECIFIED {
+			continue
+		}
+
+		methods, ok := insertMethodsByDriver[driverType]
+		if !ok {
+			t.Errorf("driver type %s has no insert-method capability row", name)
+
+			continue
+		}
+
+		if len(methods) == 0 {
+			t.Errorf("driver type %s declares an empty insert-method list", name)
+		}
+	}
+}
+
+func TestInsertMethodsValidAndUnique(t *testing.T) {
+	t.Parallel()
+
+	for driverType, methods := range insertMethodsByDriver {
+		seen := map[dgproto.InsertMethod]bool{}
+
+		for _, method := range methods {
+			if _, ok := dgproto.InsertMethod_name[int32(method)]; !ok {
+				t.Errorf("%s: unknown insert method value %d", driverType, method)
+			}
+
+			if seen[method] {
+				t.Errorf("%s: duplicate insert method %s", driverType, method)
+			}
+
+			seen[method] = true
+		}
+	}
+}
+
+func TestInsertCapabilitiesDeterministic(t *testing.T) {
+	t.Parallel()
+
+	capabilities := InsertCapabilities()
+
+	if len(capabilities) != len(insertMethodsByDriver) {
+		t.Fatalf("expected %d capabilities, got %d",
+			len(insertMethodsByDriver), len(capabilities))
+	}
+
+	types := make([]stroppy.DriverConfig_DriverType, 0, len(capabilities))
+	for _, capability := range capabilities {
+		types = append(types, capability.Type)
+	}
+
+	if !slices.IsSorted(types) {
+		t.Errorf("capabilities not ordered by driver enum value: %v", types)
+	}
+}


### PR DESCRIPTION
# Pull Request

## Description of Changes
No-arg `stroppy probe` catalog now includes the driver→insert-method matrix:

- human output gains a `DRIVERS (supported insert methods)` block;
- `-o json` output gains a `"drivers"` key: `[{"type": "postgres", "insert_methods": ["plain_query", "plain_bulk", "columnar", "native"]}, ...]`.

The matrix lives as a static map in `pkg/driver/insert_methods.go` (with unit tests guarding enum coverage, validity, and deterministic order) rather than being registered from the driver packages: the stroppy CLI links only the dispatcher, not the driver implementations, so probe answers offline without pulling database clients into the binary. `stroppy help probe` catalog section updated.

Closes #95. Part of #90.

## Motivation and Context
External automated systems (stroppy-cloud and other orchestration) need a programmable way to discover which insert methods each driver supports — e.g. to validate or offer `defaultInsertMethod` choices per target DB. Until now this knowledge lived only inside each driver's `InsertSpec` switch.

## How Has This Been Tested?
- `make linter_fix` + `make linter` — 0 issues.
- `go test ./pkg/driver/ ./cmd/stroppy/...` — 80 passed, including 3 new tests for the matrix.
- `make build`, then ran the binary:
  - `stroppy probe -o json | jq .drivers` — all 6 drivers with expected method lists;
  - `stroppy probe` — human `DRIVERS` block renders;
  - `stroppy probe tpcb/tx -o json` — script probe path unchanged.

## Type of Changes
- [ ] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [ ] Refactoring
- [ ] Other

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] I have checked build and tests
- [x] I have updated documentation if needed