### PR TITLE
feat(tpcds): picodata schema + data-load (query port pending)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
-- TPC-DS now loads on Picodata: `stroppy run tpcds/tpcds -d pico -D url=postgres://admin:...@host:1336/admin -e SCALE_FACTOR=0.01 --no-steps workload`. Ships a typed sbroad schema (`schema.pico.sql`: `char`→`varchar`, `date`→`datetime`, a `PRIMARY KEY` per Tarantool space, no FK). The 99-query suite does **not** yet run on picodata — sbroad has no comma-join, no `CROSS JOIN`, and no implicit-cross-join pragma, and ~88 of the TPC-DS queries use comma joins (template style), so they fail at parse time. `pico.sql` is kept as the mechanical-transform skeleton for the future query port; until then run with `--no-steps workload` for load only.
+- TPC-DS now loads on Picodata: `stroppy run tpcds/tpcds -d pico -D url=postgres://admin:...@host:1336/admin -e SCALE_FACTOR=0.01 --no-steps workload`. Ships a typed sbroad schema (`schema.pico.sql`: `char`→`varchar`, `date`→`datetime`, a `PRIMARY KEY` per Tarantool space, no FK). The 99-query suite does **not** yet run on picodata — sbroad has no comma-join, no `CROSS JOIN`, and no implicit-cross-join pragma, and ~88 of the TPC-DS queries use comma joins (template style), so they fail at parse time. `pico.sql` is kept as the mechanical-transform skeleton for the future query port; until then run with `--no-steps workload` for load only. ([#100](https://github.com/stroppy-io/stroppy/pull/100))
 
 ### Fixed
 
-- Wide-table bulk loads on Picodata (and the latent YDB `plain_bulk` path) no longer hit the bound-parameter limit. The batch-size-by-column-count clamp that kept multi-row INSERTs under 65535 bound parameters lived in the MySQL driver only; it now runs centrally in the shared `sqldriver.RunBulkInsert`, so every sql.DB-backed dialect is protected. Previously TPC-DS `date_dim` (28 cols), `catalog_sales`, and `web_sales` (34 cols) aborted with `extended protocol limited to 65535 parameters` and loaded zero rows.
+- Wide-table bulk loads on Picodata (and the latent YDB `plain_bulk` path) no longer hit the bound-parameter limit. The batch-size-by-column-count clamp that kept multi-row INSERTs under 65535 bound parameters lived in the MySQL driver only; it now runs centrally in the shared `sqldriver.RunBulkInsert`, so every sql.DB-backed dialect is protected. Previously TPC-DS `date_dim` (28 cols), `catalog_sales`, and `web_sales` (34 cols) aborted with `extended protocol limited to 65535 parameters` and loaded zero rows. ([#100](https://github.com/stroppy-io/stroppy/pull/100))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
+- TPC-DS now loads on Picodata: `stroppy run tpcds/tpcds -d pico -D url=postgres://admin:...@host:1336/admin -e SCALE_FACTOR=0.01 --no-steps workload`. Ships a typed sbroad schema (`schema.pico.sql`: `char`→`varchar`, `date`→`datetime`, a `PRIMARY KEY` per Tarantool space, no FK). The 99-query suite does **not** yet run on picodata — sbroad has no comma-join, no `CROSS JOIN`, and no implicit-cross-join pragma, and ~88 of the TPC-DS queries use comma joins (template style), so they fail at parse time. `pico.sql` is kept as the mechanical-transform skeleton for the future query port; until then run with `--no-steps workload` for load only.
+
+### Fixed
+
+- Wide-table bulk loads on Picodata (and the latent YDB `plain_bulk` path) no longer hit the bound-parameter limit. The batch-size-by-column-count clamp that kept multi-row INSERTs under 65535 bound parameters lived in the MySQL driver only; it now runs centrally in the shared `sqldriver.RunBulkInsert`, so every sql.DB-backed dialect is protected. Previously TPC-DS `date_dim` (28 cols), `catalog_sales`, and `web_sales` (34 cols) aborted with `extended protocol limited to 65535 parameters` and loaded zero rows.
+
+### Added
+
 - The `columnar` insert method is now accepted by the YDB driver and redirected to the native `BulkUpsert` (already a struct-of-arrays, limit-free payload), logging a one-time warning, instead of being rejected. `columnar` is now listed for YDB in `stroppy probe`. MySQL and Picodata keep their existing insert methods: on MySQL `columnar` showed no throughput benefit over multi-row `plain_bulk` (measured against TPC-C/H/DS at SF 1), and Picodata's SQL has no array/JSON-expansion path. ([#99](https://github.com/stroppy-io/stroppy/pull/99))
 - TPC-DS now runs on YDB: `stroppy run tpcds/tpcds -d ydb -D url=grpc://host:2136/database`. Ships a typed YQL schema (`schema.ydb.sql`, column-store default with row-store as an option via `-e YDB_STORE_MODE=row`) and the 99-query suite ported to YQL (`ydb.sql`). The loader now feeds YDB's native bulk upsert directly from the generator. Answer-set validation and the in-process query-stream generator stay PostgreSQL/MySQL-only, so YDB runs the baked power test. ([#97](https://github.com/stroppy-io/stroppy/pull/97))
 - `stroppy probe` (no arguments) now also lists which insert methods each driver supports — `plain_query`, `plain_bulk`, `columnar`, `native` per database — as a `DRIVERS` block in the human output and a `drivers` key in `-o json`, so external tooling can discover valid `defaultInsertMethod` values per target without reading stroppy source. ([#96](https://github.com/stroppy-io/stroppy/pull/96))

--- a/pkg/driver/mysql/insert_spec.go
+++ b/pkg/driver/mysql/insert_spec.go
@@ -60,34 +60,10 @@ func (d *Driver) InsertSpec(
 	return &stats.Query{Elapsed: time.Since(start), Rows: rows}, nil
 }
 
-// maxMySQLPlaceholders is the server-side cap on bound parameters in a single
-// prepared statement (Error 1390 "too many placeholders"). A multi-row bulk
-// INSERT binds rows*columns placeholders, so wide tables (e.g. catalog_sales,
-// 34 cols) overflow the default batch size; capBatchByColumns keeps each batch
-// under the limit.
-const maxMySQLPlaceholders = 65535
-
-// capBatchByColumns clamps the configured batch size so rows*colCount stays
-// within mysql's placeholder limit. colCount <= 0 leaves the size unchanged.
-func capBatchByColumns(batchSize, colCount int) int {
-	if colCount <= 0 {
-		return batchSize
-	}
-
-	if maxBatch := maxMySQLPlaceholders / colCount; maxBatch < batchSize {
-		batchSize = maxBatch
-	}
-
-	if batchSize < 1 {
-		batchSize = 1
-	}
-
-	return batchSize
-}
-
 // runChunk dispatches one partition's rows according to spec.Method.
 // src is drained to EOF. PLAIN_QUERY degrades to a bulk path with
-// batchSize=1 so both arms share one codepath.
+// batchSize=1 so both arms share one codepath. The bound-parameter cap
+// (65535) is applied centrally in sqldriver.RunBulkInsert.
 func (d *Driver) runChunk(
 	ctx context.Context,
 	spec *dgproto.InsertSpec,
@@ -97,9 +73,7 @@ func (d *Driver) runChunk(
 
 	switch spec.GetMethod() {
 	case dgproto.InsertMethod_NATIVE, dgproto.InsertMethod_PLAIN_BULK:
-		batchSize := capBatchByColumns(d.bulkSize, len(src.Columns()))
-
-		return sqldriver.RunBulkInsert(ctx, d.db, table, src, d.dialect, batchSize)
+		return sqldriver.RunBulkInsert(ctx, d.db, table, src, d.dialect, d.bulkSize)
 	case dgproto.InsertMethod_PLAIN_QUERY:
 		return sqldriver.RunBulkInsert(ctx, d.db, table, src, d.dialect, 1)
 	default:

--- a/pkg/driver/sqldriver/insert_spec.go
+++ b/pkg/driver/sqldriver/insert_spec.go
@@ -72,6 +72,33 @@ func RunInsertSpec[T any](
 // Exposed separately from RunInsertSpec so callers that already run
 // their own InsertMethod switch (for example, to call a driver-native
 // path for NATIVE) can reuse the bulk implementation directly.
+// maxBoundParameters is the per-statement bound-parameter cap shared by the
+// pgwire extended protocol (picodata, postgres) and MySQL's prepared-statement
+// path (Error 1390 "too many placeholders"): 65535. A multi-row bulk INSERT
+// binds rows*columns placeholders, so wide tables (e.g. TPC-DS catalog_sales,
+// 34 cols) overflow a configured batch size; clampBatchByColumns keeps each
+// batch under the limit. Applied centrally here so every sqldriver-based
+// dialect (mysql, picodata, ydb plain_bulk) is protected.
+const maxBoundParameters = 65535
+
+// clampBatchByColumns clamps batchSize so rows*colCount stays within
+// maxBoundParameters. colCount <= 0 leaves the size unchanged.
+func clampBatchByColumns(batchSize, colCount int) int {
+	if colCount <= 0 {
+		return batchSize
+	}
+
+	if maxBatch := maxBoundParameters / colCount; maxBatch < batchSize {
+		batchSize = maxBatch
+	}
+
+	if batchSize < 1 {
+		batchSize = 1
+	}
+
+	return batchSize
+}
+
 func RunBulkInsert[T any](
 	ctx context.Context,
 	db ExecContext[T],
@@ -80,16 +107,16 @@ func RunBulkInsert[T any](
 	dialect queries.Dialect,
 	batchSize int,
 ) error {
-	if batchSize < 1 {
-		batchSize = 1
-	}
-
 	columns := src.Columns()
 
 	colCount := len(columns)
 	if colCount == 0 {
 		return fmt.Errorf("%w: table %q", ErrEmptyColumnOrder, table)
 	}
+
+	// Clamp by column count so a wide table's batch never exceeds the bound-
+	// parameter cap (pgwire / MySQL prepared statements = 65535).
+	batchSize = clampBatchByColumns(batchSize, colCount)
 
 	// Buffers reused across this worker's batches: a fixed pool of row slices
 	// (filled in place by convertRowInto), the flattened args slice, and the

--- a/workloads/tpcds/README.md
+++ b/workloads/tpcds/README.md
@@ -22,6 +22,12 @@ templates at the canonical qualification parameters.
 ./build/stroppy run tpcds/tpcds -d ydb \
     -D url=grpc://localhost:2136/local \
     -e SCALE_FACTOR=0.01
+
+# Picodata (pgwire) — LOAD ONLY. Query execution is not yet supported on
+# picodata (see Status); run the prep steps without the workload:
+./build/stroppy run tpcds/tpcds -d pico \
+    -D url=postgres://admin:T0psecret@localhost:1331/admin \
+    -e SCALE_FACTOR=0.01 --no-steps workload
 ```
 
 Env overrides:
@@ -157,9 +163,27 @@ DataMaint2, scored as QphDS@SF. This workload covers:
 
 - PostgreSQL, MySQL, and YDB: load + all 103 statements verified on a local
   instance at SCALE_FACTOR=0.01.
+- Picodata: **load supported** (schema + all 24-table bulk load verified at
+  SCALE_FACTOR=0.01). **Query execution is not yet supported** — see the
+  picodata query blockers note below.
 - Not yet done: the Data Maintenance phase (refresh-data generation + insert/
-  delete DM functions) and the QphDS@SF metric; SF=1 answer-set validation against
-  the kit's `answer_sets/`; the Picodata dialect files (queries and schema).
+  delete DM functions) and the QphDS@SF metric; SF=1 answer-set validation
+  against the kit's `answer_sets/`.
+
+### Picodata query blockers
+
+The picodata schema and data-load path ship today; the 99-query suite does
+not yet run on picodata. sbroad (picodata 26.3) accepts only explicit
+`INNER JOIN ... ON` and has no comma-join, no `CROSS JOIN`, and no
+implicit-cross-join pragma/session setting (YDB has `AnsiImplicitCrossJoin`;
+sbroad does not). TPC-DS query templates use comma joins pervasively, so
+~88 of 95 queries fail at parse time. Secondary gaps behind that one:
+`rollup`/`grouping sets`, `INTERSECT`, `FULL OUTER JOIN`,
+`rank()`/`dense_rank()`/`lag()`/`lead()`, correlated subqueries,
+`datetime+int`, and `round()`. `pico.sql` carries the mechanical-transform
+skeleton (date/char/cast fixes, date+N baked) as the port starting point;
+the workload step is expected to fail until the comma-join rewrite lands.
+Load picodata with `--no-steps workload`.
 
 ## Run shapes and the two-run flow
 

--- a/workloads/tpcds/pico.sql
+++ b/workloads/tpcds/pico.sql
@@ -1,0 +1,4510 @@
+-- TPC-DS query suite for picodata (sbroad). Derived from pg.sql by the
+-- porting script; hand rewrites for the sbroad gaps land here on top of the
+-- mechanical base.
+--
+-- *** STATUS: query EXECUTION is NOT yet supported on picodata. ***
+-- Only the data-load path ships today (schema.pico.sql + load). The query
+-- bodies below are the mechanical-transform skeleton (date/char/cast fixes,
+-- date+N baked); they DO NOT EXECUTE on sbroad yet. The blocking gap:
+--
+--   sbroad (picodata 26.3) has no comma-join and no CROSS JOIN.
+--   FROM a, b  -> "expected IndexedByExpr"; CROSS JOIN -> "expected Identifier".
+--   No PRAGMA / session setting enables implicit cross joins (YDB has
+--   AnsiImplicitCrossJoin; sbroad does not). Only INNER JOIN ... ON works.
+--
+-- ~88 of 95 TPC-DS queries use comma joins (TPC-DS template style), so they
+-- fail at parse time. Secondary gaps behind that one: rollup/grouping sets,
+-- INTERSECT, FULL OUTER JOIN, rank()/dense_rank()/lag()/lead(), correlated
+-- subqueries, datetime+int, round(). See the PR/issue tracking the pico query
+-- port for the plan (AST comma-join rewrite + the targeted secondary rewrites;
+-- or an upstream sbroad implicit-cross-join feature).
+--
+-- This file is kept as the port starting point. To load picodata today, run
+-- with `--no-steps workload` (drop/create/load/index only); the workload step
+-- is expected to fail until the query port lands.
+--
+-- sbroad gaps recorded for the future port (probed against picodata 26.3):
+--   - char/date types absent -> schema.pico.sql uses varchar/datetime.
+--   - no datetime+int / DATE type -> date+N offsets baked to literals below.
+--   - rank()/dense_rank()/lag()/lead(): no engine support, no correlated
+--     subquery to emulate. 8 queries are SKIPPED here and logged at startup:
+--     query_36, query_44, query_47, query_49, query_57, query_67,
+--     query_70, query_86.
+--   - rollup/grouping sets, INTERSECT, FULL OUTER JOIN, correlated
+--     subqueries to be rewritten where the queries that need them appear.
+--
+-- TPC-DS query workload for PostgreSQL.
+-- 99 queries (queries 14/23/24/39 have two parts: _a/_b), generated from the
+-- official TPC-DS query templates at the canonical qualification parameters
+-- (RNGSEED 19620718, SCALE 1). Each query is one named --= section, parsed by
+-- parse_sql(). See workloads/tpcds/tpcds.ts.
+
+
+--= query_1
+with customer_total_return as
+(select sr_customer_sk as ctr_customer_sk
+,sr_store_sk as ctr_store_sk
+,sum(SR_FEE) as ctr_total_return
+from store_returns
+,date_dim
+where sr_returned_date_sk = d_date_sk
+and d_year =2000
+group by sr_customer_sk
+,sr_store_sk)
+,ctr_store_avg as (select ctr_store_sk, avg(ctr_total_return)*1.2 as ctr_avg from customer_total_return group by ctr_store_sk)
+ select  c_customer_id
+from customer_total_return ctr1
+,store
+,customer
+,ctr_store_avg
+where ctr1.ctr_total_return > ctr_store_avg.ctr_avg
+and ctr_store_avg.ctr_store_sk = ctr1.ctr_store_sk
+and s_store_sk = ctr1.ctr_store_sk
+and s_state = 'TN'
+and ctr1.ctr_customer_sk = c_customer_sk
+order by c_customer_id
+limit 100
+;
+
+--= query_2
+with wscs as
+ (select sold_date_sk
+        ,sales_price
+  from (select ws_sold_date_sk sold_date_sk
+              ,ws_ext_sales_price sales_price
+        from web_sales 
+        union all
+        select cs_sold_date_sk sold_date_sk
+              ,cs_ext_sales_price sales_price
+        from catalog_sales)),
+ wswscs as 
+ (select d_week_seq,
+        sum(case when (d_day_name='Sunday') then sales_price else null end) sun_sales,
+        sum(case when (d_day_name='Monday') then sales_price else null end) mon_sales,
+        sum(case when (d_day_name='Tuesday') then sales_price else  null end) tue_sales,
+        sum(case when (d_day_name='Wednesday') then sales_price else null end) wed_sales,
+        sum(case when (d_day_name='Thursday') then sales_price else null end) thu_sales,
+        sum(case when (d_day_name='Friday') then sales_price else null end) fri_sales,
+        sum(case when (d_day_name='Saturday') then sales_price else null end) sat_sales
+ from wscs
+     ,date_dim
+ where d_date_sk = sold_date_sk
+ group by d_week_seq)
+ select d_week_seq1
+       ,round(sun_sales1/sun_sales2,2)
+       ,round(mon_sales1/mon_sales2,2)
+       ,round(tue_sales1/tue_sales2,2)
+       ,round(wed_sales1/wed_sales2,2)
+       ,round(thu_sales1/thu_sales2,2)
+       ,round(fri_sales1/fri_sales2,2)
+       ,round(sat_sales1/sat_sales2,2)
+ from
+ (select wswscs.d_week_seq d_week_seq1
+        ,sun_sales sun_sales1
+        ,mon_sales mon_sales1
+        ,tue_sales tue_sales1
+        ,wed_sales wed_sales1
+        ,thu_sales thu_sales1
+        ,fri_sales fri_sales1
+        ,sat_sales sat_sales1
+  from wswscs,date_dim 
+  where date_dim.d_week_seq = wswscs.d_week_seq and
+        d_year = 1998) y,
+ (select wswscs.d_week_seq d_week_seq2
+        ,sun_sales sun_sales2
+        ,mon_sales mon_sales2
+        ,tue_sales tue_sales2
+        ,wed_sales wed_sales2
+        ,thu_sales thu_sales2
+        ,fri_sales fri_sales2
+        ,sat_sales sat_sales2
+  from wswscs
+      ,date_dim 
+  where date_dim.d_week_seq = wswscs.d_week_seq and
+        d_year = 1998+1) z
+ where d_week_seq1=d_week_seq2-53
+ order by d_week_seq1
+;
+
+--= query_3
+select  dt.d_year 
+       ,item.i_brand_id brand_id 
+       ,item.i_brand brand
+       ,sum(ss_sales_price) sum_agg
+ from  date_dim dt 
+      ,store_sales
+      ,item
+ where dt.d_date_sk = store_sales.ss_sold_date_sk
+   and store_sales.ss_item_sk = item.i_item_sk
+   and item.i_manufact_id = 816
+   and dt.d_moy=11
+ group by dt.d_year
+      ,item.i_brand
+      ,item.i_brand_id
+ order by dt.d_year
+         ,sum_agg desc
+         ,brand_id
+ limit 100
+;
+
+--= query_4
+with year_total as (
+ select c_customer_id customer_id
+       ,c_first_name customer_first_name
+       ,c_last_name customer_last_name
+       ,c_preferred_cust_flag customer_preferred_cust_flag
+       ,c_birth_country customer_birth_country
+       ,c_login customer_login
+       ,c_email_address customer_email_address
+       ,d_year dyear
+       ,sum(((ss_ext_list_price-ss_ext_wholesale_cost-ss_ext_discount_amt)+ss_ext_sales_price)/2) year_total
+       ,'s' sale_type
+ from customer
+     ,store_sales
+     ,date_dim
+ where c_customer_sk = ss_customer_sk
+   and ss_sold_date_sk = d_date_sk
+ group by c_customer_id
+         ,c_first_name
+         ,c_last_name
+         ,c_preferred_cust_flag
+         ,c_birth_country
+         ,c_login
+         ,c_email_address
+         ,d_year
+ union all
+ select c_customer_id customer_id
+       ,c_first_name customer_first_name
+       ,c_last_name customer_last_name
+       ,c_preferred_cust_flag customer_preferred_cust_flag
+       ,c_birth_country customer_birth_country
+       ,c_login customer_login
+       ,c_email_address customer_email_address
+       ,d_year dyear
+       ,sum((((cs_ext_list_price-cs_ext_wholesale_cost-cs_ext_discount_amt)+cs_ext_sales_price)/2) ) year_total
+       ,'c' sale_type
+ from customer
+     ,catalog_sales
+     ,date_dim
+ where c_customer_sk = cs_bill_customer_sk
+   and cs_sold_date_sk = d_date_sk
+ group by c_customer_id
+         ,c_first_name
+         ,c_last_name
+         ,c_preferred_cust_flag
+         ,c_birth_country
+         ,c_login
+         ,c_email_address
+         ,d_year
+union all
+ select c_customer_id customer_id
+       ,c_first_name customer_first_name
+       ,c_last_name customer_last_name
+       ,c_preferred_cust_flag customer_preferred_cust_flag
+       ,c_birth_country customer_birth_country
+       ,c_login customer_login
+       ,c_email_address customer_email_address
+       ,d_year dyear
+       ,sum((((ws_ext_list_price-ws_ext_wholesale_cost-ws_ext_discount_amt)+ws_ext_sales_price)/2) ) year_total
+       ,'w' sale_type
+ from customer
+     ,web_sales
+     ,date_dim
+ where c_customer_sk = ws_bill_customer_sk
+   and ws_sold_date_sk = d_date_sk
+ group by c_customer_id
+         ,c_first_name
+         ,c_last_name
+         ,c_preferred_cust_flag
+         ,c_birth_country
+         ,c_login
+         ,c_email_address
+         ,d_year
+         )
+  select  
+                  t_s_secyear.customer_id
+                 ,t_s_secyear.customer_first_name
+                 ,t_s_secyear.customer_last_name
+                 ,t_s_secyear.customer_birth_country
+ from year_total t_s_firstyear
+     ,year_total t_s_secyear
+     ,year_total t_c_firstyear
+     ,year_total t_c_secyear
+     ,year_total t_w_firstyear
+     ,year_total t_w_secyear
+ where t_s_secyear.customer_id = t_s_firstyear.customer_id
+   and t_s_firstyear.customer_id = t_c_secyear.customer_id
+   and t_s_firstyear.customer_id = t_c_firstyear.customer_id
+   and t_s_firstyear.customer_id = t_w_firstyear.customer_id
+   and t_s_firstyear.customer_id = t_w_secyear.customer_id
+   and t_s_firstyear.sale_type = 's'
+   and t_c_firstyear.sale_type = 'c'
+   and t_w_firstyear.sale_type = 'w'
+   and t_s_secyear.sale_type = 's'
+   and t_c_secyear.sale_type = 'c'
+   and t_w_secyear.sale_type = 'w'
+   and t_s_firstyear.dyear =  1999
+   and t_s_secyear.dyear = 1999+1
+   and t_c_firstyear.dyear =  1999
+   and t_c_secyear.dyear =  1999+1
+   and t_w_firstyear.dyear = 1999
+   and t_w_secyear.dyear = 1999+1
+   and t_s_firstyear.year_total > 0
+   and t_c_firstyear.year_total > 0
+   and t_w_firstyear.year_total > 0
+   and case when t_c_firstyear.year_total > 0 then t_c_secyear.year_total / t_c_firstyear.year_total else null end
+           > case when t_s_firstyear.year_total > 0 then t_s_secyear.year_total / t_s_firstyear.year_total else null end
+   and case when t_c_firstyear.year_total > 0 then t_c_secyear.year_total / t_c_firstyear.year_total else null end
+           > case when t_w_firstyear.year_total > 0 then t_w_secyear.year_total / t_w_firstyear.year_total else null end
+ order by t_s_secyear.customer_id
+         ,t_s_secyear.customer_first_name
+         ,t_s_secyear.customer_last_name
+         ,t_s_secyear.customer_birth_country
+limit 100
+;
+
+--= query_5
+with ssr as
+ (select s_store_id,
+        sum(sales_price) as sales,
+        sum(profit) as profit,
+        sum(return_amt) as returns,
+        sum(net_loss) as profit_loss
+ from
+  ( select  ss_store_sk as store_sk,
+            ss_sold_date_sk  as date_sk,
+            ss_ext_sales_price as sales_price,
+            ss_net_profit as profit,
+            cast(0 as decimal(7,2)) as return_amt,
+            cast(0 as decimal(7,2)) as net_loss
+    from store_sales
+    union all
+    select sr_store_sk as store_sk,
+           sr_returned_date_sk as date_sk,
+           cast(0 as decimal(7,2)) as sales_price,
+           cast(0 as decimal(7,2)) as profit,
+           sr_return_amt as return_amt,
+           sr_net_loss as net_loss
+    from store_returns
+   ) salesreturns,
+     date_dim,
+     store
+ where date_sk = d_date_sk
+       and d_date between cast('2000-08-19' as datetime) 
+                  and (cast('2000-09-02' as datetime))
+       and store_sk = s_store_sk
+ group by s_store_id)
+ ,
+ csr as
+ (select cp_catalog_page_id,
+        sum(sales_price) as sales,
+        sum(profit) as profit,
+        sum(return_amt) as returns,
+        sum(net_loss) as profit_loss
+ from
+  ( select  cs_catalog_page_sk as page_sk,
+            cs_sold_date_sk  as date_sk,
+            cs_ext_sales_price as sales_price,
+            cs_net_profit as profit,
+            cast(0 as decimal(7,2)) as return_amt,
+            cast(0 as decimal(7,2)) as net_loss
+    from catalog_sales
+    union all
+    select cr_catalog_page_sk as page_sk,
+           cr_returned_date_sk as date_sk,
+           cast(0 as decimal(7,2)) as sales_price,
+           cast(0 as decimal(7,2)) as profit,
+           cr_return_amount as return_amt,
+           cr_net_loss as net_loss
+    from catalog_returns
+   ) salesreturns,
+     date_dim,
+     catalog_page
+ where date_sk = d_date_sk
+       and d_date between cast('2000-08-19' as datetime)
+                  and (cast('2000-09-02' as datetime))
+       and page_sk = cp_catalog_page_sk
+ group by cp_catalog_page_id)
+ ,
+ wsr as
+ (select web_site_id,
+        sum(sales_price) as sales,
+        sum(profit) as profit,
+        sum(return_amt) as returns,
+        sum(net_loss) as profit_loss
+ from
+  ( select  ws_web_site_sk as wsr_web_site_sk,
+            ws_sold_date_sk  as date_sk,
+            ws_ext_sales_price as sales_price,
+            ws_net_profit as profit,
+            cast(0 as decimal(7,2)) as return_amt,
+            cast(0 as decimal(7,2)) as net_loss
+    from web_sales
+    union all
+    select ws_web_site_sk as wsr_web_site_sk,
+           wr_returned_date_sk as date_sk,
+           cast(0 as decimal(7,2)) as sales_price,
+           cast(0 as decimal(7,2)) as profit,
+           wr_return_amt as return_amt,
+           wr_net_loss as net_loss
+    from web_returns left outer join web_sales on
+         ( wr_item_sk = ws_item_sk
+           and wr_order_number = ws_order_number)
+   ) salesreturns,
+     date_dim,
+     web_site
+ where date_sk = d_date_sk
+       and d_date between cast('2000-08-19' as datetime)
+                  and (cast('2000-09-02' as datetime))
+       and wsr_web_site_sk = web_site_sk
+ group by web_site_id)
+  select  channel
+        , id
+        , sum(sales) as sales
+        , sum(returns) as returns
+        , sum(profit) as profit
+ from 
+ (select 'store channel' as channel
+        , 'store' || s_store_id as id
+        , sales
+        , returns
+        , (profit - profit_loss) as profit
+ from   ssr
+ union all
+ select 'catalog channel' as channel
+        , 'catalog_page' || cp_catalog_page_id as id
+        , sales
+        , returns
+        , (profit - profit_loss) as profit
+ from  csr
+ union all
+ select 'web channel' as channel
+        , 'web_site' || web_site_id as id
+        , sales
+        , returns
+        , (profit - profit_loss) as profit
+ from   wsr
+ ) x
+ group by rollup (channel, id)
+ order by channel
+         ,id
+ limit 100
+;
+
+--= query_6
+select  a.ca_state state, count(*) cnt
+ from customer_address a
+     ,customer c
+     ,store_sales s
+     ,date_dim d
+     ,item i
+     ,(select i_category as iavg_cat, avg(i_current_price) as iavg_price from item group by i_category) iavg
+ where       a.ca_address_sk = c.c_current_addr_sk
+ 	and c.c_customer_sk = s.ss_customer_sk
+ 	and s.ss_sold_date_sk = d.d_date_sk
+ 	and s.ss_item_sk = i.i_item_sk
+ 	and d.d_month_seq = 
+ 	     (select distinct (d_month_seq)
+ 	      from date_dim
+               where d_year = 2002
+ 	        and d_moy = 3 )
+ 	and iavg.iavg_cat = i.i_category
+ 	and i.i_current_price > 1.2 * iavg.iavg_price
+ group by a.ca_state
+ having count(*) >= 10
+ order by cnt, a.ca_state 
+ limit 100
+;
+
+--= query_7
+select  i_item_id, 
+        avg(ss_quantity) agg1,
+        avg(ss_list_price) agg2,
+        avg(ss_coupon_amt) agg3,
+        avg(ss_sales_price) agg4 
+ from store_sales, customer_demographics, date_dim, item, promotion
+ where ss_sold_date_sk = d_date_sk and
+       ss_item_sk = i_item_sk and
+       ss_cdemo_sk = cd_demo_sk and
+       ss_promo_sk = p_promo_sk and
+       cd_gender = 'F' and 
+       cd_marital_status = 'W' and
+       cd_education_status = 'College' and
+       (p_channel_email = 'N' or p_channel_event = 'N') and
+       d_year = 2001 
+ group by i_item_id
+ order by i_item_id
+ limit 100
+;
+
+--= query_8
+select  s_store_name
+      ,sum(ss_net_profit)
+ from store_sales
+     ,date_dim
+     ,store,
+     (select ca_zip
+     from (
+      SELECT substr(ca_zip,1,5) ca_zip
+      FROM customer_address
+      WHERE substr(ca_zip,1,5) IN (
+                          '47602','16704','35863','28577','83910','36201',
+                          '58412','48162','28055','41419','80332',
+                          '38607','77817','24891','16226','18410',
+                          '21231','59345','13918','51089','20317',
+                          '17167','54585','67881','78366','47770',
+                          '18360','51717','73108','14440','21800',
+                          '89338','45859','65501','34948','25973',
+                          '73219','25333','17291','10374','18829',
+                          '60736','82620','41351','52094','19326',
+                          '25214','54207','40936','21814','79077',
+                          '25178','75742','77454','30621','89193',
+                          '27369','41232','48567','83041','71948',
+                          '37119','68341','14073','16891','62878',
+                          '49130','19833','24286','27700','40979',
+                          '50412','81504','94835','84844','71954',
+                          '39503','57649','18434','24987','12350',
+                          '86379','27413','44529','98569','16515',
+                          '27287','24255','21094','16005','56436',
+                          '91110','68293','56455','54558','10298',
+                          '83647','32754','27052','51766','19444',
+                          '13869','45645','94791','57631','20712',
+                          '37788','41807','46507','21727','71836',
+                          '81070','50632','88086','63991','20244',
+                          '31655','51782','29818','63792','68605',
+                          '94898','36430','57025','20601','82080',
+                          '33869','22728','35834','29086','92645',
+                          '98584','98072','11652','78093','57553',
+                          '43830','71144','53565','18700','90209',
+                          '71256','38353','54364','28571','96560',
+                          '57839','56355','50679','45266','84680',
+                          '34306','34972','48530','30106','15371',
+                          '92380','84247','92292','68852','13338',
+                          '34594','82602','70073','98069','85066',
+                          '47289','11686','98862','26217','47529',
+                          '63294','51793','35926','24227','14196',
+                          '24594','32489','99060','49472','43432',
+                          '49211','14312','88137','47369','56877',
+                          '20534','81755','15794','12318','21060',
+                          '73134','41255','63073','81003','73873',
+                          '66057','51184','51195','45676','92696',
+                          '70450','90669','98338','25264','38919',
+                          '59226','58581','60298','17895','19489',
+                          '52301','80846','95464','68770','51634',
+                          '19988','18367','18421','11618','67975',
+                          '25494','41352','95430','15734','62585',
+                          '97173','33773','10425','75675','53535',
+                          '17879','41967','12197','67998','79658',
+                          '59130','72592','14851','43933','68101',
+                          '50636','25717','71286','24660','58058',
+                          '72991','95042','15543','33122','69280',
+                          '11912','59386','27642','65177','17672',
+                          '33467','64592','36335','54010','18767',
+                          '63193','42361','49254','33113','33159',
+                          '36479','59080','11855','81963','31016',
+                          '49140','29392','41836','32958','53163',
+                          '13844','73146','23952','65148','93498',
+                          '14530','46131','58454','13376','13378',
+                          '83986','12320','17193','59852','46081',
+                          '98533','52389','13086','68843','31013',
+                          '13261','60560','13443','45533','83583',
+                          '11489','58218','19753','22911','25115',
+                          '86709','27156','32669','13123','51933',
+                          '39214','41331','66943','14155','69998',
+                          '49101','70070','35076','14242','73021',
+                          '59494','15782','29752','37914','74686',
+                          '83086','34473','15751','81084','49230',
+                          '91894','60624','17819','28810','63180',
+                          '56224','39459','55233','75752','43639',
+                          '55349','86057','62361','50788','31830',
+                          '58062','18218','85761','60083','45484',
+                          '21204','90229','70041','41162','35390',
+                          '16364','39500','68908','26689','52868',
+                          '81335','40146','11340','61527','61794',
+                          '71997','30415','59004','29450','58117',
+                          '69952','33562','83833','27385','61860',
+                          '96435','48333','23065','32961','84919',
+                          '61997','99132','22815','56600','68730',
+                          '48017','95694','32919','88217','27116',
+                          '28239','58032','18884','16791','21343',
+                          '97462','18569','75660','15475')
+     intersect
+      select ca_zip
+      from (SELECT substr(ca_zip,1,5) ca_zip,count(*) cnt
+            FROM customer_address, customer
+            WHERE ca_address_sk = c_current_addr_sk and
+                  c_preferred_cust_flag='Y'
+            group by ca_zip
+            having count(*) > 10)A1)A2) V1
+ where ss_store_sk = s_store_sk
+  and ss_sold_date_sk = d_date_sk
+  and d_qoy = 2 and d_year = 1998
+  and (substr(s_zip,1,2) = substr(V1.ca_zip,1,2))
+ group by s_store_name
+ order by s_store_name
+ limit 100
+;
+
+--= query_9
+select case when (select count(*) 
+                  from store_sales 
+                  where ss_quantity between 1 and 20) > 1071
+            then (select avg(ss_ext_tax) 
+                  from store_sales 
+                  where ss_quantity between 1 and 20) 
+            else (select avg(ss_net_paid_inc_tax)
+                  from store_sales
+                  where ss_quantity between 1 and 20) end bucket1 ,
+       case when (select count(*)
+                  from store_sales
+                  where ss_quantity between 21 and 40) > 39161
+            then (select avg(ss_ext_tax)
+                  from store_sales
+                  where ss_quantity between 21 and 40) 
+            else (select avg(ss_net_paid_inc_tax)
+                  from store_sales
+                  where ss_quantity between 21 and 40) end bucket2,
+       case when (select count(*)
+                  from store_sales
+                  where ss_quantity between 41 and 60) > 29434
+            then (select avg(ss_ext_tax)
+                  from store_sales
+                  where ss_quantity between 41 and 60)
+            else (select avg(ss_net_paid_inc_tax)
+                  from store_sales
+                  where ss_quantity between 41 and 60) end bucket3,
+       case when (select count(*)
+                  from store_sales
+                  where ss_quantity between 61 and 80) > 6568
+            then (select avg(ss_ext_tax)
+                  from store_sales
+                  where ss_quantity between 61 and 80)
+            else (select avg(ss_net_paid_inc_tax)
+                  from store_sales
+                  where ss_quantity between 61 and 80) end bucket4,
+       case when (select count(*)
+                  from store_sales
+                  where ss_quantity between 81 and 100) > 21216
+            then (select avg(ss_ext_tax)
+                  from store_sales
+                  where ss_quantity between 81 and 100)
+            else (select avg(ss_net_paid_inc_tax)
+                  from store_sales
+                  where ss_quantity between 81 and 100) end bucket5
+from reason
+where r_reason_sk = 1
+;
+
+--= query_10
+select  
+  cd_gender,
+  cd_marital_status,
+  cd_education_status,
+  count(*) cnt1,
+  cd_purchase_estimate,
+  count(*) cnt2,
+  cd_credit_rating,
+  count(*) cnt3,
+  cd_dep_count,
+  count(*) cnt4,
+  cd_dep_employed_count,
+  count(*) cnt5,
+  cd_dep_college_count,
+  count(*) cnt6
+ from
+  customer c,customer_address ca,customer_demographics
+ where
+  c.c_current_addr_sk = ca.ca_address_sk and
+  ca_county in ('Fairfield County','Campbell County','Washtenaw County','Escambia County','Cleburne County') and
+  cd_demo_sk = c.c_current_cdemo_sk and 
+  exists (select *
+          from store_sales,date_dim
+          where c.c_customer_sk = ss_customer_sk and
+                ss_sold_date_sk = d_date_sk and
+                d_year = 2001 and
+                d_moy between 3 and 3+3) and
+   (exists (select *
+            from web_sales,date_dim
+            where c.c_customer_sk = ws_bill_customer_sk and
+                  ws_sold_date_sk = d_date_sk and
+                  d_year = 2001 and
+                  d_moy between 3 ANd 3+3) or 
+    exists (select * 
+            from catalog_sales,date_dim
+            where c.c_customer_sk = cs_ship_customer_sk and
+                  cs_sold_date_sk = d_date_sk and
+                  d_year = 2001 and
+                  d_moy between 3 and 3+3))
+ group by cd_gender,
+          cd_marital_status,
+          cd_education_status,
+          cd_purchase_estimate,
+          cd_credit_rating,
+          cd_dep_count,
+          cd_dep_employed_count,
+          cd_dep_college_count
+ order by cd_gender,
+          cd_marital_status,
+          cd_education_status,
+          cd_purchase_estimate,
+          cd_credit_rating,
+          cd_dep_count,
+          cd_dep_employed_count,
+          cd_dep_college_count
+limit 100
+;
+
+--= query_11
+with year_total as (
+ select c_customer_id customer_id
+       ,c_first_name customer_first_name
+       ,c_last_name customer_last_name
+       ,c_preferred_cust_flag customer_preferred_cust_flag
+       ,c_birth_country customer_birth_country
+       ,c_login customer_login
+       ,c_email_address customer_email_address
+       ,d_year dyear
+       ,sum(ss_ext_list_price-ss_ext_discount_amt) year_total
+       ,'s' sale_type
+ from customer
+     ,store_sales
+     ,date_dim
+ where c_customer_sk = ss_customer_sk
+   and ss_sold_date_sk = d_date_sk
+ group by c_customer_id
+         ,c_first_name
+         ,c_last_name
+         ,c_preferred_cust_flag 
+         ,c_birth_country
+         ,c_login
+         ,c_email_address
+         ,d_year 
+ union all
+ select c_customer_id customer_id
+       ,c_first_name customer_first_name
+       ,c_last_name customer_last_name
+       ,c_preferred_cust_flag customer_preferred_cust_flag
+       ,c_birth_country customer_birth_country
+       ,c_login customer_login
+       ,c_email_address customer_email_address
+       ,d_year dyear
+       ,sum(ws_ext_list_price-ws_ext_discount_amt) year_total
+       ,'w' sale_type
+ from customer
+     ,web_sales
+     ,date_dim
+ where c_customer_sk = ws_bill_customer_sk
+   and ws_sold_date_sk = d_date_sk
+ group by c_customer_id
+         ,c_first_name
+         ,c_last_name
+         ,c_preferred_cust_flag 
+         ,c_birth_country
+         ,c_login
+         ,c_email_address
+         ,d_year
+         )
+  select  
+                  t_s_secyear.customer_id
+                 ,t_s_secyear.customer_first_name
+                 ,t_s_secyear.customer_last_name
+                 ,t_s_secyear.customer_email_address
+ from year_total t_s_firstyear
+     ,year_total t_s_secyear
+     ,year_total t_w_firstyear
+     ,year_total t_w_secyear
+ where t_s_secyear.customer_id = t_s_firstyear.customer_id
+         and t_s_firstyear.customer_id = t_w_secyear.customer_id
+         and t_s_firstyear.customer_id = t_w_firstyear.customer_id
+         and t_s_firstyear.sale_type = 's'
+         and t_w_firstyear.sale_type = 'w'
+         and t_s_secyear.sale_type = 's'
+         and t_w_secyear.sale_type = 'w'
+         and t_s_firstyear.dyear = 1998
+         and t_s_secyear.dyear = 1998+1
+         and t_w_firstyear.dyear = 1998
+         and t_w_secyear.dyear = 1998+1
+         and t_s_firstyear.year_total > 0
+         and t_w_firstyear.year_total > 0
+         and case when t_w_firstyear.year_total > 0 then t_w_secyear.year_total / t_w_firstyear.year_total else 0.0 end
+             > case when t_s_firstyear.year_total > 0 then t_s_secyear.year_total / t_s_firstyear.year_total else 0.0 end
+ order by t_s_secyear.customer_id
+         ,t_s_secyear.customer_first_name
+         ,t_s_secyear.customer_last_name
+         ,t_s_secyear.customer_email_address
+limit 100
+;
+
+--= query_12
+select  i_item_id
+      ,i_item_desc 
+      ,i_category 
+      ,i_class 
+      ,i_current_price
+      ,sum(ws_ext_sales_price) as itemrevenue 
+      ,sum(ws_ext_sales_price)*100/sum(sum(ws_ext_sales_price)) over
+          (partition by i_class) as revenueratio
+from	
+	web_sales
+    	,item 
+    	,date_dim
+where 
+	ws_item_sk = i_item_sk 
+  	and i_category in ('Men', 'Books', 'Electronics')
+  	and ws_sold_date_sk = d_date_sk
+	and d_date between cast('2001-06-15' as datetime) 
+				and (cast('2001-07-15' as datetime))
+group by 
+	i_item_id
+        ,i_item_desc 
+        ,i_category
+        ,i_class
+        ,i_current_price
+order by 
+	i_category
+        ,i_class
+        ,i_item_id
+        ,i_item_desc
+        ,revenueratio
+limit 100
+;
+
+--= query_13
+select avg(ss_quantity)
+       ,avg(ss_ext_sales_price)
+       ,avg(ss_ext_wholesale_cost)
+       ,sum(ss_ext_wholesale_cost)
+ from store_sales
+     ,store
+     ,customer_demographics
+     ,household_demographics
+     ,customer_address
+     ,date_dim
+ where s_store_sk = ss_store_sk
+ and  ss_sold_date_sk = d_date_sk and d_year = 2001
+ and((ss_hdemo_sk=hd_demo_sk
+  and cd_demo_sk = ss_cdemo_sk
+  and cd_marital_status = 'M'
+  and cd_education_status = 'College'
+  and ss_sales_price between 100.00 and 150.00
+  and hd_dep_count = 3   
+     )or
+     (ss_hdemo_sk=hd_demo_sk
+  and cd_demo_sk = ss_cdemo_sk
+  and cd_marital_status = 'D'
+  and cd_education_status = 'Primary'
+  and ss_sales_price between 50.00 and 100.00   
+  and hd_dep_count = 1
+     ) or 
+     (ss_hdemo_sk=hd_demo_sk
+  and cd_demo_sk = ss_cdemo_sk
+  and cd_marital_status = 'W'
+  and cd_education_status = '2 yr Degree'
+  and ss_sales_price between 150.00 and 200.00 
+  and hd_dep_count = 1  
+     ))
+ and((ss_addr_sk = ca_address_sk
+  and ca_country = 'United States'
+  and ca_state in ('IL', 'TN', 'TX')
+  and ss_net_profit between 100 and 200  
+     ) or
+     (ss_addr_sk = ca_address_sk
+  and ca_country = 'United States'
+  and ca_state in ('WY', 'OH', 'ID')
+  and ss_net_profit between 150 and 300  
+     ) or
+     (ss_addr_sk = ca_address_sk
+  and ca_country = 'United States'
+  and ca_state in ('MS', 'SC', 'IA')
+  and ss_net_profit between 50 and 250  
+     ))
+;
+
+--= query_14_a
+with  cross_items as
+ (select i_item_sk ss_item_sk
+ from item,
+ (select iss.i_brand_id brand_id
+     ,iss.i_class_id class_id
+     ,iss.i_category_id category_id
+ from store_sales
+     ,item iss
+     ,date_dim d1
+ where ss_item_sk = iss.i_item_sk
+   and ss_sold_date_sk = d1.d_date_sk
+   and d1.d_year between 1999 AND 1999 + 2
+ intersect 
+ select ics.i_brand_id
+     ,ics.i_class_id
+     ,ics.i_category_id
+ from catalog_sales
+     ,item ics
+     ,date_dim d2
+ where cs_item_sk = ics.i_item_sk
+   and cs_sold_date_sk = d2.d_date_sk
+   and d2.d_year between 1999 AND 1999 + 2
+ intersect
+ select iws.i_brand_id
+     ,iws.i_class_id
+     ,iws.i_category_id
+ from web_sales
+     ,item iws
+     ,date_dim d3
+ where ws_item_sk = iws.i_item_sk
+   and ws_sold_date_sk = d3.d_date_sk
+   and d3.d_year between 1999 AND 1999 + 2)
+ where i_brand_id = brand_id
+      and i_class_id = class_id
+      and i_category_id = category_id
+),
+ avg_sales as
+ (select avg(quantity*list_price) average_sales
+  from (select ss_quantity quantity
+             ,ss_list_price list_price
+       from store_sales
+           ,date_dim
+       where ss_sold_date_sk = d_date_sk
+         and d_year between 1999 and 1999 + 2
+       union all 
+       select cs_quantity quantity 
+             ,cs_list_price list_price
+       from catalog_sales
+           ,date_dim
+       where cs_sold_date_sk = d_date_sk
+         and d_year between 1999 and 1999 + 2 
+       union all
+       select ws_quantity quantity
+             ,ws_list_price list_price
+       from web_sales
+           ,date_dim
+       where ws_sold_date_sk = d_date_sk
+         and d_year between 1999 and 1999 + 2) x)
+  select  channel, i_brand_id,i_class_id,i_category_id,sum(sales), sum(number_sales)
+ from(
+       select 'store' channel, i_brand_id,i_class_id
+             ,i_category_id,sum(ss_quantity*ss_list_price) sales
+             , count(*) number_sales
+       from store_sales
+           ,item
+           ,date_dim
+       where ss_item_sk in (select ss_item_sk from cross_items)
+         and ss_item_sk = i_item_sk
+         and ss_sold_date_sk = d_date_sk
+         and d_year = 1999+2 
+         and d_moy = 11
+       group by i_brand_id,i_class_id,i_category_id
+       having sum(ss_quantity*ss_list_price) > (select average_sales from avg_sales)
+       union all
+       select 'catalog' channel, i_brand_id,i_class_id,i_category_id, sum(cs_quantity*cs_list_price) sales, count(*) number_sales
+       from catalog_sales
+           ,item
+           ,date_dim
+       where cs_item_sk in (select ss_item_sk from cross_items)
+         and cs_item_sk = i_item_sk
+         and cs_sold_date_sk = d_date_sk
+         and d_year = 1999+2 
+         and d_moy = 11
+       group by i_brand_id,i_class_id,i_category_id
+       having sum(cs_quantity*cs_list_price) > (select average_sales from avg_sales)
+       union all
+       select 'web' channel, i_brand_id,i_class_id,i_category_id, sum(ws_quantity*ws_list_price) sales , count(*) number_sales
+       from web_sales
+           ,item
+           ,date_dim
+       where ws_item_sk in (select ss_item_sk from cross_items)
+         and ws_item_sk = i_item_sk
+         and ws_sold_date_sk = d_date_sk
+         and d_year = 1999+2
+         and d_moy = 11
+       group by i_brand_id,i_class_id,i_category_id
+       having sum(ws_quantity*ws_list_price) > (select average_sales from avg_sales)
+ ) y
+ group by rollup (channel, i_brand_id,i_class_id,i_category_id)
+ order by channel,i_brand_id,i_class_id,i_category_id
+ limit 100
+;
+
+--= query_14_b
+with  cross_items as
+ (select i_item_sk ss_item_sk
+ from item,
+ (select iss.i_brand_id brand_id
+     ,iss.i_class_id class_id
+     ,iss.i_category_id category_id
+ from store_sales
+     ,item iss
+     ,date_dim d1
+ where ss_item_sk = iss.i_item_sk
+   and ss_sold_date_sk = d1.d_date_sk
+   and d1.d_year between 1999 AND 1999 + 2
+ intersect
+ select ics.i_brand_id
+     ,ics.i_class_id
+     ,ics.i_category_id
+ from catalog_sales
+     ,item ics
+     ,date_dim d2
+ where cs_item_sk = ics.i_item_sk
+   and cs_sold_date_sk = d2.d_date_sk
+   and d2.d_year between 1999 AND 1999 + 2
+ intersect
+ select iws.i_brand_id
+     ,iws.i_class_id
+     ,iws.i_category_id
+ from web_sales
+     ,item iws
+     ,date_dim d3
+ where ws_item_sk = iws.i_item_sk
+   and ws_sold_date_sk = d3.d_date_sk
+   and d3.d_year between 1999 AND 1999 + 2) x
+ where i_brand_id = brand_id
+      and i_class_id = class_id
+      and i_category_id = category_id
+),
+ avg_sales as
+(select avg(quantity*list_price) average_sales
+  from (select ss_quantity quantity
+             ,ss_list_price list_price
+       from store_sales
+           ,date_dim
+       where ss_sold_date_sk = d_date_sk
+         and d_year between 1999 and 1999 + 2
+       union all
+       select cs_quantity quantity
+             ,cs_list_price list_price
+       from catalog_sales
+           ,date_dim
+       where cs_sold_date_sk = d_date_sk
+         and d_year between 1999 and 1999 + 2
+       union all
+       select ws_quantity quantity
+             ,ws_list_price list_price
+       from web_sales
+           ,date_dim
+       where ws_sold_date_sk = d_date_sk
+         and d_year between 1999 and 1999 + 2) x)
+  select  this_year.channel ty_channel
+                           ,this_year.i_brand_id ty_brand
+                           ,this_year.i_class_id ty_class
+                           ,this_year.i_category_id ty_category
+                           ,this_year.sales ty_sales
+                           ,this_year.number_sales ty_number_sales
+                           ,last_year.channel ly_channel
+                           ,last_year.i_brand_id ly_brand
+                           ,last_year.i_class_id ly_class
+                           ,last_year.i_category_id ly_category
+                           ,last_year.sales ly_sales
+                           ,last_year.number_sales ly_number_sales 
+ from
+ (select 'store' channel, i_brand_id,i_class_id,i_category_id
+        ,sum(ss_quantity*ss_list_price) sales, count(*) number_sales
+ from store_sales 
+     ,item
+     ,date_dim
+ where ss_item_sk in (select ss_item_sk from cross_items)
+   and ss_item_sk = i_item_sk
+   and ss_sold_date_sk = d_date_sk
+   and d_week_seq = (select d_week_seq
+                     from date_dim
+                     where d_year = 1999 + 1
+                       and d_moy = 12
+                       and d_dom = 3)
+ group by i_brand_id,i_class_id,i_category_id
+ having sum(ss_quantity*ss_list_price) > (select average_sales from avg_sales)) this_year,
+ (select 'store' channel, i_brand_id,i_class_id
+        ,i_category_id, sum(ss_quantity*ss_list_price) sales, count(*) number_sales
+ from store_sales
+     ,item
+     ,date_dim
+ where ss_item_sk in (select ss_item_sk from cross_items)
+   and ss_item_sk = i_item_sk
+   and ss_sold_date_sk = d_date_sk
+   and d_week_seq = (select d_week_seq
+                     from date_dim
+                     where d_year = 1999
+                       and d_moy = 12
+                       and d_dom = 3)
+ group by i_brand_id,i_class_id,i_category_id
+ having sum(ss_quantity*ss_list_price) > (select average_sales from avg_sales)) last_year
+ where this_year.i_brand_id= last_year.i_brand_id
+   and this_year.i_class_id = last_year.i_class_id
+   and this_year.i_category_id = last_year.i_category_id
+ order by this_year.channel, this_year.i_brand_id, this_year.i_class_id, this_year.i_category_id
+ limit 100
+;
+
+--= query_15
+select  ca_zip
+       ,sum(cs_sales_price)
+ from catalog_sales
+     ,customer
+     ,customer_address
+     ,date_dim
+ where cs_bill_customer_sk = c_customer_sk
+ 	and c_current_addr_sk = ca_address_sk 
+ 	and ( substr(ca_zip,1,5) in ('85669', '86197','88274','83405','86475',
+                                   '85392', '85460', '80348', '81792')
+ 	      or ca_state in ('CA','WA','GA')
+ 	      or cs_sales_price > 500)
+ 	and cs_sold_date_sk = d_date_sk
+ 	and d_qoy = 2 and d_year = 2001
+ group by ca_zip
+ order by ca_zip
+ limit 100
+;
+
+--= query_16
+select  
+   count(distinct cs_order_number) as "order count"
+  ,sum(cs_ext_ship_cost) as "total shipping cost"
+  ,sum(cs_net_profit) as "total net profit"
+from
+   catalog_sales cs1
+  ,date_dim
+  ,customer_address
+  ,call_center
+where
+    d_date between '2002-4-01' and 
+           (cast('2002-05-31' as datetime))
+and cs1.cs_ship_date_sk = d_date_sk
+and cs1.cs_ship_addr_sk = ca_address_sk
+and ca_state = 'PA'
+and cs1.cs_call_center_sk = cc_call_center_sk
+and cc_county in ('Williamson County','Williamson County','Williamson County','Williamson County',
+                  'Williamson County'
+)
+and exists (select *
+            from catalog_sales cs2
+            where cs1.cs_order_number = cs2.cs_order_number
+              and cs1.cs_warehouse_sk <> cs2.cs_warehouse_sk)
+and not exists(select *
+               from catalog_returns cr1
+               where cs1.cs_order_number = cr1.cr_order_number)
+order by count(distinct cs_order_number)
+limit 100
+;
+
+--= query_17
+select  i_item_id
+       ,i_item_desc
+       ,s_state
+       ,count(ss_quantity) as store_sales_quantitycount
+       ,avg(ss_quantity) as store_sales_quantityave
+       ,stddev_samp(ss_quantity) as store_sales_quantitystdev
+       ,stddev_samp(ss_quantity)/avg(ss_quantity) as store_sales_quantitycov
+       ,count(sr_return_quantity) as store_returns_quantitycount
+       ,avg(sr_return_quantity) as store_returns_quantityave
+       ,stddev_samp(sr_return_quantity) as store_returns_quantitystdev
+       ,stddev_samp(sr_return_quantity)/avg(sr_return_quantity) as store_returns_quantitycov
+       ,count(cs_quantity) as catalog_sales_quantitycount ,avg(cs_quantity) as catalog_sales_quantityave
+       ,stddev_samp(cs_quantity) as catalog_sales_quantitystdev
+       ,stddev_samp(cs_quantity)/avg(cs_quantity) as catalog_sales_quantitycov
+ from store_sales
+     ,store_returns
+     ,catalog_sales
+     ,date_dim d1
+     ,date_dim d2
+     ,date_dim d3
+     ,store
+     ,item
+ where d1.d_quarter_name = '2001Q1'
+   and d1.d_date_sk = ss_sold_date_sk
+   and i_item_sk = ss_item_sk
+   and s_store_sk = ss_store_sk
+   and ss_customer_sk = sr_customer_sk
+   and ss_item_sk = sr_item_sk
+   and ss_ticket_number = sr_ticket_number
+   and sr_returned_date_sk = d2.d_date_sk
+   and d2.d_quarter_name in ('2001Q1','2001Q2','2001Q3')
+   and sr_customer_sk = cs_bill_customer_sk
+   and sr_item_sk = cs_item_sk
+   and cs_sold_date_sk = d3.d_date_sk
+   and d3.d_quarter_name in ('2001Q1','2001Q2','2001Q3')
+ group by i_item_id
+         ,i_item_desc
+         ,s_state
+ order by i_item_id
+         ,i_item_desc
+         ,s_state
+limit 100
+;
+
+--= query_18
+select  i_item_id,
+        ca_country,
+        ca_state, 
+        ca_county,
+        avg( cast(cs_quantity as decimal(12,2))) agg1,
+        avg( cast(cs_list_price as decimal(12,2))) agg2,
+        avg( cast(cs_coupon_amt as decimal(12,2))) agg3,
+        avg( cast(cs_sales_price as decimal(12,2))) agg4,
+        avg( cast(cs_net_profit as decimal(12,2))) agg5,
+        avg( cast(c_birth_year as decimal(12,2))) agg6,
+        avg( cast(cd1.cd_dep_count as decimal(12,2))) agg7
+ from catalog_sales, customer_demographics cd1, 
+      customer_demographics cd2, customer, customer_address, date_dim, item
+ where cs_sold_date_sk = d_date_sk and
+       cs_item_sk = i_item_sk and
+       cs_bill_cdemo_sk = cd1.cd_demo_sk and
+       cs_bill_customer_sk = c_customer_sk and
+       cd1.cd_gender = 'F' and 
+       cd1.cd_education_status = 'Primary' and
+       c_current_cdemo_sk = cd2.cd_demo_sk and
+       c_current_addr_sk = ca_address_sk and
+       c_birth_month in (1,3,7,11,10,4) and
+       d_year = 2001 and
+       ca_state in ('AL','MO','TN'
+                   ,'GA','MT','IN','CA')
+ group by rollup (i_item_id, ca_country, ca_state, ca_county)
+ order by ca_country,
+        ca_state, 
+        ca_county,
+	i_item_id
+ limit 100
+;
+
+--= query_19
+select  i_brand_id brand_id, i_brand brand, i_manufact_id, i_manufact,
+ 	sum(ss_ext_sales_price) ext_price
+ from date_dim, store_sales, item,customer,customer_address,store
+ where d_date_sk = ss_sold_date_sk
+   and ss_item_sk = i_item_sk
+   and i_manager_id=14
+   and d_moy=11
+   and d_year=2002
+   and ss_customer_sk = c_customer_sk 
+   and c_current_addr_sk = ca_address_sk
+   and substr(ca_zip,1,5) <> substr(s_zip,1,5) 
+   and ss_store_sk = s_store_sk 
+ group by i_brand
+      ,i_brand_id
+      ,i_manufact_id
+      ,i_manufact
+ order by ext_price desc
+         ,i_brand
+         ,i_brand_id
+         ,i_manufact_id
+         ,i_manufact
+limit 100
+;
+
+--= query_20
+select  i_item_id
+       ,i_item_desc 
+       ,i_category 
+       ,i_class 
+       ,i_current_price
+       ,sum(cs_ext_sales_price) as itemrevenue 
+       ,sum(cs_ext_sales_price)*100/sum(sum(cs_ext_sales_price)) over
+           (partition by i_class) as revenueratio
+ from	catalog_sales
+     ,item 
+     ,date_dim
+ where cs_item_sk = i_item_sk 
+   and i_category in ('Books', 'Music', 'Sports')
+   and cs_sold_date_sk = d_date_sk
+ and d_date between cast('2002-06-18' as datetime) 
+ 				and (cast('2002-07-18' as datetime))
+ group by i_item_id
+         ,i_item_desc 
+         ,i_category
+         ,i_class
+         ,i_current_price
+ order by i_category
+         ,i_class
+         ,i_item_id
+         ,i_item_desc
+         ,revenueratio
+limit 100
+;
+
+--= query_21
+select  *
+ from(select w_warehouse_name
+            ,i_item_id
+            ,sum(case when (cast(d_date as datetime) < cast ('1999-06-22' as datetime))
+	                then inv_quantity_on_hand 
+                      else 0 end) as inv_before
+            ,sum(case when (cast(d_date as datetime) >= cast ('1999-06-22' as datetime))
+                      then inv_quantity_on_hand 
+                      else 0 end) as inv_after
+   from inventory
+       ,warehouse
+       ,item
+       ,date_dim
+   where i_current_price between 0.99 and 1.49
+     and i_item_sk          = inv_item_sk
+     and inv_warehouse_sk   = w_warehouse_sk
+     and inv_date_sk    = d_date_sk
+     and d_date between (cast('1999-05-23' as datetime))
+                    and (cast('1999-07-22' as datetime))
+   group by w_warehouse_name, i_item_id) x
+ where (case when inv_before > 0 
+             then inv_after / inv_before 
+             else null
+             end) between 2.0/3.0 and 3.0/2.0
+ order by w_warehouse_name
+         ,i_item_id
+ limit 100
+;
+
+--= query_22
+select  i_product_name
+             ,i_brand
+             ,i_class
+             ,i_category
+             ,avg(inv_quantity_on_hand) qoh
+       from inventory
+           ,date_dim
+           ,item
+       where inv_date_sk=d_date_sk
+              and inv_item_sk=i_item_sk
+              and d_month_seq between 1200 and 1200 + 11
+       group by rollup(i_product_name
+                       ,i_brand
+                       ,i_class
+                       ,i_category)
+order by qoh, i_product_name, i_brand, i_class, i_category
+limit 100
+;
+
+--= query_23_a
+with frequent_ss_items as 
+ (select substr(i_item_desc,1,30) itemdesc,i_item_sk item_sk,d_date solddate,count(*) cnt
+  from store_sales
+      ,date_dim 
+      ,item
+  where ss_sold_date_sk = d_date_sk
+    and ss_item_sk = i_item_sk 
+    and d_year in (2000,2000+1,2000+2,2000+3)
+  group by substr(i_item_desc,1,30),i_item_sk,d_date
+  having count(*) >4),
+ max_store_sales as
+ (select max(csales) tpcds_cmax 
+  from (select c_customer_sk,sum(ss_quantity*ss_sales_price) csales
+        from store_sales
+            ,customer
+            ,date_dim 
+        where ss_customer_sk = c_customer_sk
+         and ss_sold_date_sk = d_date_sk
+         and d_year in (2000,2000+1,2000+2,2000+3) 
+        group by c_customer_sk)),
+ best_ss_customer as
+ (select c_customer_sk,sum(ss_quantity*ss_sales_price) ssales
+  from store_sales
+      ,customer
+  where ss_customer_sk = c_customer_sk
+  group by c_customer_sk
+  having sum(ss_quantity*ss_sales_price) > (95/100.0) * (select
+  *
+from
+ max_store_sales))
+  select  sum(sales)
+ from (select cs_quantity*cs_list_price sales
+       from catalog_sales
+           ,date_dim 
+       where d_year = 2000 
+         and d_moy = 7 
+         and cs_sold_date_sk = d_date_sk 
+         and cs_item_sk in (select item_sk from frequent_ss_items)
+         and cs_bill_customer_sk in (select c_customer_sk from best_ss_customer)
+      union all
+      select ws_quantity*ws_list_price sales
+       from web_sales 
+           ,date_dim 
+       where d_year = 2000 
+         and d_moy = 7 
+         and ws_sold_date_sk = d_date_sk 
+         and ws_item_sk in (select item_sk from frequent_ss_items)
+         and ws_bill_customer_sk in (select c_customer_sk from best_ss_customer)) 
+ limit 100
+;
+
+--= query_23_b
+with frequent_ss_items as
+ (select substr(i_item_desc,1,30) itemdesc,i_item_sk item_sk,d_date solddate,count(*) cnt
+  from store_sales
+      ,date_dim
+      ,item
+  where ss_sold_date_sk = d_date_sk
+    and ss_item_sk = i_item_sk
+    and d_year in (2000,2000 + 1,2000 + 2,2000 + 3)
+  group by substr(i_item_desc,1,30),i_item_sk,d_date
+  having count(*) >4),
+ max_store_sales as
+ (select max(csales) tpcds_cmax
+  from (select c_customer_sk,sum(ss_quantity*ss_sales_price) csales
+        from store_sales
+            ,customer
+            ,date_dim 
+        where ss_customer_sk = c_customer_sk
+         and ss_sold_date_sk = d_date_sk
+         and d_year in (2000,2000+1,2000+2,2000+3)
+        group by c_customer_sk)),
+ best_ss_customer as
+ (select c_customer_sk,sum(ss_quantity*ss_sales_price) ssales
+  from store_sales
+      ,customer
+  where ss_customer_sk = c_customer_sk
+  group by c_customer_sk
+  having sum(ss_quantity*ss_sales_price) > (95/100.0) * (select
+  *
+ from max_store_sales))
+  select  c_last_name,c_first_name,sales
+ from (select c_last_name,c_first_name,sum(cs_quantity*cs_list_price) sales
+        from catalog_sales
+            ,customer
+            ,date_dim 
+        where d_year = 2000 
+         and d_moy = 7 
+         and cs_sold_date_sk = d_date_sk 
+         and cs_item_sk in (select item_sk from frequent_ss_items)
+         and cs_bill_customer_sk in (select c_customer_sk from best_ss_customer)
+         and cs_bill_customer_sk = c_customer_sk 
+       group by c_last_name,c_first_name
+      union all
+      select c_last_name,c_first_name,sum(ws_quantity*ws_list_price) sales
+       from web_sales
+           ,customer
+           ,date_dim 
+       where d_year = 2000 
+         and d_moy = 7 
+         and ws_sold_date_sk = d_date_sk 
+         and ws_item_sk in (select item_sk from frequent_ss_items)
+         and ws_bill_customer_sk in (select c_customer_sk from best_ss_customer)
+         and ws_bill_customer_sk = c_customer_sk
+       group by c_last_name,c_first_name) 
+     order by c_last_name,c_first_name,sales
+  limit 100
+;
+
+--= query_24_a
+with ssales as
+(select c_last_name
+      ,c_first_name
+      ,s_store_name
+      ,ca_state
+      ,s_state
+      ,i_color
+      ,i_current_price
+      ,i_manager_id
+      ,i_units
+      ,i_size
+      ,sum(ss_net_paid) netpaid
+from store_sales
+    ,store_returns
+    ,store
+    ,item
+    ,customer
+    ,customer_address
+where ss_ticket_number = sr_ticket_number
+  and ss_item_sk = sr_item_sk
+  and ss_customer_sk = c_customer_sk
+  and ss_item_sk = i_item_sk
+  and ss_store_sk = s_store_sk
+  and c_current_addr_sk = ca_address_sk
+  and c_birth_country <> upper(ca_country)
+  and s_zip = ca_zip
+and s_market_id=5
+group by c_last_name
+        ,c_first_name
+        ,s_store_name
+        ,ca_state
+        ,s_state
+        ,i_color
+        ,i_current_price
+        ,i_manager_id
+        ,i_units
+        ,i_size)
+select c_last_name
+      ,c_first_name
+      ,s_store_name
+      ,sum(netpaid) paid
+from ssales
+where i_color = 'aquamarine'
+group by c_last_name
+        ,c_first_name
+        ,s_store_name
+having sum(netpaid) > (select 0.05*avg(netpaid)
+                                 from ssales)
+order by c_last_name
+        ,c_first_name
+        ,s_store_name
+;
+
+--= query_24_b
+with ssales as
+(select c_last_name
+      ,c_first_name
+      ,s_store_name
+      ,ca_state
+      ,s_state
+      ,i_color
+      ,i_current_price
+      ,i_manager_id
+      ,i_units
+      ,i_size
+      ,sum(ss_net_paid) netpaid
+from store_sales
+    ,store_returns
+    ,store
+    ,item
+    ,customer
+    ,customer_address
+where ss_ticket_number = sr_ticket_number
+  and ss_item_sk = sr_item_sk
+  and ss_customer_sk = c_customer_sk
+  and ss_item_sk = i_item_sk
+  and ss_store_sk = s_store_sk
+  and c_current_addr_sk = ca_address_sk
+  and c_birth_country <> upper(ca_country)
+  and s_zip = ca_zip
+  and s_market_id = 5
+group by c_last_name
+        ,c_first_name
+        ,s_store_name
+        ,ca_state
+        ,s_state
+        ,i_color
+        ,i_current_price
+        ,i_manager_id
+        ,i_units
+        ,i_size)
+select c_last_name
+      ,c_first_name
+      ,s_store_name
+      ,sum(netpaid) paid
+from ssales
+where i_color = 'seashell'
+group by c_last_name
+        ,c_first_name
+        ,s_store_name
+having sum(netpaid) > (select 0.05*avg(netpaid)
+                           from ssales)
+order by c_last_name
+        ,c_first_name
+        ,s_store_name
+;
+
+--= query_25
+select  
+ i_item_id
+ ,i_item_desc
+ ,s_store_id
+ ,s_store_name
+ ,max(ss_net_profit) as store_sales_profit
+ ,max(sr_net_loss) as store_returns_loss
+ ,max(cs_net_profit) as catalog_sales_profit
+ from
+ store_sales
+ ,store_returns
+ ,catalog_sales
+ ,date_dim d1
+ ,date_dim d2
+ ,date_dim d3
+ ,store
+ ,item
+ where
+ d1.d_moy = 4
+ and d1.d_year = 1999
+ and d1.d_date_sk = ss_sold_date_sk
+ and i_item_sk = ss_item_sk
+ and s_store_sk = ss_store_sk
+ and ss_customer_sk = sr_customer_sk
+ and ss_item_sk = sr_item_sk
+ and ss_ticket_number = sr_ticket_number
+ and sr_returned_date_sk = d2.d_date_sk
+ and d2.d_moy               between 4 and  10
+ and d2.d_year              = 1999
+ and sr_customer_sk = cs_bill_customer_sk
+ and sr_item_sk = cs_item_sk
+ and cs_sold_date_sk = d3.d_date_sk
+ and d3.d_moy               between 4 and  10 
+ and d3.d_year              = 1999
+ group by
+ i_item_id
+ ,i_item_desc
+ ,s_store_id
+ ,s_store_name
+ order by
+ i_item_id
+ ,i_item_desc
+ ,s_store_id
+ ,s_store_name
+ limit 100
+;
+
+--= query_26
+select  i_item_id, 
+        avg(cs_quantity) agg1,
+        avg(cs_list_price) agg2,
+        avg(cs_coupon_amt) agg3,
+        avg(cs_sales_price) agg4 
+ from catalog_sales, customer_demographics, date_dim, item, promotion
+ where cs_sold_date_sk = d_date_sk and
+       cs_item_sk = i_item_sk and
+       cs_bill_cdemo_sk = cd_demo_sk and
+       cs_promo_sk = p_promo_sk and
+       cd_gender = 'M' and 
+       cd_marital_status = 'W' and
+       cd_education_status = 'Unknown' and
+       (p_channel_email = 'N' or p_channel_event = 'N') and
+       d_year = 2002 
+ group by i_item_id
+ order by i_item_id
+ limit 100
+;
+
+--= query_27
+select  i_item_id,
+        s_state, grouping(s_state) g_state,
+        avg(ss_quantity) agg1,
+        avg(ss_list_price) agg2,
+        avg(ss_coupon_amt) agg3,
+        avg(ss_sales_price) agg4
+ from store_sales, customer_demographics, date_dim, store, item
+ where ss_sold_date_sk = d_date_sk and
+       ss_item_sk = i_item_sk and
+       ss_store_sk = s_store_sk and
+       ss_cdemo_sk = cd_demo_sk and
+       cd_gender = 'M' and
+       cd_marital_status = 'W' and
+       cd_education_status = 'Secondary' and
+       d_year = 1999 and
+       s_state in ('TN','TN', 'TN', 'TN', 'TN', 'TN')
+ group by rollup (i_item_id, s_state)
+ order by i_item_id
+         ,s_state
+ limit 100
+;
+
+--= query_28
+select  *
+from (select avg(ss_list_price) B1_LP
+            ,count(ss_list_price) B1_CNT
+            ,count(distinct ss_list_price) B1_CNTD
+      from store_sales
+      where ss_quantity between 0 and 5
+        and (ss_list_price between 107 and 107+10 
+             or ss_coupon_amt between 1319 and 1319+1000
+             or ss_wholesale_cost between 60 and 60+20)) B1,
+     (select avg(ss_list_price) B2_LP
+            ,count(ss_list_price) B2_CNT
+            ,count(distinct ss_list_price) B2_CNTD
+      from store_sales
+      where ss_quantity between 6 and 10
+        and (ss_list_price between 23 and 23+10
+          or ss_coupon_amt between 825 and 825+1000
+          or ss_wholesale_cost between 43 and 43+20)) B2,
+     (select avg(ss_list_price) B3_LP
+            ,count(ss_list_price) B3_CNT
+            ,count(distinct ss_list_price) B3_CNTD
+      from store_sales
+      where ss_quantity between 11 and 15
+        and (ss_list_price between 74 and 74+10
+          or ss_coupon_amt between 4381 and 4381+1000
+          or ss_wholesale_cost between 57 and 57+20)) B3,
+     (select avg(ss_list_price) B4_LP
+            ,count(ss_list_price) B4_CNT
+            ,count(distinct ss_list_price) B4_CNTD
+      from store_sales
+      where ss_quantity between 16 and 20
+        and (ss_list_price between 89 and 89+10
+          or ss_coupon_amt between 3117 and 3117+1000
+          or ss_wholesale_cost between 68 and 68+20)) B4,
+     (select avg(ss_list_price) B5_LP
+            ,count(ss_list_price) B5_CNT
+            ,count(distinct ss_list_price) B5_CNTD
+      from store_sales
+      where ss_quantity between 21 and 25
+        and (ss_list_price between 58 and 58+10
+          or ss_coupon_amt between 9402 and 9402+1000
+          or ss_wholesale_cost between 38 and 38+20)) B5,
+     (select avg(ss_list_price) B6_LP
+            ,count(ss_list_price) B6_CNT
+            ,count(distinct ss_list_price) B6_CNTD
+      from store_sales
+      where ss_quantity between 26 and 30
+        and (ss_list_price between 64 and 64+10
+          or ss_coupon_amt between 5792 and 5792+1000
+          or ss_wholesale_cost between 73 and 73+20)) B6
+limit 100
+;
+
+--= query_29
+select   
+     i_item_id
+    ,i_item_desc
+    ,s_store_id
+    ,s_store_name
+    ,max(ss_quantity)        as store_sales_quantity
+    ,max(sr_return_quantity) as store_returns_quantity
+    ,max(cs_quantity)        as catalog_sales_quantity
+ from
+    store_sales
+   ,store_returns
+   ,catalog_sales
+   ,date_dim             d1
+   ,date_dim             d2
+   ,date_dim             d3
+   ,store
+   ,item
+ where
+     d1.d_moy               = 4 
+ and d1.d_year              = 1998
+ and d1.d_date_sk           = ss_sold_date_sk
+ and i_item_sk              = ss_item_sk
+ and s_store_sk             = ss_store_sk
+ and ss_customer_sk         = sr_customer_sk
+ and ss_item_sk             = sr_item_sk
+ and ss_ticket_number       = sr_ticket_number
+ and sr_returned_date_sk    = d2.d_date_sk
+ and d2.d_moy               between 4 and  4 + 3 
+ and d2.d_year              = 1998
+ and sr_customer_sk         = cs_bill_customer_sk
+ and sr_item_sk             = cs_item_sk
+ and cs_sold_date_sk        = d3.d_date_sk     
+ and d3.d_year              in (1998,1998+1,1998+2)
+ group by
+    i_item_id
+   ,i_item_desc
+   ,s_store_id
+   ,s_store_name
+ order by
+    i_item_id 
+   ,i_item_desc
+   ,s_store_id
+   ,s_store_name
+ limit 100
+;
+
+--= query_30
+with customer_total_return as
+ (select wr_returning_customer_sk as ctr_customer_sk
+        ,ca_state as ctr_state, 
+ 	sum(wr_return_amt) as ctr_total_return
+ from web_returns
+     ,date_dim
+     ,customer_address
+ where wr_returned_date_sk = d_date_sk 
+   and d_year =2000
+   and wr_returning_addr_sk = ca_address_sk 
+ group by wr_returning_customer_sk
+         ,ca_state)
+,ctr_state_avg as (select ctr_state, avg(ctr_total_return)*1.2 as ctr_avg from customer_total_return group by ctr_state)
+  select  c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag
+       ,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address
+       ,c_last_review_date,ctr_total_return
+ from customer_total_return ctr1
+     ,customer_address
+     ,customer
+     ,ctr_state_avg
+ where ctr1.ctr_total_return > ctr_state_avg.ctr_avg
+ 			  and ctr_state_avg.ctr_state = ctr1.ctr_state
+       and ca_address_sk = c_current_addr_sk
+       and ca_state = 'AR'
+       and ctr1.ctr_customer_sk = c_customer_sk
+ order by c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag
+                  ,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address
+                  ,c_last_review_date,ctr_total_return
+limit 100
+;
+
+--= query_31
+with ss as
+ (select ca_county,d_qoy, d_year,sum(ss_ext_sales_price) as store_sales
+ from store_sales,date_dim,customer_address
+ where ss_sold_date_sk = d_date_sk
+  and ss_addr_sk=ca_address_sk
+ group by ca_county,d_qoy, d_year),
+ ws as
+ (select ca_county,d_qoy, d_year,sum(ws_ext_sales_price) as web_sales
+ from web_sales,date_dim,customer_address
+ where ws_sold_date_sk = d_date_sk
+  and ws_bill_addr_sk=ca_address_sk
+ group by ca_county,d_qoy, d_year)
+ select 
+        ss1.ca_county
+       ,ss1.d_year
+       ,ws2.web_sales/ws1.web_sales web_q1_q2_increase
+       ,ss2.store_sales/ss1.store_sales store_q1_q2_increase
+       ,ws3.web_sales/ws2.web_sales web_q2_q3_increase
+       ,ss3.store_sales/ss2.store_sales store_q2_q3_increase
+ from
+        ss ss1
+       ,ss ss2
+       ,ss ss3
+       ,ws ws1
+       ,ws ws2
+       ,ws ws3
+ where
+    ss1.d_qoy = 1
+    and ss1.d_year = 1999
+    and ss1.ca_county = ss2.ca_county
+    and ss2.d_qoy = 2
+    and ss2.d_year = 1999
+ and ss2.ca_county = ss3.ca_county
+    and ss3.d_qoy = 3
+    and ss3.d_year = 1999
+    and ss1.ca_county = ws1.ca_county
+    and ws1.d_qoy = 1
+    and ws1.d_year = 1999
+    and ws1.ca_county = ws2.ca_county
+    and ws2.d_qoy = 2
+    and ws2.d_year = 1999
+    and ws1.ca_county = ws3.ca_county
+    and ws3.d_qoy = 3
+    and ws3.d_year =1999
+    and case when ws1.web_sales > 0 then ws2.web_sales/ws1.web_sales else null end 
+       > case when ss1.store_sales > 0 then ss2.store_sales/ss1.store_sales else null end
+    and case when ws2.web_sales > 0 then ws3.web_sales/ws2.web_sales else null end
+       > case when ss2.store_sales > 0 then ss3.store_sales/ss2.store_sales else null end
+ order by store_q2_q3_increase
+;
+
+--= query_32
+select  sum(cs_ext_discount_amt)  as "excess discount amount" 
+from 
+   catalog_sales 
+   ,item 
+   ,date_dim
+where
+i_manufact_id = 722
+and i_item_sk = cs_item_sk 
+and d_date between '2001-03-09' and 
+        (cast('2001-06-07' as datetime))
+and d_date_sk = cs_sold_date_sk 
+and cs_ext_discount_amt  
+     > ( 
+         select 
+            1.3 * avg(cs_ext_discount_amt) 
+         from 
+            catalog_sales 
+           ,date_dim
+         where 
+              cs_item_sk = i_item_sk 
+          and d_date between '2001-03-09' and
+                             (cast('2001-06-07' as datetime))
+          and d_date_sk = cs_sold_date_sk 
+      ) 
+limit 100
+;
+
+--= query_33
+with ss as (
+ select
+          i_manufact_id,sum(ss_ext_sales_price) total_sales
+ from
+ 	store_sales,
+ 	date_dim,
+         customer_address,
+         item
+ where
+         i_manufact_id in (select
+  i_manufact_id
+from
+ item
+where i_category in ('Books'))
+ and     ss_item_sk              = i_item_sk
+ and     ss_sold_date_sk         = d_date_sk
+ and     d_year                  = 2001
+ and     d_moy                   = 3
+ and     ss_addr_sk              = ca_address_sk
+ and     ca_gmt_offset           = -5 
+ group by i_manufact_id),
+ cs as (
+ select
+          i_manufact_id,sum(cs_ext_sales_price) total_sales
+ from
+ 	catalog_sales,
+ 	date_dim,
+         customer_address,
+         item
+ where
+         i_manufact_id               in (select
+  i_manufact_id
+from
+ item
+where i_category in ('Books'))
+ and     cs_item_sk              = i_item_sk
+ and     cs_sold_date_sk         = d_date_sk
+ and     d_year                  = 2001
+ and     d_moy                   = 3
+ and     cs_bill_addr_sk         = ca_address_sk
+ and     ca_gmt_offset           = -5 
+ group by i_manufact_id),
+ ws as (
+ select
+          i_manufact_id,sum(ws_ext_sales_price) total_sales
+ from
+ 	web_sales,
+ 	date_dim,
+         customer_address,
+         item
+ where
+         i_manufact_id               in (select
+  i_manufact_id
+from
+ item
+where i_category in ('Books'))
+ and     ws_item_sk              = i_item_sk
+ and     ws_sold_date_sk         = d_date_sk
+ and     d_year                  = 2001
+ and     d_moy                   = 3
+ and     ws_bill_addr_sk         = ca_address_sk
+ and     ca_gmt_offset           = -5
+ group by i_manufact_id)
+  select  i_manufact_id ,sum(total_sales) total_sales
+ from  (select * from ss 
+        union all
+        select * from cs 
+        union all
+        select * from ws) tmp1
+ group by i_manufact_id
+ order by total_sales
+limit 100
+;
+
+--= query_34
+select c_last_name
+       ,c_first_name
+       ,c_salutation
+       ,c_preferred_cust_flag
+       ,ss_ticket_number
+       ,cnt from
+   (select ss_ticket_number
+          ,ss_customer_sk
+          ,count(*) cnt
+    from store_sales,date_dim,store,household_demographics
+    where store_sales.ss_sold_date_sk = date_dim.d_date_sk
+    and store_sales.ss_store_sk = store.s_store_sk  
+    and store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk
+    and (date_dim.d_dom between 1 and 3 or date_dim.d_dom between 25 and 28)
+    and (household_demographics.hd_buy_potential = '1001-5000' or
+         household_demographics.hd_buy_potential = '0-500')
+    and household_demographics.hd_vehicle_count > 0
+    and (case when household_demographics.hd_vehicle_count > 0 
+	then household_demographics.hd_dep_count/ household_demographics.hd_vehicle_count 
+	else null 
+	end)  > 1.2
+    and date_dim.d_year in (2000,2000+1,2000+2)
+    and store.s_county in ('Williamson County','Williamson County','Williamson County','Williamson County',
+                           'Williamson County','Williamson County','Williamson County','Williamson County')
+    group by ss_ticket_number,ss_customer_sk) dn,customer
+    where ss_customer_sk = c_customer_sk
+      and cnt between 15 and 20
+    order by c_last_name,c_first_name,c_salutation,c_preferred_cust_flag desc, ss_ticket_number
+;
+
+--= query_35
+select   
+  ca_state,
+  cd_gender,
+  cd_marital_status,
+  cd_dep_count,
+  count(*) cnt1,
+  avg(cd_dep_count) aggone1,
+  stddev_samp(cd_dep_count) aggtwo1,
+  sum(cd_dep_count) aggthree1,
+  cd_dep_employed_count,
+  count(*) cnt2,
+  avg(cd_dep_employed_count) aggone2,
+  stddev_samp(cd_dep_employed_count) aggtwo2,
+  sum(cd_dep_employed_count) aggthree2,
+  cd_dep_college_count,
+  count(*) cnt3,
+  avg(cd_dep_college_count) aggone3,
+  stddev_samp(cd_dep_college_count) aggtwo3,
+  sum(cd_dep_college_count) aggthree3
+ from
+  customer c,customer_address ca,customer_demographics
+ where
+  c.c_current_addr_sk = ca.ca_address_sk and
+  cd_demo_sk = c.c_current_cdemo_sk and 
+  exists (select *
+          from store_sales,date_dim
+          where c.c_customer_sk = ss_customer_sk and
+                ss_sold_date_sk = d_date_sk and
+                d_year = 1999 and
+                d_qoy < 4) and
+   (exists (select *
+            from web_sales,date_dim
+            where c.c_customer_sk = ws_bill_customer_sk and
+                  ws_sold_date_sk = d_date_sk and
+                  d_year = 1999 and
+                  d_qoy < 4) or 
+    exists (select * 
+            from catalog_sales,date_dim
+            where c.c_customer_sk = cs_ship_customer_sk and
+                  cs_sold_date_sk = d_date_sk and
+                  d_year = 1999 and
+                  d_qoy < 4))
+ group by ca_state,
+          cd_gender,
+          cd_marital_status,
+          cd_dep_count,
+          cd_dep_employed_count,
+          cd_dep_college_count
+ order by ca_state,
+          cd_gender,
+          cd_marital_status,
+          cd_dep_count,
+          cd_dep_employed_count,
+          cd_dep_college_count
+ limit 100
+;
+
+--= query_37
+select  i_item_id
+       ,i_item_desc
+       ,i_current_price
+ from item, inventory, date_dim, catalog_sales
+ where i_current_price between 29 and 29 + 30
+ and inv_item_sk = i_item_sk
+ and d_date_sk=inv_date_sk
+ and d_date between cast('2002-03-29' as datetime) and (cast('2002-05-28' as datetime))
+ and i_manufact_id in (705,742,777,944)
+ and inv_quantity_on_hand between 100 and 500
+ and cs_item_sk = i_item_sk
+ group by i_item_id,i_item_desc,i_current_price
+ order by i_item_id
+ limit 100
+;
+
+--= query_38
+select  count(*) from (
+    select distinct c_last_name, c_first_name, d_date
+    from store_sales, date_dim, customer
+          where store_sales.ss_sold_date_sk = date_dim.d_date_sk
+      and store_sales.ss_customer_sk = customer.c_customer_sk
+      and d_month_seq between 1189 and 1189 + 11
+  intersect
+    select distinct c_last_name, c_first_name, d_date
+    from catalog_sales, date_dim, customer
+          where catalog_sales.cs_sold_date_sk = date_dim.d_date_sk
+      and catalog_sales.cs_bill_customer_sk = customer.c_customer_sk
+      and d_month_seq between 1189 and 1189 + 11
+  intersect
+    select distinct c_last_name, c_first_name, d_date
+    from web_sales, date_dim, customer
+          where web_sales.ws_sold_date_sk = date_dim.d_date_sk
+      and web_sales.ws_bill_customer_sk = customer.c_customer_sk
+      and d_month_seq between 1189 and 1189 + 11
+) hot_cust
+limit 100
+;
+
+--= query_39_a
+with inv as
+(select w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy
+       ,stdev,mean, case mean when 0 then null else stdev/mean end cov
+ from(select w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy
+            ,stddev_samp(inv_quantity_on_hand) stdev,avg(inv_quantity_on_hand) mean
+      from inventory
+          ,item
+          ,warehouse
+          ,date_dim
+      where inv_item_sk = i_item_sk
+        and inv_warehouse_sk = w_warehouse_sk
+        and inv_date_sk = d_date_sk
+        and d_year =2000
+      group by w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy) foo
+ where case mean when 0 then 0 else stdev/mean end > 1)
+select inv1.w_warehouse_sk,inv1.i_item_sk,inv1.d_moy,inv1.mean, inv1.cov
+        ,inv2.w_warehouse_sk,inv2.i_item_sk,inv2.d_moy,inv2.mean, inv2.cov
+from inv inv1,inv inv2
+where inv1.i_item_sk = inv2.i_item_sk
+  and inv1.w_warehouse_sk =  inv2.w_warehouse_sk
+  and inv1.d_moy=1
+  and inv2.d_moy=1+1
+order by inv1.w_warehouse_sk,inv1.i_item_sk,inv1.d_moy,inv1.mean,inv1.cov
+        ,inv2.d_moy,inv2.mean, inv2.cov
+;
+
+--= query_39_b
+with inv as
+(select w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy
+       ,stdev,mean, case mean when 0 then null else stdev/mean end cov
+ from(select w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy
+            ,stddev_samp(inv_quantity_on_hand) stdev,avg(inv_quantity_on_hand) mean
+      from inventory
+          ,item
+          ,warehouse
+          ,date_dim
+      where inv_item_sk = i_item_sk
+        and inv_warehouse_sk = w_warehouse_sk
+        and inv_date_sk = d_date_sk
+        and d_year =2000
+      group by w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy) foo
+ where case mean when 0 then 0 else stdev/mean end > 1)
+select inv1.w_warehouse_sk,inv1.i_item_sk,inv1.d_moy,inv1.mean, inv1.cov
+        ,inv2.w_warehouse_sk,inv2.i_item_sk,inv2.d_moy,inv2.mean, inv2.cov
+from inv inv1,inv inv2
+where inv1.i_item_sk = inv2.i_item_sk
+  and inv1.w_warehouse_sk =  inv2.w_warehouse_sk
+  and inv1.d_moy=1
+  and inv2.d_moy=1+1
+  and inv1.cov > 1.5
+order by inv1.w_warehouse_sk,inv1.i_item_sk,inv1.d_moy,inv1.mean,inv1.cov
+        ,inv2.d_moy,inv2.mean, inv2.cov
+;
+
+--= query_40
+select  
+   w_state
+  ,i_item_id
+  ,sum(case when (cast(d_date as datetime) < cast ('2001-05-02' as datetime)) 
+ 		then cs_sales_price - coalesce(cr_refunded_cash,0) else 0 end) as sales_before
+  ,sum(case when (cast(d_date as datetime) >= cast ('2001-05-02' as datetime)) 
+ 		then cs_sales_price - coalesce(cr_refunded_cash,0) else 0 end) as sales_after
+ from
+   catalog_sales left outer join catalog_returns on
+       (cs_order_number = cr_order_number 
+        and cs_item_sk = cr_item_sk)
+  ,warehouse 
+  ,item
+  ,date_dim
+ where
+     i_current_price between 0.99 and 1.49
+ and i_item_sk          = cs_item_sk
+ and cs_warehouse_sk    = w_warehouse_sk 
+ and cs_sold_date_sk    = d_date_sk
+ and d_date between (cast('2001-04-02' as datetime))
+                and (cast('2001-06-01' as datetime)) 
+ group by
+    w_state,i_item_id
+ order by w_state,i_item_id
+limit 100
+;
+
+--= query_41
+select  distinct(i_product_name)
+ from item i1
+ where i_manufact_id between 704 and 704+40 
+   and (select count(*) as item_cnt
+        from item
+        where (i_manufact = i1.i_manufact and
+        ((i_category = 'Women' and 
+        (i_color = 'forest' or i_color = 'lime') and 
+        (i_units = 'Pallet' or i_units = 'Pound') and
+        (i_size = 'economy' or i_size = 'small')
+        ) or
+        (i_category = 'Women' and
+        (i_color = 'navy' or i_color = 'slate') and
+        (i_units = 'Gross' or i_units = 'Bunch') and
+        (i_size = 'extra large' or i_size = 'petite')
+        ) or
+        (i_category = 'Men' and
+        (i_color = 'powder' or i_color = 'sky') and
+        (i_units = 'Dozen' or i_units = 'Lb') and
+        (i_size = 'N/A' or i_size = 'large')
+        ) or
+        (i_category = 'Men' and
+        (i_color = 'maroon' or i_color = 'smoke') and
+        (i_units = 'Ounce' or i_units = 'Case') and
+        (i_size = 'economy' or i_size = 'small')
+        ))) or
+       (i_manufact = i1.i_manufact and
+        ((i_category = 'Women' and 
+        (i_color = 'dark' or i_color = 'aquamarine') and 
+        (i_units = 'Ton' or i_units = 'Tbl') and
+        (i_size = 'economy' or i_size = 'small')
+        ) or
+        (i_category = 'Women' and
+        (i_color = 'frosted' or i_color = 'plum') and
+        (i_units = 'Dram' or i_units = 'Box') and
+        (i_size = 'extra large' or i_size = 'petite')
+        ) or
+        (i_category = 'Men' and
+        (i_color = 'papaya' or i_color = 'peach') and
+        (i_units = 'Bundle' or i_units = 'Carton') and
+        (i_size = 'N/A' or i_size = 'large')
+        ) or
+        (i_category = 'Men' and
+        (i_color = 'firebrick' or i_color = 'sienna') and
+        (i_units = 'Cup' or i_units = 'Each') and
+        (i_size = 'economy' or i_size = 'small')
+        )))) > 0
+ order by i_product_name
+ limit 100
+;
+
+--= query_42
+select  dt.d_year
+ 	,item.i_category_id
+ 	,item.i_category
+ 	,sum(ss_ext_sales_price)
+ from 	date_dim dt
+ 	,store_sales
+ 	,item
+ where dt.d_date_sk = store_sales.ss_sold_date_sk
+ 	and store_sales.ss_item_sk = item.i_item_sk
+ 	and item.i_manager_id = 1  	
+ 	and dt.d_moy=11
+ 	and dt.d_year=1998
+ group by 	dt.d_year
+ 		,item.i_category_id
+ 		,item.i_category
+ order by       sum(ss_ext_sales_price) desc,dt.d_year
+ 		,item.i_category_id
+ 		,item.i_category
+limit 100
+;
+
+--= query_43
+select  s_store_name, s_store_id,
+        sum(case when (d_day_name='Sunday') then ss_sales_price else null end) sun_sales,
+        sum(case when (d_day_name='Monday') then ss_sales_price else null end) mon_sales,
+        sum(case when (d_day_name='Tuesday') then ss_sales_price else  null end) tue_sales,
+        sum(case when (d_day_name='Wednesday') then ss_sales_price else null end) wed_sales,
+        sum(case when (d_day_name='Thursday') then ss_sales_price else null end) thu_sales,
+        sum(case when (d_day_name='Friday') then ss_sales_price else null end) fri_sales,
+        sum(case when (d_day_name='Saturday') then ss_sales_price else null end) sat_sales
+ from date_dim, store_sales, store
+ where d_date_sk = ss_sold_date_sk and
+       s_store_sk = ss_store_sk and
+       s_gmt_offset = -5 and
+       d_year = 2000 
+ group by s_store_name, s_store_id
+ order by s_store_name, s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales
+ limit 100
+;
+
+--= query_45
+select  ca_zip, ca_city, sum(ws_sales_price)
+ from web_sales, customer, customer_address, date_dim, item
+ where ws_bill_customer_sk = c_customer_sk
+ 	and c_current_addr_sk = ca_address_sk 
+ 	and ws_item_sk = i_item_sk 
+ 	and ( substr(ca_zip,1,5) in ('85669', '86197','88274','83405','86475', '85392', '85460', '80348', '81792')
+ 	      or 
+ 	      i_item_id in (select i_item_id
+                             from item
+                             where i_item_sk in (2, 3, 5, 7, 11, 13, 17, 19, 23, 29)
+                             )
+ 	    )
+ 	and ws_sold_date_sk = d_date_sk
+ 	and d_qoy = 1 and d_year = 2000
+ group by ca_zip, ca_city
+ order by ca_zip, ca_city
+ limit 100
+;
+
+--= query_46
+select  c_last_name
+       ,c_first_name
+       ,ca_city
+       ,bought_city
+       ,ss_ticket_number
+       ,amt,profit 
+ from
+   (select ss_ticket_number
+          ,ss_customer_sk
+          ,ca_city bought_city
+          ,sum(ss_coupon_amt) amt
+          ,sum(ss_net_profit) profit
+    from store_sales,date_dim,store,household_demographics,customer_address 
+    where store_sales.ss_sold_date_sk = date_dim.d_date_sk
+    and store_sales.ss_store_sk = store.s_store_sk  
+    and store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk
+    and store_sales.ss_addr_sk = customer_address.ca_address_sk
+    and (household_demographics.hd_dep_count = 8 or
+         household_demographics.hd_vehicle_count= 0)
+    and date_dim.d_dow in (6,0)
+    and date_dim.d_year in (2000,2000+1,2000+2) 
+    and store.s_city in ('Midway','Fairview','Fairview','Midway','Fairview') 
+    group by ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city) dn,customer,customer_address current_addr
+    where ss_customer_sk = c_customer_sk
+      and customer.c_current_addr_sk = current_addr.ca_address_sk
+      and current_addr.ca_city <> bought_city
+  order by c_last_name
+          ,c_first_name
+          ,ca_city
+          ,bought_city
+          ,ss_ticket_number
+  limit 100
+;
+
+--= query_48
+select sum (ss_quantity)
+ from store_sales, store, customer_demographics, customer_address, date_dim
+ where s_store_sk = ss_store_sk
+ and  ss_sold_date_sk = d_date_sk and d_year = 2001
+ and  
+ (
+  (
+   cd_demo_sk = ss_cdemo_sk
+   and 
+   cd_marital_status = 'S'
+   and 
+   cd_education_status = 'Secondary'
+   and 
+   ss_sales_price between 100.00 and 150.00  
+   )
+ or
+  (
+  cd_demo_sk = ss_cdemo_sk
+   and 
+   cd_marital_status = 'M'
+   and 
+   cd_education_status = '2 yr Degree'
+   and 
+   ss_sales_price between 50.00 and 100.00   
+  )
+ or 
+ (
+  cd_demo_sk = ss_cdemo_sk
+  and 
+   cd_marital_status = 'D'
+   and 
+   cd_education_status = 'Advanced Degree'
+   and 
+   ss_sales_price between 150.00 and 200.00  
+ )
+ )
+ and
+ (
+  (
+  ss_addr_sk = ca_address_sk
+  and
+  ca_country = 'United States'
+  and
+  ca_state in ('ND', 'NY', 'SD')
+  and ss_net_profit between 0 and 2000  
+  )
+ or
+  (ss_addr_sk = ca_address_sk
+  and
+  ca_country = 'United States'
+  and
+  ca_state in ('MD', 'GA', 'KS')
+  and ss_net_profit between 150 and 3000 
+  )
+ or
+  (ss_addr_sk = ca_address_sk
+  and
+  ca_country = 'United States'
+  and
+  ca_state in ('CO', 'MN', 'NC')
+  and ss_net_profit between 50 and 25000 
+  )
+ )
+;
+
+--= query_50
+select  
+   s_store_name
+  ,s_company_id
+  ,s_street_number
+  ,s_street_name
+  ,s_street_type
+  ,s_suite_number
+  ,s_city
+  ,s_county
+  ,s_state
+  ,s_zip
+  ,sum(case when (sr_returned_date_sk - ss_sold_date_sk <= 30 ) then 1 else 0 end)  as "30 days" 
+  ,sum(case when (sr_returned_date_sk - ss_sold_date_sk > 30) and 
+                 (sr_returned_date_sk - ss_sold_date_sk <= 60) then 1 else 0 end )  as "31-60 days" 
+  ,sum(case when (sr_returned_date_sk - ss_sold_date_sk > 60) and 
+                 (sr_returned_date_sk - ss_sold_date_sk <= 90) then 1 else 0 end)  as "61-90 days" 
+  ,sum(case when (sr_returned_date_sk - ss_sold_date_sk > 90) and
+                 (sr_returned_date_sk - ss_sold_date_sk <= 120) then 1 else 0 end)  as "91-120 days" 
+  ,sum(case when (sr_returned_date_sk - ss_sold_date_sk  > 120) then 1 else 0 end)  as ">120 days" 
+from
+   store_sales
+  ,store_returns
+  ,store
+  ,date_dim d1
+  ,date_dim d2
+where
+    d2.d_year = 2001
+and d2.d_moy  = 8
+and ss_ticket_number = sr_ticket_number
+and ss_item_sk = sr_item_sk
+and ss_sold_date_sk   = d1.d_date_sk
+and sr_returned_date_sk   = d2.d_date_sk
+and ss_customer_sk = sr_customer_sk
+and ss_store_sk = s_store_sk
+group by
+   s_store_name
+  ,s_company_id
+  ,s_street_number
+  ,s_street_name
+  ,s_street_type
+  ,s_suite_number
+  ,s_city
+  ,s_county
+  ,s_state
+  ,s_zip
+order by s_store_name
+        ,s_company_id
+        ,s_street_number
+        ,s_street_name
+        ,s_street_type
+        ,s_suite_number
+        ,s_city
+        ,s_county
+        ,s_state
+        ,s_zip
+limit 100
+;
+
+--= query_51
+WITH web_v1 as (
+select
+  ws_item_sk item_sk, d_date,
+  sum(sum(ws_sales_price))
+      over (partition by ws_item_sk order by d_date rows between unbounded preceding and current row) cume_sales
+from web_sales
+    ,date_dim
+where ws_sold_date_sk=d_date_sk
+  and d_month_seq between 1212 and 1212+11
+  and ws_item_sk is not NULL
+group by ws_item_sk, d_date),
+store_v1 as (
+select
+  ss_item_sk item_sk, d_date,
+  sum(sum(ss_sales_price))
+      over (partition by ss_item_sk order by d_date rows between unbounded preceding and current row) cume_sales
+from store_sales
+    ,date_dim
+where ss_sold_date_sk=d_date_sk
+  and d_month_seq between 1212 and 1212+11
+  and ss_item_sk is not NULL
+group by ss_item_sk, d_date)
+ select  *
+from (select item_sk
+     ,d_date
+     ,web_sales
+     ,store_sales
+     ,max(web_sales)
+         over (partition by item_sk order by d_date rows between unbounded preceding and current row) web_cumulative
+     ,max(store_sales)
+         over (partition by item_sk order by d_date rows between unbounded preceding and current row) store_cumulative
+     from (select case when web.item_sk is not null then web.item_sk else store.item_sk end item_sk
+                 ,case when web.d_date is not null then web.d_date else store.d_date end d_date
+                 ,web.cume_sales web_sales
+                 ,store.cume_sales store_sales
+           from web_v1 web full outer join store_v1 store on (web.item_sk = store.item_sk
+                                                          and web.d_date = store.d_date)
+          )x )y
+where web_cumulative > store_cumulative
+order by item_sk
+        ,d_date
+limit 100
+;
+
+--= query_52
+select  dt.d_year
+ 	,item.i_brand_id brand_id
+ 	,item.i_brand brand
+ 	,sum(ss_ext_sales_price) ext_price
+ from date_dim dt
+     ,store_sales
+     ,item
+ where dt.d_date_sk = store_sales.ss_sold_date_sk
+    and store_sales.ss_item_sk = item.i_item_sk
+    and item.i_manager_id = 1
+    and dt.d_moy=12
+    and dt.d_year=2000
+ group by dt.d_year
+ 	,item.i_brand
+ 	,item.i_brand_id
+ order by dt.d_year
+ 	,ext_price desc
+ 	,brand_id
+limit 100
+;
+
+--= query_53
+select  * from 
+(select i_manufact_id,
+sum(ss_sales_price) sum_sales,
+avg(sum(ss_sales_price)) over (partition by i_manufact_id) avg_quarterly_sales
+from item, store_sales, date_dim, store
+where ss_item_sk = i_item_sk and
+ss_sold_date_sk = d_date_sk and
+ss_store_sk = s_store_sk and
+d_month_seq in (1186,1186+1,1186+2,1186+3,1186+4,1186+5,1186+6,1186+7,1186+8,1186+9,1186+10,1186+11) and
+((i_category in ('Books','Children','Electronics') and
+i_class in ('personal','portable','reference','self-help') and
+i_brand in ('scholaramalgamalg #14','scholaramalgamalg #7',
+		'exportiunivamalg #9','scholaramalgamalg #9'))
+or(i_category in ('Women','Music','Men') and
+i_class in ('accessories','classical','fragrances','pants') and
+i_brand in ('amalgimporto #1','edu packscholar #1','exportiimporto #1',
+		'importoamalg #1')))
+group by i_manufact_id, d_qoy ) tmp1
+where case when avg_quarterly_sales > 0 
+	then abs (sum_sales - avg_quarterly_sales)/ avg_quarterly_sales 
+	else null end > 0.1
+order by avg_quarterly_sales,
+	 sum_sales,
+	 i_manufact_id
+limit 100
+;
+
+--= query_54
+with my_customers as (
+ select distinct c_customer_sk
+        , c_current_addr_sk
+ from   
+        ( select cs_sold_date_sk sold_date_sk,
+                 cs_bill_customer_sk customer_sk,
+                 cs_item_sk item_sk
+          from   catalog_sales
+          union all
+          select ws_sold_date_sk sold_date_sk,
+                 ws_bill_customer_sk customer_sk,
+                 ws_item_sk item_sk
+          from   web_sales
+         ) cs_or_ws_sales,
+         item,
+         date_dim,
+         customer
+ where   sold_date_sk = d_date_sk
+         and item_sk = i_item_sk
+         and i_category = 'Music'
+         and i_class = 'country'
+         and c_customer_sk = cs_or_ws_sales.customer_sk
+         and d_moy = 1
+         and d_year = 1999
+ )
+ , my_revenue as (
+ select c_customer_sk,
+        sum(ss_ext_sales_price) as revenue
+ from   my_customers,
+        store_sales,
+        customer_address,
+        store,
+        date_dim
+ where  c_current_addr_sk = ca_address_sk
+        and ca_county = s_county
+        and ca_state = s_state
+        and ss_sold_date_sk = d_date_sk
+        and c_customer_sk = ss_customer_sk
+        and d_month_seq between (select distinct d_month_seq+1
+                                 from   date_dim where d_year = 1999 and d_moy = 1)
+                           and  (select distinct d_month_seq+3
+                                 from   date_dim where d_year = 1999 and d_moy = 1)
+ group by c_customer_sk
+ )
+ , segments as
+ (select cast((revenue/50) as integer) as segment
+  from   my_revenue
+ )
+  select  segment, count(*) as num_customers, segment*50 as segment_base
+ from segments
+ group by segment
+ order by segment, num_customers
+ limit 100
+;
+
+--= query_55
+select  i_brand_id brand_id, i_brand brand,
+ 	sum(ss_ext_sales_price) ext_price
+ from date_dim, store_sales, item
+ where d_date_sk = ss_sold_date_sk
+ 	and ss_item_sk = i_item_sk
+ 	and i_manager_id=52
+ 	and d_moy=11
+ 	and d_year=2000
+ group by i_brand, i_brand_id
+ order by ext_price desc, i_brand_id
+limit 100
+;
+
+--= query_56
+with ss as (
+ select i_item_id,sum(ss_ext_sales_price) total_sales
+ from
+ 	store_sales,
+ 	date_dim,
+         customer_address,
+         item
+ where i_item_id in (select
+     i_item_id
+from item
+where i_color in ('powder','orchid','pink'))
+ and     ss_item_sk              = i_item_sk
+ and     ss_sold_date_sk         = d_date_sk
+ and     d_year                  = 2000
+ and     d_moy                   = 3
+ and     ss_addr_sk              = ca_address_sk
+ and     ca_gmt_offset           = -6 
+ group by i_item_id),
+ cs as (
+ select i_item_id,sum(cs_ext_sales_price) total_sales
+ from
+ 	catalog_sales,
+ 	date_dim,
+         customer_address,
+         item
+ where
+         i_item_id               in (select
+  i_item_id
+from item
+where i_color in ('powder','orchid','pink'))
+ and     cs_item_sk              = i_item_sk
+ and     cs_sold_date_sk         = d_date_sk
+ and     d_year                  = 2000
+ and     d_moy                   = 3
+ and     cs_bill_addr_sk         = ca_address_sk
+ and     ca_gmt_offset           = -6 
+ group by i_item_id),
+ ws as (
+ select i_item_id,sum(ws_ext_sales_price) total_sales
+ from
+ 	web_sales,
+ 	date_dim,
+         customer_address,
+         item
+ where
+         i_item_id               in (select
+  i_item_id
+from item
+where i_color in ('powder','orchid','pink'))
+ and     ws_item_sk              = i_item_sk
+ and     ws_sold_date_sk         = d_date_sk
+ and     d_year                  = 2000
+ and     d_moy                   = 3
+ and     ws_bill_addr_sk         = ca_address_sk
+ and     ca_gmt_offset           = -6
+ group by i_item_id)
+  select  i_item_id ,sum(total_sales) total_sales
+ from  (select * from ss 
+        union all
+        select * from cs 
+        union all
+        select * from ws) tmp1
+ group by i_item_id
+ order by total_sales,
+          i_item_id
+ limit 100
+;
+
+--= query_58
+with ss_items as
+ (select i_item_id item_id
+        ,sum(ss_ext_sales_price) ss_item_rev 
+ from store_sales
+     ,item
+     ,date_dim
+ where ss_item_sk = i_item_sk
+   and d_date in (select d_date
+                  from date_dim
+                  where d_week_seq = (select d_week_seq 
+                                      from date_dim
+                                      where d_date = '2001-06-16'))
+   and ss_sold_date_sk   = d_date_sk
+ group by i_item_id),
+ cs_items as
+ (select i_item_id item_id
+        ,sum(cs_ext_sales_price) cs_item_rev
+  from catalog_sales
+      ,item
+      ,date_dim
+ where cs_item_sk = i_item_sk
+  and  d_date in (select d_date
+                  from date_dim
+                  where d_week_seq = (select d_week_seq 
+                                      from date_dim
+                                      where d_date = '2001-06-16'))
+  and  cs_sold_date_sk = d_date_sk
+ group by i_item_id),
+ ws_items as
+ (select i_item_id item_id
+        ,sum(ws_ext_sales_price) ws_item_rev
+  from web_sales
+      ,item
+      ,date_dim
+ where ws_item_sk = i_item_sk
+  and  d_date in (select d_date
+                  from date_dim
+                  where d_week_seq =(select d_week_seq 
+                                     from date_dim
+                                     where d_date = '2001-06-16'))
+  and ws_sold_date_sk   = d_date_sk
+ group by i_item_id)
+  select  ss_items.item_id
+       ,ss_item_rev
+       ,ss_item_rev/((ss_item_rev+cs_item_rev+ws_item_rev)/3) * 100 ss_dev
+       ,cs_item_rev
+       ,cs_item_rev/((ss_item_rev+cs_item_rev+ws_item_rev)/3) * 100 cs_dev
+       ,ws_item_rev
+       ,ws_item_rev/((ss_item_rev+cs_item_rev+ws_item_rev)/3) * 100 ws_dev
+       ,(ss_item_rev+cs_item_rev+ws_item_rev)/3 average
+ from ss_items,cs_items,ws_items
+ where ss_items.item_id=cs_items.item_id
+   and ss_items.item_id=ws_items.item_id 
+   and ss_item_rev between 0.9 * cs_item_rev and 1.1 * cs_item_rev
+   and ss_item_rev between 0.9 * ws_item_rev and 1.1 * ws_item_rev
+   and cs_item_rev between 0.9 * ss_item_rev and 1.1 * ss_item_rev
+   and cs_item_rev between 0.9 * ws_item_rev and 1.1 * ws_item_rev
+   and ws_item_rev between 0.9 * ss_item_rev and 1.1 * ss_item_rev
+   and ws_item_rev between 0.9 * cs_item_rev and 1.1 * cs_item_rev
+ order by item_id
+         ,ss_item_rev
+ limit 100
+;
+
+--= query_59
+with wss as 
+ (select d_week_seq,
+        ss_store_sk,
+        sum(case when (d_day_name='Sunday') then ss_sales_price else null end) sun_sales,
+        sum(case when (d_day_name='Monday') then ss_sales_price else null end) mon_sales,
+        sum(case when (d_day_name='Tuesday') then ss_sales_price else  null end) tue_sales,
+        sum(case when (d_day_name='Wednesday') then ss_sales_price else null end) wed_sales,
+        sum(case when (d_day_name='Thursday') then ss_sales_price else null end) thu_sales,
+        sum(case when (d_day_name='Friday') then ss_sales_price else null end) fri_sales,
+        sum(case when (d_day_name='Saturday') then ss_sales_price else null end) sat_sales
+ from store_sales,date_dim
+ where d_date_sk = ss_sold_date_sk
+ group by d_week_seq,ss_store_sk
+ )
+  select  s_store_name1,s_store_id1,d_week_seq1
+       ,sun_sales1/sun_sales2,mon_sales1/mon_sales2
+       ,tue_sales1/tue_sales2,wed_sales1/wed_sales2,thu_sales1/thu_sales2
+       ,fri_sales1/fri_sales2,sat_sales1/sat_sales2
+ from
+ (select s_store_name s_store_name1,wss.d_week_seq d_week_seq1
+        ,s_store_id s_store_id1,sun_sales sun_sales1
+        ,mon_sales mon_sales1,tue_sales tue_sales1
+        ,wed_sales wed_sales1,thu_sales thu_sales1
+        ,fri_sales fri_sales1,sat_sales sat_sales1
+  from wss,store,date_dim d
+  where d.d_week_seq = wss.d_week_seq and
+        ss_store_sk = s_store_sk and 
+        d_month_seq between 1195 and 1195 + 11) y,
+ (select s_store_name s_store_name2,wss.d_week_seq d_week_seq2
+        ,s_store_id s_store_id2,sun_sales sun_sales2
+        ,mon_sales mon_sales2,tue_sales tue_sales2
+        ,wed_sales wed_sales2,thu_sales thu_sales2
+        ,fri_sales fri_sales2,sat_sales sat_sales2
+  from wss,store,date_dim d
+  where d.d_week_seq = wss.d_week_seq and
+        ss_store_sk = s_store_sk and 
+        d_month_seq between 1195+ 12 and 1195 + 23) x
+ where s_store_id1=s_store_id2
+   and d_week_seq1=d_week_seq2-52
+ order by s_store_name1,s_store_id1,d_week_seq1
+limit 100
+;
+
+--= query_60
+with ss as (
+ select
+          i_item_id,sum(ss_ext_sales_price) total_sales
+ from
+ 	store_sales,
+ 	date_dim,
+         customer_address,
+         item
+ where
+         i_item_id in (select
+  i_item_id
+from
+ item
+where i_category in ('Jewelry'))
+ and     ss_item_sk              = i_item_sk
+ and     ss_sold_date_sk         = d_date_sk
+ and     d_year                  = 2000
+ and     d_moy                   = 10
+ and     ss_addr_sk              = ca_address_sk
+ and     ca_gmt_offset           = -5 
+ group by i_item_id),
+ cs as (
+ select
+          i_item_id,sum(cs_ext_sales_price) total_sales
+ from
+ 	catalog_sales,
+ 	date_dim,
+         customer_address,
+         item
+ where
+         i_item_id               in (select
+  i_item_id
+from
+ item
+where i_category in ('Jewelry'))
+ and     cs_item_sk              = i_item_sk
+ and     cs_sold_date_sk         = d_date_sk
+ and     d_year                  = 2000
+ and     d_moy                   = 10
+ and     cs_bill_addr_sk         = ca_address_sk
+ and     ca_gmt_offset           = -5 
+ group by i_item_id),
+ ws as (
+ select
+          i_item_id,sum(ws_ext_sales_price) total_sales
+ from
+ 	web_sales,
+ 	date_dim,
+         customer_address,
+         item
+ where
+         i_item_id               in (select
+  i_item_id
+from
+ item
+where i_category in ('Jewelry'))
+ and     ws_item_sk              = i_item_sk
+ and     ws_sold_date_sk         = d_date_sk
+ and     d_year                  = 2000
+ and     d_moy                   = 10
+ and     ws_bill_addr_sk         = ca_address_sk
+ and     ca_gmt_offset           = -5
+ group by i_item_id)
+  select   
+  i_item_id
+,sum(total_sales) total_sales
+ from  (select * from ss 
+        union all
+        select * from cs 
+        union all
+        select * from ws) tmp1
+ group by i_item_id
+ order by i_item_id
+      ,total_sales
+ limit 100
+;
+
+--= query_61
+select  promotions,total,cast(promotions as decimal(15,4))/cast(total as decimal(15,4))*100
+from
+  (select sum(ss_ext_sales_price) promotions
+   from  store_sales
+        ,store
+        ,promotion
+        ,date_dim
+        ,customer
+        ,customer_address 
+        ,item
+   where ss_sold_date_sk = d_date_sk
+   and   ss_store_sk = s_store_sk
+   and   ss_promo_sk = p_promo_sk
+   and   ss_customer_sk= c_customer_sk
+   and   ca_address_sk = c_current_addr_sk
+   and   ss_item_sk = i_item_sk 
+   and   ca_gmt_offset = -7
+   and   i_category = 'Home'
+   and   (p_channel_dmail = 'Y' or p_channel_email = 'Y' or p_channel_tv = 'Y')
+   and   s_gmt_offset = -7
+   and   d_year = 2000
+   and   d_moy  = 12) promotional_sales,
+  (select sum(ss_ext_sales_price) total
+   from  store_sales
+        ,store
+        ,date_dim
+        ,customer
+        ,customer_address
+        ,item
+   where ss_sold_date_sk = d_date_sk
+   and   ss_store_sk = s_store_sk
+   and   ss_customer_sk= c_customer_sk
+   and   ca_address_sk = c_current_addr_sk
+   and   ss_item_sk = i_item_sk
+   and   ca_gmt_offset = -7
+   and   i_category = 'Home'
+   and   s_gmt_offset = -7
+   and   d_year = 2000
+   and   d_moy  = 12) all_sales
+order by promotions, total
+limit 100
+;
+
+--= query_62
+select  
+   substr(w_warehouse_name,1,20)
+  ,sm_type
+  ,web_name
+  ,sum(case when (ws_ship_date_sk - ws_sold_date_sk <= 30 ) then 1 else 0 end)  as "30 days" 
+  ,sum(case when (ws_ship_date_sk - ws_sold_date_sk > 30) and 
+                 (ws_ship_date_sk - ws_sold_date_sk <= 60) then 1 else 0 end )  as "31-60 days" 
+  ,sum(case when (ws_ship_date_sk - ws_sold_date_sk > 60) and 
+                 (ws_ship_date_sk - ws_sold_date_sk <= 90) then 1 else 0 end)  as "61-90 days" 
+  ,sum(case when (ws_ship_date_sk - ws_sold_date_sk > 90) and
+                 (ws_ship_date_sk - ws_sold_date_sk <= 120) then 1 else 0 end)  as "91-120 days" 
+  ,sum(case when (ws_ship_date_sk - ws_sold_date_sk  > 120) then 1 else 0 end)  as ">120 days" 
+from
+   web_sales
+  ,warehouse
+  ,ship_mode
+  ,web_site
+  ,date_dim
+where
+    d_month_seq between 1223 and 1223 + 11
+and ws_ship_date_sk   = d_date_sk
+and ws_warehouse_sk   = w_warehouse_sk
+and ws_ship_mode_sk   = sm_ship_mode_sk
+and ws_web_site_sk    = web_site_sk
+group by
+   substr(w_warehouse_name,1,20)
+  ,sm_type
+  ,web_name
+order by substr(w_warehouse_name,1,20)
+        ,sm_type
+       ,web_name
+limit 100
+;
+
+--= query_63
+select  * 
+from (select i_manager_id
+             ,sum(ss_sales_price) sum_sales
+             ,avg(sum(ss_sales_price)) over (partition by i_manager_id) avg_monthly_sales
+      from item
+          ,store_sales
+          ,date_dim
+          ,store
+      where ss_item_sk = i_item_sk
+        and ss_sold_date_sk = d_date_sk
+        and ss_store_sk = s_store_sk
+        and d_month_seq in (1222,1222+1,1222+2,1222+3,1222+4,1222+5,1222+6,1222+7,1222+8,1222+9,1222+10,1222+11)
+        and ((    i_category in ('Books','Children','Electronics')
+              and i_class in ('personal','portable','reference','self-help')
+              and i_brand in ('scholaramalgamalg #14','scholaramalgamalg #7',
+		                  'exportiunivamalg #9','scholaramalgamalg #9'))
+           or(    i_category in ('Women','Music','Men')
+              and i_class in ('accessories','classical','fragrances','pants')
+              and i_brand in ('amalgimporto #1','edu packscholar #1','exportiimporto #1',
+		                 'importoamalg #1')))
+group by i_manager_id, d_moy) tmp1
+where case when avg_monthly_sales > 0 then abs (sum_sales - avg_monthly_sales) / avg_monthly_sales else null end > 0.1
+order by i_manager_id
+        ,avg_monthly_sales
+        ,sum_sales
+limit 100
+;
+
+--= query_64
+with cs_ui as
+ (select cs_item_sk
+        ,sum(cs_ext_list_price) as sale,sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit) as refund
+  from catalog_sales
+      ,catalog_returns
+  where cs_item_sk = cr_item_sk
+    and cs_order_number = cr_order_number
+  group by cs_item_sk
+  having sum(cs_ext_list_price)>2*sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit)),
+cross_sales as
+ (select i_product_name product_name
+     ,i_item_sk item_sk
+     ,s_store_name store_name
+     ,s_zip store_zip
+     ,ad1.ca_street_number b_street_number
+     ,ad1.ca_street_name b_street_name
+     ,ad1.ca_city b_city
+     ,ad1.ca_zip b_zip
+     ,ad2.ca_street_number c_street_number
+     ,ad2.ca_street_name c_street_name
+     ,ad2.ca_city c_city
+     ,ad2.ca_zip c_zip
+     ,d1.d_year as syear
+     ,d2.d_year as fsyear
+     ,d3.d_year s2year
+     ,count(*) cnt
+     ,sum(ss_wholesale_cost) s1
+     ,sum(ss_list_price) s2
+     ,sum(ss_coupon_amt) s3
+  FROM   store_sales
+        ,store_returns
+        ,cs_ui
+        ,date_dim d1
+        ,date_dim d2
+        ,date_dim d3
+        ,store
+        ,customer
+        ,customer_demographics cd1
+        ,customer_demographics cd2
+        ,promotion
+        ,household_demographics hd1
+        ,household_demographics hd2
+        ,customer_address ad1
+        ,customer_address ad2
+        ,income_band ib1
+        ,income_band ib2
+        ,item
+  WHERE  ss_store_sk = s_store_sk AND
+         ss_sold_date_sk = d1.d_date_sk AND
+         ss_customer_sk = c_customer_sk AND
+         ss_cdemo_sk= cd1.cd_demo_sk AND
+         ss_hdemo_sk = hd1.hd_demo_sk AND
+         ss_addr_sk = ad1.ca_address_sk and
+         ss_item_sk = i_item_sk and
+         ss_item_sk = sr_item_sk and
+         ss_ticket_number = sr_ticket_number and
+         ss_item_sk = cs_ui.cs_item_sk and
+         c_current_cdemo_sk = cd2.cd_demo_sk AND
+         c_current_hdemo_sk = hd2.hd_demo_sk AND
+         c_current_addr_sk = ad2.ca_address_sk and
+         c_first_sales_date_sk = d2.d_date_sk and
+         c_first_shipto_date_sk = d3.d_date_sk and
+         ss_promo_sk = p_promo_sk and
+         hd1.hd_income_band_sk = ib1.ib_income_band_sk and
+         hd2.hd_income_band_sk = ib2.ib_income_band_sk and
+         cd1.cd_marital_status <> cd2.cd_marital_status and
+         i_color in ('orange','lace','lawn','misty','blush','pink') and
+         i_current_price between 48 and 48 + 10 and
+         i_current_price between 48 + 1 and 48 + 15
+group by i_product_name
+       ,i_item_sk
+       ,s_store_name
+       ,s_zip
+       ,ad1.ca_street_number
+       ,ad1.ca_street_name
+       ,ad1.ca_city
+       ,ad1.ca_zip
+       ,ad2.ca_street_number
+       ,ad2.ca_street_name
+       ,ad2.ca_city
+       ,ad2.ca_zip
+       ,d1.d_year
+       ,d2.d_year
+       ,d3.d_year
+)
+select cs1.product_name
+     ,cs1.store_name
+     ,cs1.store_zip
+     ,cs1.b_street_number
+     ,cs1.b_street_name
+     ,cs1.b_city
+     ,cs1.b_zip
+     ,cs1.c_street_number
+     ,cs1.c_street_name
+     ,cs1.c_city
+     ,cs1.c_zip
+     ,cs1.syear
+     ,cs1.cnt
+     ,cs1.s1 as s11
+     ,cs1.s2 as s21
+     ,cs1.s3 as s31
+     ,cs2.s1 as s12
+     ,cs2.s2 as s22
+     ,cs2.s3 as s32
+     ,cs2.syear
+     ,cs2.cnt
+from cross_sales cs1,cross_sales cs2
+where cs1.item_sk=cs2.item_sk and
+     cs1.syear = 1999 and
+     cs2.syear = 1999 + 1 and
+     cs2.cnt <= cs1.cnt and
+     cs1.store_name = cs2.store_name and
+     cs1.store_zip = cs2.store_zip
+order by cs1.product_name
+       ,cs1.store_name
+       ,cs2.cnt
+       ,cs1.s1
+       ,cs2.s1
+;
+
+--= query_65
+select 
+	s_store_name,
+	i_item_desc,
+	sc.revenue,
+	i_current_price,
+	i_wholesale_cost,
+	i_brand
+ from store, item,
+     (select ss_store_sk, avg(revenue) as ave
+ 	from
+ 	    (select  ss_store_sk, ss_item_sk, 
+ 		     sum(ss_sales_price) as revenue
+ 		from store_sales, date_dim
+ 		where ss_sold_date_sk = d_date_sk and d_month_seq between 1176 and 1176+11
+ 		group by ss_store_sk, ss_item_sk) sa
+ 	group by ss_store_sk) sb,
+     (select  ss_store_sk, ss_item_sk, sum(ss_sales_price) as revenue
+ 	from store_sales, date_dim
+ 	where ss_sold_date_sk = d_date_sk and d_month_seq between 1176 and 1176+11
+ 	group by ss_store_sk, ss_item_sk) sc
+ where sb.ss_store_sk = sc.ss_store_sk and 
+       sc.revenue <= 0.1 * sb.ave and
+       s_store_sk = sc.ss_store_sk and
+       i_item_sk = sc.ss_item_sk
+ order by s_store_name, i_item_desc
+limit 100
+;
+
+--= query_66
+select   
+         w_warehouse_name
+ 	,w_warehouse_sq_ft
+ 	,w_city
+ 	,w_county
+ 	,w_state
+ 	,w_country
+        ,ship_carriers
+        ,year
+ 	,sum(jan_sales) as jan_sales
+ 	,sum(feb_sales) as feb_sales
+ 	,sum(mar_sales) as mar_sales
+ 	,sum(apr_sales) as apr_sales
+ 	,sum(may_sales) as may_sales
+ 	,sum(jun_sales) as jun_sales
+ 	,sum(jul_sales) as jul_sales
+ 	,sum(aug_sales) as aug_sales
+ 	,sum(sep_sales) as sep_sales
+ 	,sum(oct_sales) as oct_sales
+ 	,sum(nov_sales) as nov_sales
+ 	,sum(dec_sales) as dec_sales
+ 	,sum(jan_sales/w_warehouse_sq_ft) as jan_sales_per_sq_foot
+ 	,sum(feb_sales/w_warehouse_sq_ft) as feb_sales_per_sq_foot
+ 	,sum(mar_sales/w_warehouse_sq_ft) as mar_sales_per_sq_foot
+ 	,sum(apr_sales/w_warehouse_sq_ft) as apr_sales_per_sq_foot
+ 	,sum(may_sales/w_warehouse_sq_ft) as may_sales_per_sq_foot
+ 	,sum(jun_sales/w_warehouse_sq_ft) as jun_sales_per_sq_foot
+ 	,sum(jul_sales/w_warehouse_sq_ft) as jul_sales_per_sq_foot
+ 	,sum(aug_sales/w_warehouse_sq_ft) as aug_sales_per_sq_foot
+ 	,sum(sep_sales/w_warehouse_sq_ft) as sep_sales_per_sq_foot
+ 	,sum(oct_sales/w_warehouse_sq_ft) as oct_sales_per_sq_foot
+ 	,sum(nov_sales/w_warehouse_sq_ft) as nov_sales_per_sq_foot
+ 	,sum(dec_sales/w_warehouse_sq_ft) as dec_sales_per_sq_foot
+ 	,sum(jan_net) as jan_net
+ 	,sum(feb_net) as feb_net
+ 	,sum(mar_net) as mar_net
+ 	,sum(apr_net) as apr_net
+ 	,sum(may_net) as may_net
+ 	,sum(jun_net) as jun_net
+ 	,sum(jul_net) as jul_net
+ 	,sum(aug_net) as aug_net
+ 	,sum(sep_net) as sep_net
+ 	,sum(oct_net) as oct_net
+ 	,sum(nov_net) as nov_net
+ 	,sum(dec_net) as dec_net
+ from (
+     select 
+ 	w_warehouse_name
+ 	,w_warehouse_sq_ft
+ 	,w_city
+ 	,w_county
+ 	,w_state
+ 	,w_country
+ 	,'ORIENTAL' || ',' || 'BOXBUNDLES' as ship_carriers
+       ,d_year as year
+ 	,sum(case when d_moy = 1 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as jan_sales
+ 	,sum(case when d_moy = 2 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as feb_sales
+ 	,sum(case when d_moy = 3 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as mar_sales
+ 	,sum(case when d_moy = 4 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as apr_sales
+ 	,sum(case when d_moy = 5 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as may_sales
+ 	,sum(case when d_moy = 6 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as jun_sales
+ 	,sum(case when d_moy = 7 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as jul_sales
+ 	,sum(case when d_moy = 8 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as aug_sales
+ 	,sum(case when d_moy = 9 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as sep_sales
+ 	,sum(case when d_moy = 10 
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as oct_sales
+ 	,sum(case when d_moy = 11
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as nov_sales
+ 	,sum(case when d_moy = 12
+ 		then ws_ext_sales_price* ws_quantity else 0 end) as dec_sales
+ 	,sum(case when d_moy = 1 
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as jan_net
+ 	,sum(case when d_moy = 2
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as feb_net
+ 	,sum(case when d_moy = 3 
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as mar_net
+ 	,sum(case when d_moy = 4 
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as apr_net
+ 	,sum(case when d_moy = 5 
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as may_net
+ 	,sum(case when d_moy = 6 
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as jun_net
+ 	,sum(case when d_moy = 7 
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as jul_net
+ 	,sum(case when d_moy = 8 
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as aug_net
+ 	,sum(case when d_moy = 9 
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as sep_net
+ 	,sum(case when d_moy = 10 
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as oct_net
+ 	,sum(case when d_moy = 11
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as nov_net
+ 	,sum(case when d_moy = 12
+ 		then ws_net_paid_inc_ship * ws_quantity else 0 end) as dec_net
+     from
+          web_sales
+         ,warehouse
+         ,date_dim
+         ,time_dim
+ 	  ,ship_mode
+     where
+            ws_warehouse_sk =  w_warehouse_sk
+        and ws_sold_date_sk = d_date_sk
+        and ws_sold_time_sk = t_time_sk
+ 	and ws_ship_mode_sk = sm_ship_mode_sk
+        and d_year = 2001
+ 	and t_time between 42970 and 42970+28800 
+ 	and sm_carrier in ('ORIENTAL','BOXBUNDLES')
+     group by 
+        w_warehouse_name
+ 	,w_warehouse_sq_ft
+ 	,w_city
+ 	,w_county
+ 	,w_state
+ 	,w_country
+       ,d_year
+ union all
+     select 
+ 	w_warehouse_name
+ 	,w_warehouse_sq_ft
+ 	,w_city
+ 	,w_county
+ 	,w_state
+ 	,w_country
+ 	,'ORIENTAL' || ',' || 'BOXBUNDLES' as ship_carriers
+       ,d_year as year
+ 	,sum(case when d_moy = 1 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as jan_sales
+ 	,sum(case when d_moy = 2 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as feb_sales
+ 	,sum(case when d_moy = 3 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as mar_sales
+ 	,sum(case when d_moy = 4 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as apr_sales
+ 	,sum(case when d_moy = 5 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as may_sales
+ 	,sum(case when d_moy = 6 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as jun_sales
+ 	,sum(case when d_moy = 7 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as jul_sales
+ 	,sum(case when d_moy = 8 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as aug_sales
+ 	,sum(case when d_moy = 9 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as sep_sales
+ 	,sum(case when d_moy = 10 
+ 		then cs_ext_list_price* cs_quantity else 0 end) as oct_sales
+ 	,sum(case when d_moy = 11
+ 		then cs_ext_list_price* cs_quantity else 0 end) as nov_sales
+ 	,sum(case when d_moy = 12
+ 		then cs_ext_list_price* cs_quantity else 0 end) as dec_sales
+ 	,sum(case when d_moy = 1 
+ 		then cs_net_paid * cs_quantity else 0 end) as jan_net
+ 	,sum(case when d_moy = 2 
+ 		then cs_net_paid * cs_quantity else 0 end) as feb_net
+ 	,sum(case when d_moy = 3 
+ 		then cs_net_paid * cs_quantity else 0 end) as mar_net
+ 	,sum(case when d_moy = 4 
+ 		then cs_net_paid * cs_quantity else 0 end) as apr_net
+ 	,sum(case when d_moy = 5 
+ 		then cs_net_paid * cs_quantity else 0 end) as may_net
+ 	,sum(case when d_moy = 6 
+ 		then cs_net_paid * cs_quantity else 0 end) as jun_net
+ 	,sum(case when d_moy = 7 
+ 		then cs_net_paid * cs_quantity else 0 end) as jul_net
+ 	,sum(case when d_moy = 8 
+ 		then cs_net_paid * cs_quantity else 0 end) as aug_net
+ 	,sum(case when d_moy = 9 
+ 		then cs_net_paid * cs_quantity else 0 end) as sep_net
+ 	,sum(case when d_moy = 10 
+ 		then cs_net_paid * cs_quantity else 0 end) as oct_net
+ 	,sum(case when d_moy = 11
+ 		then cs_net_paid * cs_quantity else 0 end) as nov_net
+ 	,sum(case when d_moy = 12
+ 		then cs_net_paid * cs_quantity else 0 end) as dec_net
+     from
+          catalog_sales
+         ,warehouse
+         ,date_dim
+         ,time_dim
+ 	 ,ship_mode
+     where
+            cs_warehouse_sk =  w_warehouse_sk
+        and cs_sold_date_sk = d_date_sk
+        and cs_sold_time_sk = t_time_sk
+ 	and cs_ship_mode_sk = sm_ship_mode_sk
+        and d_year = 2001
+ 	and t_time between 42970 AND 42970+28800 
+ 	and sm_carrier in ('ORIENTAL','BOXBUNDLES')
+     group by 
+        w_warehouse_name
+ 	,w_warehouse_sq_ft
+ 	,w_city
+ 	,w_county
+ 	,w_state
+ 	,w_country
+       ,d_year
+ ) x
+ group by 
+        w_warehouse_name
+ 	,w_warehouse_sq_ft
+ 	,w_city
+ 	,w_county
+ 	,w_state
+ 	,w_country
+ 	,ship_carriers
+       ,year
+ order by w_warehouse_name
+ limit 100
+;
+
+--= query_68
+select  c_last_name
+       ,c_first_name
+       ,ca_city
+       ,bought_city
+       ,ss_ticket_number
+       ,extended_price
+       ,extended_tax
+       ,list_price
+ from (select ss_ticket_number
+             ,ss_customer_sk
+             ,ca_city bought_city
+             ,sum(ss_ext_sales_price) extended_price 
+             ,sum(ss_ext_list_price) list_price
+             ,sum(ss_ext_tax) extended_tax 
+       from store_sales
+           ,date_dim
+           ,store
+           ,household_demographics
+           ,customer_address 
+       where store_sales.ss_sold_date_sk = date_dim.d_date_sk
+         and store_sales.ss_store_sk = store.s_store_sk  
+        and store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk
+        and store_sales.ss_addr_sk = customer_address.ca_address_sk
+        and date_dim.d_dom between 1 and 2 
+        and (household_demographics.hd_dep_count = 3 or
+             household_demographics.hd_vehicle_count= 4)
+        and date_dim.d_year in (1998,1998+1,1998+2)
+        and store.s_city in ('Fairview','Midway')
+       group by ss_ticket_number
+               ,ss_customer_sk
+               ,ss_addr_sk,ca_city) dn
+      ,customer
+      ,customer_address current_addr
+ where ss_customer_sk = c_customer_sk
+   and customer.c_current_addr_sk = current_addr.ca_address_sk
+   and current_addr.ca_city <> bought_city
+ order by c_last_name
+         ,ss_ticket_number
+ limit 100
+;
+
+--= query_69
+select  
+  cd_gender,
+  cd_marital_status,
+  cd_education_status,
+  count(*) cnt1,
+  cd_purchase_estimate,
+  count(*) cnt2,
+  cd_credit_rating,
+  count(*) cnt3
+ from
+  customer c,customer_address ca,customer_demographics
+ where
+  c.c_current_addr_sk = ca.ca_address_sk and
+  ca_state in ('IL','TX','ME') and
+  cd_demo_sk = c.c_current_cdemo_sk and 
+  exists (select *
+          from store_sales,date_dim
+          where c.c_customer_sk = ss_customer_sk and
+                ss_sold_date_sk = d_date_sk and
+                d_year = 2002 and
+                d_moy between 1 and 1+2) and
+   (not exists (select *
+            from web_sales,date_dim
+            where c.c_customer_sk = ws_bill_customer_sk and
+                  ws_sold_date_sk = d_date_sk and
+                  d_year = 2002 and
+                  d_moy between 1 and 1+2) and
+    not exists (select * 
+            from catalog_sales,date_dim
+            where c.c_customer_sk = cs_ship_customer_sk and
+                  cs_sold_date_sk = d_date_sk and
+                  d_year = 2002 and
+                  d_moy between 1 and 1+2))
+ group by cd_gender,
+          cd_marital_status,
+          cd_education_status,
+          cd_purchase_estimate,
+          cd_credit_rating
+ order by cd_gender,
+          cd_marital_status,
+          cd_education_status,
+          cd_purchase_estimate,
+          cd_credit_rating
+ limit 100
+;
+
+--= query_71
+select i_brand_id brand_id, i_brand brand,t_hour,t_minute,
+ 	sum(ext_price) ext_price
+ from item, (select ws_ext_sales_price as ext_price, 
+                        ws_sold_date_sk as sold_date_sk,
+                        ws_item_sk as sold_item_sk,
+                        ws_sold_time_sk as time_sk  
+                 from web_sales,date_dim
+                 where d_date_sk = ws_sold_date_sk
+                   and d_moy=12
+                   and d_year=2002
+                 union all
+                 select cs_ext_sales_price as ext_price,
+                        cs_sold_date_sk as sold_date_sk,
+                        cs_item_sk as sold_item_sk,
+                        cs_sold_time_sk as time_sk
+                 from catalog_sales,date_dim
+                 where d_date_sk = cs_sold_date_sk
+                   and d_moy=12
+                   and d_year=2002
+                 union all
+                 select ss_ext_sales_price as ext_price,
+                        ss_sold_date_sk as sold_date_sk,
+                        ss_item_sk as sold_item_sk,
+                        ss_sold_time_sk as time_sk
+                 from store_sales,date_dim
+                 where d_date_sk = ss_sold_date_sk
+                   and d_moy=12
+                   and d_year=2002
+                 ) tmp,time_dim
+ where
+   sold_item_sk = i_item_sk
+   and i_manager_id=1
+   and time_sk = t_time_sk
+   and (t_meal_time = 'breakfast' or t_meal_time = 'dinner')
+ group by i_brand, i_brand_id,t_hour,t_minute
+ order by ext_price desc, i_brand_id
+;
+
+--= query_72
+select  i_item_desc
+      ,w_warehouse_name
+      ,d1.d_week_seq
+      ,sum(case when p_promo_sk is null then 1 else 0 end) no_promo
+      ,sum(case when p_promo_sk is not null then 1 else 0 end) promo
+      ,count(*) total_cnt
+from catalog_sales
+join inventory on (cs_item_sk = inv_item_sk)
+join warehouse on (w_warehouse_sk=inv_warehouse_sk)
+join item on (i_item_sk = cs_item_sk)
+join customer_demographics on (cs_bill_cdemo_sk = cd_demo_sk)
+join household_demographics on (cs_bill_hdemo_sk = hd_demo_sk)
+join date_dim d1 on (cs_sold_date_sk = d1.d_date_sk)
+join date_dim d2 on (inv_date_sk = d2.d_date_sk)
+join date_dim d3 on (cs_ship_date_sk = d3.d_date_sk)
+left outer join promotion on (cs_promo_sk=p_promo_sk)
+left outer join catalog_returns on (cr_item_sk = cs_item_sk and cr_order_number = cs_order_number)
+where d1.d_week_seq = d2.d_week_seq
+  and inv_quantity_on_hand < cs_quantity 
+  and d3.d_date > d1.d_date + 5
+  and hd_buy_potential = '1001-5000'
+  and d1.d_year = 1998
+  and cd_marital_status = 'S'
+group by i_item_desc,w_warehouse_name,d1.d_week_seq
+order by total_cnt desc, i_item_desc, w_warehouse_name, d_week_seq
+limit 100
+;
+
+--= query_73
+select c_last_name
+       ,c_first_name
+       ,c_salutation
+       ,c_preferred_cust_flag 
+       ,ss_ticket_number
+       ,cnt from
+   (select ss_ticket_number
+          ,ss_customer_sk
+          ,count(*) cnt
+    from store_sales,date_dim,store,household_demographics
+    where store_sales.ss_sold_date_sk = date_dim.d_date_sk
+    and store_sales.ss_store_sk = store.s_store_sk  
+    and store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk
+    and date_dim.d_dom between 1 and 2 
+    and (household_demographics.hd_buy_potential = '1001-5000' or
+         household_demographics.hd_buy_potential = '5001-10000')
+    and household_demographics.hd_vehicle_count > 0
+    and case when household_demographics.hd_vehicle_count > 0 then 
+             household_demographics.hd_dep_count/ household_demographics.hd_vehicle_count else null end > 1
+    and date_dim.d_year in (2000,2000+1,2000+2)
+    and store.s_county in ('Williamson County','Williamson County','Williamson County','Williamson County')
+    group by ss_ticket_number,ss_customer_sk) dj,customer
+    where ss_customer_sk = c_customer_sk
+      and cnt between 1 and 5
+    order by cnt desc, c_last_name asc
+;
+
+--= query_74
+with year_total as (
+ select c_customer_id customer_id
+       ,c_first_name customer_first_name
+       ,c_last_name customer_last_name
+       ,d_year as year
+       ,max(ss_net_paid) year_total
+       ,'s' sale_type
+ from customer
+     ,store_sales
+     ,date_dim
+ where c_customer_sk = ss_customer_sk
+   and ss_sold_date_sk = d_date_sk
+   and d_year in (1999,1999+1)
+ group by c_customer_id
+         ,c_first_name
+         ,c_last_name
+         ,d_year
+ union all
+ select c_customer_id customer_id
+       ,c_first_name customer_first_name
+       ,c_last_name customer_last_name
+       ,d_year as year
+       ,max(ws_net_paid) year_total
+       ,'w' sale_type
+ from customer
+     ,web_sales
+     ,date_dim
+ where c_customer_sk = ws_bill_customer_sk
+   and ws_sold_date_sk = d_date_sk
+   and d_year in (1999,1999+1)
+ group by c_customer_id
+         ,c_first_name
+         ,c_last_name
+         ,d_year
+         )
+  select 
+        t_s_secyear.customer_id, t_s_secyear.customer_first_name, t_s_secyear.customer_last_name
+ from year_total t_s_firstyear
+     ,year_total t_s_secyear
+     ,year_total t_w_firstyear
+     ,year_total t_w_secyear
+ where t_s_secyear.customer_id = t_s_firstyear.customer_id
+         and t_s_firstyear.customer_id = t_w_secyear.customer_id
+         and t_s_firstyear.customer_id = t_w_firstyear.customer_id
+         and t_s_firstyear.sale_type = 's'
+         and t_w_firstyear.sale_type = 'w'
+         and t_s_secyear.sale_type = 's'
+         and t_w_secyear.sale_type = 'w'
+         and t_s_firstyear.year = 1999
+         and t_s_secyear.year = 1999+1
+         and t_w_firstyear.year = 1999
+         and t_w_secyear.year = 1999+1
+         and t_s_firstyear.year_total > 0
+         and t_w_firstyear.year_total > 0
+         and case when t_w_firstyear.year_total > 0 then t_w_secyear.year_total / t_w_firstyear.year_total else null end
+           > case when t_s_firstyear.year_total > 0 then t_s_secyear.year_total / t_s_firstyear.year_total else null end
+ order by 1,3,2
+limit 100
+;
+
+--= query_75
+WITH all_sales AS (
+ SELECT d_year
+       ,i_brand_id
+       ,i_class_id
+       ,i_category_id
+       ,i_manufact_id
+       ,SUM(sales_cnt) AS sales_cnt
+       ,SUM(sales_amt) AS sales_amt
+ FROM (SELECT d_year
+             ,i_brand_id
+             ,i_class_id
+             ,i_category_id
+             ,i_manufact_id
+             ,cs_quantity - COALESCE(cr_return_quantity,0) AS sales_cnt
+             ,cs_ext_sales_price - COALESCE(cr_return_amount,0.0) AS sales_amt
+       FROM catalog_sales JOIN item ON i_item_sk=cs_item_sk
+                          JOIN date_dim ON d_date_sk=cs_sold_date_sk
+                          LEFT JOIN catalog_returns ON (cs_order_number=cr_order_number 
+                                                    AND cs_item_sk=cr_item_sk)
+       WHERE i_category='Sports'
+       UNION
+       SELECT d_year
+             ,i_brand_id
+             ,i_class_id
+             ,i_category_id
+             ,i_manufact_id
+             ,ss_quantity - COALESCE(sr_return_quantity,0) AS sales_cnt
+             ,ss_ext_sales_price - COALESCE(sr_return_amt,0.0) AS sales_amt
+       FROM store_sales JOIN item ON i_item_sk=ss_item_sk
+                        JOIN date_dim ON d_date_sk=ss_sold_date_sk
+                        LEFT JOIN store_returns ON (ss_ticket_number=sr_ticket_number 
+                                                AND ss_item_sk=sr_item_sk)
+       WHERE i_category='Sports'
+       UNION
+       SELECT d_year
+             ,i_brand_id
+             ,i_class_id
+             ,i_category_id
+             ,i_manufact_id
+             ,ws_quantity - COALESCE(wr_return_quantity,0) AS sales_cnt
+             ,ws_ext_sales_price - COALESCE(wr_return_amt,0.0) AS sales_amt
+       FROM web_sales JOIN item ON i_item_sk=ws_item_sk
+                      JOIN date_dim ON d_date_sk=ws_sold_date_sk
+                      LEFT JOIN web_returns ON (ws_order_number=wr_order_number 
+                                            AND ws_item_sk=wr_item_sk)
+       WHERE i_category='Sports') sales_detail
+ GROUP BY d_year, i_brand_id, i_class_id, i_category_id, i_manufact_id)
+ SELECT  prev_yr.d_year AS prev_year
+                          ,curr_yr.d_year AS year
+                          ,curr_yr.i_brand_id
+                          ,curr_yr.i_class_id
+                          ,curr_yr.i_category_id
+                          ,curr_yr.i_manufact_id
+                          ,prev_yr.sales_cnt AS prev_yr_cnt
+                          ,curr_yr.sales_cnt AS curr_yr_cnt
+                          ,curr_yr.sales_cnt-prev_yr.sales_cnt AS sales_cnt_diff
+                          ,curr_yr.sales_amt-prev_yr.sales_amt AS sales_amt_diff
+ FROM all_sales curr_yr, all_sales prev_yr
+ WHERE curr_yr.i_brand_id=prev_yr.i_brand_id
+   AND curr_yr.i_class_id=prev_yr.i_class_id
+   AND curr_yr.i_category_id=prev_yr.i_category_id
+   AND curr_yr.i_manufact_id=prev_yr.i_manufact_id
+   AND curr_yr.d_year=2002
+   AND prev_yr.d_year=2002-1
+   AND CAST(curr_yr.sales_cnt AS DECIMAL(17,2))/CAST(prev_yr.sales_cnt AS DECIMAL(17,2))<0.9
+ ORDER BY sales_cnt_diff,sales_amt_diff
+ limit 100
+;
+
+--= query_76
+select  channel, col_name, d_year, d_qoy, i_category, COUNT(*) sales_cnt, SUM(ext_sales_price) sales_amt FROM (
+        SELECT 'store' as channel, 'ss_customer_sk' col_name, d_year, d_qoy, i_category, ss_ext_sales_price ext_sales_price
+         FROM store_sales, item, date_dim
+         WHERE ss_customer_sk IS NULL
+           AND ss_sold_date_sk=d_date_sk
+           AND ss_item_sk=i_item_sk
+        UNION ALL
+        SELECT 'web' as channel, 'ws_promo_sk' col_name, d_year, d_qoy, i_category, ws_ext_sales_price ext_sales_price
+         FROM web_sales, item, date_dim
+         WHERE ws_promo_sk IS NULL
+           AND ws_sold_date_sk=d_date_sk
+           AND ws_item_sk=i_item_sk
+        UNION ALL
+        SELECT 'catalog' as channel, 'cs_bill_customer_sk' col_name, d_year, d_qoy, i_category, cs_ext_sales_price ext_sales_price
+         FROM catalog_sales, item, date_dim
+         WHERE cs_bill_customer_sk IS NULL
+           AND cs_sold_date_sk=d_date_sk
+           AND cs_item_sk=i_item_sk) foo
+GROUP BY channel, col_name, d_year, d_qoy, i_category
+ORDER BY channel, col_name, d_year, d_qoy, i_category
+limit 100
+;
+
+--= query_77
+with ss as
+ (select s_store_sk,
+         sum(ss_ext_sales_price) as sales,
+         sum(ss_net_profit) as profit
+ from store_sales,
+      date_dim,
+      store
+ where ss_sold_date_sk = d_date_sk
+       and d_date between cast('2000-08-10' as datetime) 
+                  and (cast('2000-09-09' as datetime)) 
+       and ss_store_sk = s_store_sk
+ group by s_store_sk)
+ ,
+ sr as
+ (select s_store_sk,
+         sum(sr_return_amt) as returns,
+         sum(sr_net_loss) as profit_loss
+ from store_returns,
+      date_dim,
+      store
+ where sr_returned_date_sk = d_date_sk
+       and d_date between cast('2000-08-10' as datetime)
+                  and (cast('2000-09-09' as datetime))
+       and sr_store_sk = s_store_sk
+ group by s_store_sk), 
+ cs as
+ (select cs_call_center_sk,
+        sum(cs_ext_sales_price) as sales,
+        sum(cs_net_profit) as profit
+ from catalog_sales,
+      date_dim
+ where cs_sold_date_sk = d_date_sk
+       and d_date between cast('2000-08-10' as datetime)
+                  and (cast('2000-09-09' as datetime))
+ group by cs_call_center_sk 
+ ), 
+ cr as
+ (select cr_call_center_sk,
+         sum(cr_return_amount) as returns,
+         sum(cr_net_loss) as profit_loss
+ from catalog_returns,
+      date_dim
+ where cr_returned_date_sk = d_date_sk
+       and d_date between cast('2000-08-10' as datetime)
+                  and (cast('2000-09-09' as datetime))
+ group by cr_call_center_sk
+ ), 
+ ws as
+ ( select wp_web_page_sk,
+        sum(ws_ext_sales_price) as sales,
+        sum(ws_net_profit) as profit
+ from web_sales,
+      date_dim,
+      web_page
+ where ws_sold_date_sk = d_date_sk
+       and d_date between cast('2000-08-10' as datetime)
+                  and (cast('2000-09-09' as datetime))
+       and ws_web_page_sk = wp_web_page_sk
+ group by wp_web_page_sk), 
+ wr as
+ (select wp_web_page_sk,
+        sum(wr_return_amt) as returns,
+        sum(wr_net_loss) as profit_loss
+ from web_returns,
+      date_dim,
+      web_page
+ where wr_returned_date_sk = d_date_sk
+       and d_date between cast('2000-08-10' as datetime)
+                  and (cast('2000-09-09' as datetime))
+       and wr_web_page_sk = wp_web_page_sk
+ group by wp_web_page_sk)
+  select  channel
+        , id
+        , sum(sales) as sales
+        , sum(returns) as returns
+        , sum(profit) as profit
+ from 
+ (select 'store channel' as channel
+        , ss.s_store_sk as id
+        , sales
+        , coalesce(returns, 0) as returns
+        , (profit - coalesce(profit_loss,0)) as profit
+ from   ss left join sr
+        on  ss.s_store_sk = sr.s_store_sk
+ union all
+ select 'catalog channel' as channel
+        , cs_call_center_sk as id
+        , sales
+        , returns
+        , (profit - profit_loss) as profit
+ from  cs
+       , cr
+ union all
+ select 'web channel' as channel
+        , ws.wp_web_page_sk as id
+        , sales
+        , coalesce(returns, 0) returns
+        , (profit - coalesce(profit_loss,0)) as profit
+ from   ws left join wr
+        on  ws.wp_web_page_sk = wr.wp_web_page_sk
+ ) x
+ group by rollup (channel, id)
+ order by channel
+         ,id
+ limit 100
+;
+
+--= query_78
+with ws as
+  (select d_year AS ws_sold_year, ws_item_sk,
+    ws_bill_customer_sk ws_customer_sk,
+    sum(ws_quantity) ws_qty,
+    sum(ws_wholesale_cost) ws_wc,
+    sum(ws_sales_price) ws_sp
+   from web_sales
+   left join web_returns on wr_order_number=ws_order_number and ws_item_sk=wr_item_sk
+   join date_dim on ws_sold_date_sk = d_date_sk
+   where wr_order_number is null
+   group by d_year, ws_item_sk, ws_bill_customer_sk
+   ),
+cs as
+  (select d_year AS cs_sold_year, cs_item_sk,
+    cs_bill_customer_sk cs_customer_sk,
+    sum(cs_quantity) cs_qty,
+    sum(cs_wholesale_cost) cs_wc,
+    sum(cs_sales_price) cs_sp
+   from catalog_sales
+   left join catalog_returns on cr_order_number=cs_order_number and cs_item_sk=cr_item_sk
+   join date_dim on cs_sold_date_sk = d_date_sk
+   where cr_order_number is null
+   group by d_year, cs_item_sk, cs_bill_customer_sk
+   ),
+ss as
+  (select d_year AS ss_sold_year, ss_item_sk,
+    ss_customer_sk,
+    sum(ss_quantity) ss_qty,
+    sum(ss_wholesale_cost) ss_wc,
+    sum(ss_sales_price) ss_sp
+   from store_sales
+   left join store_returns on sr_ticket_number=ss_ticket_number and ss_item_sk=sr_item_sk
+   join date_dim on ss_sold_date_sk = d_date_sk
+   where sr_ticket_number is null
+   group by d_year, ss_item_sk, ss_customer_sk
+   )
+ select 
+ss_customer_sk,
+round(ss_qty::numeric/(coalesce(ws_qty,0)+coalesce(cs_qty,0)),2) ratio,
+ss_qty store_qty, ss_wc store_wholesale_cost, ss_sp store_sales_price,
+coalesce(ws_qty,0)+coalesce(cs_qty,0) other_chan_qty,
+coalesce(ws_wc,0)+coalesce(cs_wc,0) other_chan_wholesale_cost,
+coalesce(ws_sp,0)+coalesce(cs_sp,0) other_chan_sales_price
+from ss
+left join ws on (ws_sold_year=ss_sold_year and ws_item_sk=ss_item_sk and ws_customer_sk=ss_customer_sk)
+left join cs on (cs_sold_year=ss_sold_year and cs_item_sk=ss_item_sk and cs_customer_sk=ss_customer_sk)
+where (coalesce(ws_qty,0)>0 or coalesce(cs_qty, 0)>0) and ss_sold_year=1998
+order by 
+  ss_customer_sk,
+  ss_qty desc, ss_wc desc, ss_sp desc,
+  other_chan_qty,
+  other_chan_wholesale_cost,
+  other_chan_sales_price,
+  ratio
+limit 100
+;
+
+--= query_79
+select 
+  c_last_name,c_first_name,substr(s_city,1,30),ss_ticket_number,amt,profit
+  from
+   (select ss_ticket_number
+          ,ss_customer_sk
+          ,store.s_city
+          ,sum(ss_coupon_amt) amt
+          ,sum(ss_net_profit) profit
+    from store_sales,date_dim,store,household_demographics
+    where store_sales.ss_sold_date_sk = date_dim.d_date_sk
+    and store_sales.ss_store_sk = store.s_store_sk  
+    and store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk
+    and (household_demographics.hd_dep_count = 7 or household_demographics.hd_vehicle_count > -1)
+    and date_dim.d_dow = 1
+    and date_dim.d_year in (2000,2000+1,2000+2) 
+    and store.s_number_employees between 200 and 295
+    group by ss_ticket_number,ss_customer_sk,ss_addr_sk,store.s_city) ms,customer
+    where ss_customer_sk = c_customer_sk
+ order by c_last_name,c_first_name,substr(s_city,1,30), profit
+limit 100
+;
+
+--= query_80
+with ssr as
+ (select  s_store_id as store_id,
+          sum(ss_ext_sales_price) as sales,
+          sum(coalesce(sr_return_amt, 0)) as returns,
+          sum(ss_net_profit - coalesce(sr_net_loss, 0)) as profit
+  from store_sales left outer join store_returns on
+         (ss_item_sk = sr_item_sk and ss_ticket_number = sr_ticket_number),
+     date_dim,
+     store,
+     item,
+     promotion
+ where ss_sold_date_sk = d_date_sk
+       and d_date between cast('2002-08-14' as datetime) 
+                  and (cast('2002-09-13' as datetime))
+       and ss_store_sk = s_store_sk
+       and ss_item_sk = i_item_sk
+       and i_current_price > 50
+       and ss_promo_sk = p_promo_sk
+       and p_channel_tv = 'N'
+ group by s_store_id)
+ ,
+ csr as
+ (select  cp_catalog_page_id as catalog_page_id,
+          sum(cs_ext_sales_price) as sales,
+          sum(coalesce(cr_return_amount, 0)) as returns,
+          sum(cs_net_profit - coalesce(cr_net_loss, 0)) as profit
+  from catalog_sales left outer join catalog_returns on
+         (cs_item_sk = cr_item_sk and cs_order_number = cr_order_number),
+     date_dim,
+     catalog_page,
+     item,
+     promotion
+ where cs_sold_date_sk = d_date_sk
+       and d_date between cast('2002-08-14' as datetime)
+                  and (cast('2002-09-13' as datetime))
+        and cs_catalog_page_sk = cp_catalog_page_sk
+       and cs_item_sk = i_item_sk
+       and i_current_price > 50
+       and cs_promo_sk = p_promo_sk
+       and p_channel_tv = 'N'
+group by cp_catalog_page_id)
+ ,
+ wsr as
+ (select  web_site_id,
+          sum(ws_ext_sales_price) as sales,
+          sum(coalesce(wr_return_amt, 0)) as returns,
+          sum(ws_net_profit - coalesce(wr_net_loss, 0)) as profit
+  from web_sales left outer join web_returns on
+         (ws_item_sk = wr_item_sk and ws_order_number = wr_order_number),
+     date_dim,
+     web_site,
+     item,
+     promotion
+ where ws_sold_date_sk = d_date_sk
+       and d_date between cast('2002-08-14' as datetime)
+                  and (cast('2002-09-13' as datetime))
+        and ws_web_site_sk = web_site_sk
+       and ws_item_sk = i_item_sk
+       and i_current_price > 50
+       and ws_promo_sk = p_promo_sk
+       and p_channel_tv = 'N'
+group by web_site_id)
+  select  channel
+        , id
+        , sum(sales) as sales
+        , sum(returns) as returns
+        , sum(profit) as profit
+ from 
+ (select 'store channel' as channel
+        , 'store' || store_id as id
+        , sales
+        , returns
+        , profit
+ from   ssr
+ union all
+ select 'catalog channel' as channel
+        , 'catalog_page' || catalog_page_id as id
+        , sales
+        , returns
+        , profit
+ from  csr
+ union all
+ select 'web channel' as channel
+        , 'web_site' || web_site_id as id
+        , sales
+        , returns
+        , profit
+ from   wsr
+ ) x
+ group by rollup (channel, id)
+ order by channel
+         ,id
+ limit 100
+;
+
+--= query_81
+with customer_total_return as
+ (select cr_returning_customer_sk as ctr_customer_sk
+        ,ca_state as ctr_state, 
+ 	sum(cr_return_amt_inc_tax) as ctr_total_return
+ from catalog_returns
+     ,date_dim
+     ,customer_address
+ where cr_returned_date_sk = d_date_sk 
+   and d_year =2001
+   and cr_returning_addr_sk = ca_address_sk 
+ group by cr_returning_customer_sk
+         ,ca_state )
+,ctr_state_avg as (select ctr_state, avg(ctr_total_return)*1.2 as ctr_avg from customer_total_return group by ctr_state)
+  select  c_customer_id,c_salutation,c_first_name,c_last_name,ca_street_number,ca_street_name
+                   ,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset
+                  ,ca_location_type,ctr_total_return
+ from customer_total_return ctr1
+     ,customer_address
+     ,customer
+     ,ctr_state_avg
+ where ctr1.ctr_total_return > ctr_state_avg.ctr_avg
+ 			  and ctr_state_avg.ctr_state = ctr1.ctr_state
+       and ca_address_sk = c_current_addr_sk
+       and ca_state = 'TN'
+       and ctr1.ctr_customer_sk = c_customer_sk
+ order by c_customer_id,c_salutation,c_first_name,c_last_name,ca_street_number,ca_street_name
+                   ,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset
+                  ,ca_location_type,ctr_total_return
+ limit 100
+;
+
+--= query_82
+select  i_item_id
+       ,i_item_desc
+       ,i_current_price
+ from item, inventory, date_dim, store_sales
+ where i_current_price between 58 and 58+30
+ and inv_item_sk = i_item_sk
+ and d_date_sk=inv_date_sk
+ and d_date between cast('2001-01-13' as datetime) and (cast('2001-03-14' as datetime))
+ and i_manufact_id in (259,559,580,485)
+ and inv_quantity_on_hand between 100 and 500
+ and ss_item_sk = i_item_sk
+ group by i_item_id,i_item_desc,i_current_price
+ order by i_item_id
+ limit 100
+;
+
+--= query_83
+with sr_items as
+ (select i_item_id item_id,
+        sum(sr_return_quantity) sr_item_qty
+ from store_returns,
+      item,
+      date_dim
+ where sr_item_sk = i_item_sk
+ and   d_date    in 
+	(select d_date
+	from date_dim
+	where d_week_seq in 
+		(select d_week_seq
+		from date_dim
+	  where d_date in ('2001-07-13','2001-09-10','2001-11-16')))
+ and   sr_returned_date_sk   = d_date_sk
+ group by i_item_id),
+ cr_items as
+ (select i_item_id item_id,
+        sum(cr_return_quantity) cr_item_qty
+ from catalog_returns,
+      item,
+      date_dim
+ where cr_item_sk = i_item_sk
+ and   d_date    in 
+	(select d_date
+	from date_dim
+	where d_week_seq in 
+		(select d_week_seq
+		from date_dim
+	  where d_date in ('2001-07-13','2001-09-10','2001-11-16')))
+ and   cr_returned_date_sk   = d_date_sk
+ group by i_item_id),
+ wr_items as
+ (select i_item_id item_id,
+        sum(wr_return_quantity) wr_item_qty
+ from web_returns,
+      item,
+      date_dim
+ where wr_item_sk = i_item_sk
+ and   d_date    in 
+	(select d_date
+	from date_dim
+	where d_week_seq in 
+		(select d_week_seq
+		from date_dim
+		where d_date in ('2001-07-13','2001-09-10','2001-11-16')))
+ and   wr_returned_date_sk   = d_date_sk
+ group by i_item_id)
+  select  sr_items.item_id
+       ,sr_item_qty
+       ,sr_item_qty/(sr_item_qty+cr_item_qty+wr_item_qty)/3.0 * 100 sr_dev
+       ,cr_item_qty
+       ,cr_item_qty/(sr_item_qty+cr_item_qty+wr_item_qty)/3.0 * 100 cr_dev
+       ,wr_item_qty
+       ,wr_item_qty/(sr_item_qty+cr_item_qty+wr_item_qty)/3.0 * 100 wr_dev
+       ,(sr_item_qty+cr_item_qty+wr_item_qty)/3.0 average
+ from sr_items
+     ,cr_items
+     ,wr_items
+ where sr_items.item_id=cr_items.item_id
+   and sr_items.item_id=wr_items.item_id 
+ order by sr_items.item_id
+         ,sr_item_qty
+ limit 100
+;
+
+--= query_84
+select  c_customer_id as customer_id
+       , coalesce(c_last_name,'') || ', ' || coalesce(c_first_name,'') as customername
+ from customer
+     ,customer_address
+     ,customer_demographics
+     ,household_demographics
+     ,income_band
+     ,store_returns
+ where ca_city	        =  'Woodland'
+   and c_current_addr_sk = ca_address_sk
+   and ib_lower_bound   >=  60306
+   and ib_upper_bound   <=  60306 + 50000
+   and ib_income_band_sk = hd_income_band_sk
+   and cd_demo_sk = c_current_cdemo_sk
+   and hd_demo_sk = c_current_hdemo_sk
+   and sr_cdemo_sk = cd_demo_sk
+ order by c_customer_id
+ limit 100
+;
+
+--= query_85
+select  substr(r_reason_desc,1,20)
+       ,avg(ws_quantity)
+       ,avg(wr_refunded_cash)
+       ,avg(wr_fee)
+ from web_sales, web_returns, web_page, customer_demographics cd1,
+      customer_demographics cd2, customer_address, date_dim, reason 
+ where ws_web_page_sk = wp_web_page_sk
+   and ws_item_sk = wr_item_sk
+   and ws_order_number = wr_order_number
+   and ws_sold_date_sk = d_date_sk and d_year = 1998
+   and cd1.cd_demo_sk = wr_refunded_cdemo_sk 
+   and cd2.cd_demo_sk = wr_returning_cdemo_sk
+   and ca_address_sk = wr_refunded_addr_sk
+   and r_reason_sk = wr_reason_sk
+   and
+   (
+    (
+     cd1.cd_marital_status = 'D'
+     and
+     cd1.cd_marital_status = cd2.cd_marital_status
+     and
+     cd1.cd_education_status = 'Primary'
+     and 
+     cd1.cd_education_status = cd2.cd_education_status
+     and
+     ws_sales_price between 100.00 and 150.00
+    )
+   or
+    (
+     cd1.cd_marital_status = 'S'
+     and
+     cd1.cd_marital_status = cd2.cd_marital_status
+     and
+     cd1.cd_education_status = 'College' 
+     and
+     cd1.cd_education_status = cd2.cd_education_status
+     and
+     ws_sales_price between 50.00 and 100.00
+    )
+   or
+    (
+     cd1.cd_marital_status = 'U'
+     and
+     cd1.cd_marital_status = cd2.cd_marital_status
+     and
+     cd1.cd_education_status = 'Advanced Degree'
+     and
+     cd1.cd_education_status = cd2.cd_education_status
+     and
+     ws_sales_price between 150.00 and 200.00
+    )
+   )
+   and
+   (
+    (
+     ca_country = 'United States'
+     and
+     ca_state in ('NC', 'TX', 'IA')
+     and ws_net_profit between 100 and 200  
+    )
+    or
+    (
+     ca_country = 'United States'
+     and
+     ca_state in ('WI', 'WV', 'GA')
+     and ws_net_profit between 150 and 300  
+    )
+    or
+    (
+     ca_country = 'United States'
+     and
+     ca_state in ('OK', 'VA', 'KY')
+     and ws_net_profit between 50 and 250  
+    )
+   )
+group by r_reason_desc
+order by substr(r_reason_desc,1,20)
+        ,avg(ws_quantity)
+        ,avg(wr_refunded_cash)
+        ,avg(wr_fee)
+limit 100
+;
+
+--= query_87
+select count(*) 
+from ((select distinct c_last_name, c_first_name, d_date
+       from store_sales, date_dim, customer
+       where store_sales.ss_sold_date_sk = date_dim.d_date_sk
+         and store_sales.ss_customer_sk = customer.c_customer_sk
+         and d_month_seq between 1202 and 1202+11)
+       except
+      (select distinct c_last_name, c_first_name, d_date
+       from catalog_sales, date_dim, customer
+       where catalog_sales.cs_sold_date_sk = date_dim.d_date_sk
+         and catalog_sales.cs_bill_customer_sk = customer.c_customer_sk
+         and d_month_seq between 1202 and 1202+11)
+       except
+      (select distinct c_last_name, c_first_name, d_date
+       from web_sales, date_dim, customer
+       where web_sales.ws_sold_date_sk = date_dim.d_date_sk
+         and web_sales.ws_bill_customer_sk = customer.c_customer_sk
+         and d_month_seq between 1202 and 1202+11)
+) cool_cust
+;
+
+--= query_88
+select  *
+from
+ (select count(*) h8_30_to_9
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk   
+     and ss_hdemo_sk = household_demographics.hd_demo_sk 
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 8
+     and time_dim.t_minute >= 30
+     and ((household_demographics.hd_dep_count = 0 and household_demographics.hd_vehicle_count<=0+2) or
+          (household_demographics.hd_dep_count = -1 and household_demographics.hd_vehicle_count<=-1+2) or
+          (household_demographics.hd_dep_count = 3 and household_demographics.hd_vehicle_count<=3+2)) 
+     and store.s_store_name = 'ese') s1,
+ (select count(*) h9_to_9_30 
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk 
+     and time_dim.t_hour = 9 
+     and time_dim.t_minute < 30
+     and ((household_demographics.hd_dep_count = 0 and household_demographics.hd_vehicle_count<=0+2) or
+          (household_demographics.hd_dep_count = -1 and household_demographics.hd_vehicle_count<=-1+2) or
+          (household_demographics.hd_dep_count = 3 and household_demographics.hd_vehicle_count<=3+2))
+     and store.s_store_name = 'ese') s2,
+ (select count(*) h9_30_to_10 
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 9
+     and time_dim.t_minute >= 30
+     and ((household_demographics.hd_dep_count = 0 and household_demographics.hd_vehicle_count<=0+2) or
+          (household_demographics.hd_dep_count = -1 and household_demographics.hd_vehicle_count<=-1+2) or
+          (household_demographics.hd_dep_count = 3 and household_demographics.hd_vehicle_count<=3+2))
+     and store.s_store_name = 'ese') s3,
+ (select count(*) h10_to_10_30
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 10 
+     and time_dim.t_minute < 30
+     and ((household_demographics.hd_dep_count = 0 and household_demographics.hd_vehicle_count<=0+2) or
+          (household_demographics.hd_dep_count = -1 and household_demographics.hd_vehicle_count<=-1+2) or
+          (household_demographics.hd_dep_count = 3 and household_demographics.hd_vehicle_count<=3+2))
+     and store.s_store_name = 'ese') s4,
+ (select count(*) h10_30_to_11
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 10 
+     and time_dim.t_minute >= 30
+     and ((household_demographics.hd_dep_count = 0 and household_demographics.hd_vehicle_count<=0+2) or
+          (household_demographics.hd_dep_count = -1 and household_demographics.hd_vehicle_count<=-1+2) or
+          (household_demographics.hd_dep_count = 3 and household_demographics.hd_vehicle_count<=3+2))
+     and store.s_store_name = 'ese') s5,
+ (select count(*) h11_to_11_30
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk 
+     and time_dim.t_hour = 11
+     and time_dim.t_minute < 30
+     and ((household_demographics.hd_dep_count = 0 and household_demographics.hd_vehicle_count<=0+2) or
+          (household_demographics.hd_dep_count = -1 and household_demographics.hd_vehicle_count<=-1+2) or
+          (household_demographics.hd_dep_count = 3 and household_demographics.hd_vehicle_count<=3+2))
+     and store.s_store_name = 'ese') s6,
+ (select count(*) h11_30_to_12
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 11
+     and time_dim.t_minute >= 30
+     and ((household_demographics.hd_dep_count = 0 and household_demographics.hd_vehicle_count<=0+2) or
+          (household_demographics.hd_dep_count = -1 and household_demographics.hd_vehicle_count<=-1+2) or
+          (household_demographics.hd_dep_count = 3 and household_demographics.hd_vehicle_count<=3+2))
+     and store.s_store_name = 'ese') s7,
+ (select count(*) h12_to_12_30
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 12
+     and time_dim.t_minute < 30
+     and ((household_demographics.hd_dep_count = 0 and household_demographics.hd_vehicle_count<=0+2) or
+          (household_demographics.hd_dep_count = -1 and household_demographics.hd_vehicle_count<=-1+2) or
+          (household_demographics.hd_dep_count = 3 and household_demographics.hd_vehicle_count<=3+2))
+     and store.s_store_name = 'ese') s8
+;
+
+--= query_89
+select  *
+from(
+select i_category, i_class, i_brand,
+       s_store_name, s_company_name,
+       d_moy,
+       sum(ss_sales_price) sum_sales,
+       avg(sum(ss_sales_price)) over
+         (partition by i_category, i_brand, s_store_name, s_company_name)
+         avg_monthly_sales
+from item, store_sales, date_dim, store
+where ss_item_sk = i_item_sk and
+      ss_sold_date_sk = d_date_sk and
+      ss_store_sk = s_store_sk and
+      d_year in (2001) and
+        ((i_category in ('Books','Children','Electronics') and
+          i_class in ('history','school-uniforms','audio')
+         )
+      or (i_category in ('Men','Sports','Shoes') and
+          i_class in ('pants','tennis','womens') 
+        ))
+group by i_category, i_class, i_brand,
+         s_store_name, s_company_name, d_moy) tmp1
+where case when (avg_monthly_sales <> 0) then (abs(sum_sales - avg_monthly_sales) / avg_monthly_sales) else null end > 0.1
+order by sum_sales - avg_monthly_sales, s_store_name
+limit 100
+;
+
+--= query_90
+select  cast(amc as decimal(15,4))/nullif(cast(pmc as decimal(15,4)),0) am_pm_ratio
+ from ( select count(*) amc
+       from web_sales, household_demographics , time_dim, web_page
+       where ws_sold_time_sk = time_dim.t_time_sk
+         and ws_ship_hdemo_sk = household_demographics.hd_demo_sk
+         and ws_web_page_sk = web_page.wp_web_page_sk
+         and time_dim.t_hour between 12 and 12+1
+         and household_demographics.hd_dep_count = 6
+         and web_page.wp_char_count between 5000 and 5200) at,
+      ( select count(*) pmc
+       from web_sales, household_demographics , time_dim, web_page
+       where ws_sold_time_sk = time_dim.t_time_sk
+         and ws_ship_hdemo_sk = household_demographics.hd_demo_sk
+         and ws_web_page_sk = web_page.wp_web_page_sk
+         and time_dim.t_hour between 14 and 14+1
+         and household_demographics.hd_dep_count = 6
+         and web_page.wp_char_count between 5000 and 5200) pt
+ order by am_pm_ratio
+ limit 100
+;
+
+--= query_91
+select  
+        cc_call_center_id Call_Center,
+        cc_name Call_Center_Name,
+        cc_manager Manager,
+        sum(cr_net_loss) Returns_Loss
+from
+        call_center,
+        catalog_returns,
+        date_dim,
+        customer,
+        customer_address,
+        customer_demographics,
+        household_demographics
+where
+        cr_call_center_sk       = cc_call_center_sk
+and     cr_returned_date_sk     = d_date_sk
+and     cr_returning_customer_sk= c_customer_sk
+and     cd_demo_sk              = c_current_cdemo_sk
+and     hd_demo_sk              = c_current_hdemo_sk
+and     ca_address_sk           = c_current_addr_sk
+and     d_year                  = 2000 
+and     d_moy                   = 12
+and     ( (cd_marital_status       = 'M' and cd_education_status     = 'Unknown')
+        or(cd_marital_status       = 'W' and cd_education_status     = 'Advanced Degree'))
+and     hd_buy_potential like 'Unknown%'
+and     ca_gmt_offset           = -7
+group by cc_call_center_id,cc_name,cc_manager,cd_marital_status,cd_education_status
+order by sum(cr_net_loss) desc
+;
+
+--= query_92
+select  
+   sum(ws_ext_discount_amt)  as "Excess Discount Amount" 
+from 
+    web_sales 
+   ,item 
+   ,date_dim
+where
+i_manufact_id = 714
+and i_item_sk = ws_item_sk 
+and d_date between '2000-02-01' and 
+        (cast('2000-05-01' as datetime))
+and d_date_sk = ws_sold_date_sk 
+and ws_ext_discount_amt  
+     > ( 
+         SELECT 
+            1.3 * avg(ws_ext_discount_amt) 
+         FROM 
+            web_sales 
+           ,date_dim
+         WHERE 
+              ws_item_sk = i_item_sk 
+          and d_date between '2000-02-01' and
+                             (cast('2000-05-01' as datetime))
+          and d_date_sk = ws_sold_date_sk 
+      ) 
+order by sum(ws_ext_discount_amt)
+limit 100
+;
+
+--= query_93
+select  ss_customer_sk
+            ,sum(act_sales) sumsales
+      from (select ss_item_sk
+                  ,ss_ticket_number
+                  ,ss_customer_sk
+                  ,case when sr_return_quantity is not null then (ss_quantity-sr_return_quantity)*ss_sales_price
+                                                            else (ss_quantity*ss_sales_price) end act_sales
+            from store_sales left outer join store_returns on (sr_item_sk = ss_item_sk
+                                                               and sr_ticket_number = ss_ticket_number)
+                ,reason
+            where sr_reason_sk = r_reason_sk
+              and r_reason_desc = 'reason 58') t
+      group by ss_customer_sk
+      order by sumsales, ss_customer_sk
+limit 100
+;
+
+--= query_94
+select  
+   count(distinct ws_order_number) as "order count"
+  ,sum(ws_ext_ship_cost) as "total shipping cost"
+  ,sum(ws_net_profit) as "total net profit"
+from
+   web_sales ws1
+  ,date_dim
+  ,customer_address
+  ,web_site
+where
+    d_date between '2002-5-01' and 
+           (cast('2002-06-30' as datetime))
+and ws1.ws_ship_date_sk = d_date_sk
+and ws1.ws_ship_addr_sk = ca_address_sk
+and ca_state = 'OK'
+and ws1.ws_web_site_sk = web_site_sk
+and web_company_name = 'pri'
+and exists (select *
+            from web_sales ws2
+            where ws1.ws_order_number = ws2.ws_order_number
+              and ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk)
+and not exists(select *
+               from web_returns wr1
+               where ws1.ws_order_number = wr1.wr_order_number)
+order by count(distinct ws_order_number)
+limit 100
+;
+
+--= query_95
+with ws_wh as
+(select ws1.ws_order_number,ws1.ws_warehouse_sk wh1,ws2.ws_warehouse_sk wh2
+ from web_sales ws1,web_sales ws2
+ where ws1.ws_order_number = ws2.ws_order_number
+   and ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk)
+ select  
+   count(distinct ws_order_number) as "order count"
+  ,sum(ws_ext_ship_cost) as "total shipping cost"
+  ,sum(ws_net_profit) as "total net profit"
+from
+   web_sales ws1
+  ,date_dim
+  ,customer_address
+  ,web_site
+where
+    d_date between '2001-4-01' and 
+           (cast('2001-05-31' as datetime))
+and ws1.ws_ship_date_sk = d_date_sk
+and ws1.ws_ship_addr_sk = ca_address_sk
+and ca_state = 'VA'
+and ws1.ws_web_site_sk = web_site_sk
+and web_company_name = 'pri'
+and ws1.ws_order_number in (select ws_order_number
+                            from ws_wh)
+and ws1.ws_order_number in (select wr_order_number
+                            from web_returns,ws_wh
+                            where wr_order_number = ws_wh.ws_order_number)
+order by count(distinct ws_order_number)
+limit 100
+;
+
+--= query_96
+select  count(*) 
+from store_sales
+    ,household_demographics 
+    ,time_dim, store
+where ss_sold_time_sk = time_dim.t_time_sk   
+    and ss_hdemo_sk = household_demographics.hd_demo_sk 
+    and ss_store_sk = s_store_sk
+    and time_dim.t_hour = 8
+    and time_dim.t_minute >= 30
+    and household_demographics.hd_dep_count = 0
+    and store.s_store_name = 'ese'
+order by count(*)
+limit 100
+;
+
+--= query_97
+with ssci as (
+select ss_customer_sk customer_sk
+      ,ss_item_sk item_sk
+from store_sales,date_dim
+where ss_sold_date_sk = d_date_sk
+  and d_month_seq between 1199 and 1199 + 11
+group by ss_customer_sk
+        ,ss_item_sk),
+csci as(
+ select cs_bill_customer_sk customer_sk
+      ,cs_item_sk item_sk
+from catalog_sales,date_dim
+where cs_sold_date_sk = d_date_sk
+  and d_month_seq between 1199 and 1199 + 11
+group by cs_bill_customer_sk
+        ,cs_item_sk)
+ select  sum(case when ssci.customer_sk is not null and csci.customer_sk is null then 1 else 0 end) store_only
+      ,sum(case when ssci.customer_sk is null and csci.customer_sk is not null then 1 else 0 end) catalog_only
+      ,sum(case when ssci.customer_sk is not null and csci.customer_sk is not null then 1 else 0 end) store_and_catalog
+from ssci full outer join csci on (ssci.customer_sk=csci.customer_sk
+                               and ssci.item_sk = csci.item_sk)
+limit 100
+;
+
+--= query_98
+select i_item_id
+      ,i_item_desc 
+      ,i_category 
+      ,i_class 
+      ,i_current_price
+      ,sum(ss_ext_sales_price) as itemrevenue 
+      ,sum(ss_ext_sales_price)*100/sum(sum(ss_ext_sales_price)) over
+          (partition by i_class) as revenueratio
+from	
+	store_sales
+    	,item 
+    	,date_dim
+where 
+	ss_item_sk = i_item_sk 
+  	and i_category in ('Men', 'Sports', 'Jewelry')
+  	and ss_sold_date_sk = d_date_sk
+	and d_date between cast('1999-02-05' as datetime) 
+				and (cast('1999-03-07' as datetime))
+group by 
+	i_item_id
+        ,i_item_desc 
+        ,i_category
+        ,i_class
+        ,i_current_price
+order by 
+	i_category
+        ,i_class
+        ,i_item_id
+        ,i_item_desc
+        ,revenueratio
+;
+
+--= query_99
+select  
+   substr(w_warehouse_name,1,20)
+  ,sm_type
+  ,cc_name
+  ,sum(case when (cs_ship_date_sk - cs_sold_date_sk <= 30 ) then 1 else 0 end)  as "30 days" 
+  ,sum(case when (cs_ship_date_sk - cs_sold_date_sk > 30) and 
+                 (cs_ship_date_sk - cs_sold_date_sk <= 60) then 1 else 0 end )  as "31-60 days" 
+  ,sum(case when (cs_ship_date_sk - cs_sold_date_sk > 60) and 
+                 (cs_ship_date_sk - cs_sold_date_sk <= 90) then 1 else 0 end)  as "61-90 days" 
+  ,sum(case when (cs_ship_date_sk - cs_sold_date_sk > 90) and
+                 (cs_ship_date_sk - cs_sold_date_sk <= 120) then 1 else 0 end)  as "91-120 days" 
+  ,sum(case when (cs_ship_date_sk - cs_sold_date_sk  > 120) then 1 else 0 end)  as ">120 days" 
+from
+   catalog_sales
+  ,warehouse
+  ,ship_mode
+  ,call_center
+  ,date_dim
+where
+    d_month_seq between 1194 and 1194 + 11
+and cs_ship_date_sk   = d_date_sk
+and cs_warehouse_sk   = w_warehouse_sk
+and cs_ship_mode_sk   = sm_ship_mode_sk
+and cs_call_center_sk = cc_call_center_sk
+group by
+   substr(w_warehouse_name,1,20)
+  ,sm_type
+  ,cc_name
+order by substr(w_warehouse_name,1,20)
+        ,sm_type
+        ,cc_name
+limit 100
+;

--- a/workloads/tpcds/schema.pico.sql
+++ b/workloads/tpcds/schema.pico.sql
@@ -1,0 +1,740 @@
+-- TPC-DS schema for picodata (sbroad / Tarantool). Column names and order
+-- match the ported dsdgen emission and the pg schema; types are adapted to
+-- sbroad's SQL subset (probed against picodata 26.3):
+--   - char(N) -> varchar(N): sbroad has no fixed-width CHAR.
+--   - date    -> datetime:   sbroad has no DATE type (Tarantool datetime).
+--   - every table carries a PRIMARY KEY (Tarantool spaces require one);
+--     key columns are NOT NULL. No FOREIGN KEY (sbroad limitation).
+-- Section layout mirrors schema.pg.sql so tpcds.ts needs no schema-shape
+-- branch: drop_schema (plain DROP TABLE IF EXISTS, no CASCADE), create_schema,
+-- create_indexes. set_timeout/preconfigure_db are omitted (pg-specific SETs;
+-- absent sections are no-ops in the dump pass).
+--+ drop_schema
+--= drop_web_returns
+DROP TABLE IF EXISTS web_returns
+--= drop_web_sales
+DROP TABLE IF EXISTS web_sales
+--= drop_catalog_returns
+DROP TABLE IF EXISTS catalog_returns
+--= drop_catalog_sales
+DROP TABLE IF EXISTS catalog_sales
+--= drop_store_returns
+DROP TABLE IF EXISTS store_returns
+--= drop_store_sales
+DROP TABLE IF EXISTS store_sales
+--= drop_inventory
+DROP TABLE IF EXISTS inventory
+--= drop_item
+DROP TABLE IF EXISTS item
+--= drop_promotion
+DROP TABLE IF EXISTS promotion
+--= drop_store
+DROP TABLE IF EXISTS store
+--= drop_call_center
+DROP TABLE IF EXISTS call_center
+--= drop_customer
+DROP TABLE IF EXISTS customer
+--= drop_customer_address
+DROP TABLE IF EXISTS customer_address
+--= drop_catalog_page
+DROP TABLE IF EXISTS catalog_page
+--= drop_web_site
+DROP TABLE IF EXISTS web_site
+--= drop_web_page
+DROP TABLE IF EXISTS web_page
+--= drop_warehouse
+DROP TABLE IF EXISTS warehouse
+--= drop_time_dim
+DROP TABLE IF EXISTS time_dim
+--= drop_date_dim
+DROP TABLE IF EXISTS date_dim
+--= drop_customer_demographics
+DROP TABLE IF EXISTS customer_demographics
+--= drop_household_demographics
+DROP TABLE IF EXISTS household_demographics
+--= drop_reason
+DROP TABLE IF EXISTS reason
+--= drop_ship_mode
+DROP TABLE IF EXISTS ship_mode
+--= drop_income_band
+DROP TABLE IF EXISTS income_band
+
+--+ create_schema
+--= create_income_band
+CREATE TABLE income_band (
+
+    ib_income_band_sk          integer NOT NULL,
+    ib_lower_bound             integer,
+    ib_upper_bound             integer,
+    PRIMARY KEY (ib_income_band_sk)
+)
+--= create_ship_mode
+CREATE TABLE ship_mode (
+
+    sm_ship_mode_sk            integer NOT NULL,
+    sm_ship_mode_id            varchar(16),
+    sm_type                    varchar(30),
+    sm_code                    varchar(10),
+    sm_carrier                 varchar(20),
+    sm_contract                varchar(20),
+    PRIMARY KEY (sm_ship_mode_sk)
+)
+--= create_reason
+CREATE TABLE reason (
+
+    r_reason_sk                integer NOT NULL,
+    r_reason_id                varchar(16),
+    r_reason_desc              varchar(100),
+    PRIMARY KEY (r_reason_sk)
+)
+--= create_household_demographics
+CREATE TABLE household_demographics (
+
+    hd_demo_sk                 integer NOT NULL,
+    hd_income_band_sk          integer,
+    hd_buy_potential           varchar(15),
+    hd_dep_count               integer,
+    hd_vehicle_count           integer,
+    PRIMARY KEY (hd_demo_sk)
+)
+--= create_customer_demographics
+CREATE TABLE customer_demographics (
+
+    cd_demo_sk                 integer NOT NULL,
+    cd_gender                  varchar(1),
+    cd_marital_status          varchar(1),
+    cd_education_status        varchar(20),
+    cd_purchase_estimate       integer,
+    cd_credit_rating           varchar(10),
+    cd_dep_count               integer,
+    cd_dep_employed_count      integer,
+    cd_dep_college_count       integer,
+    PRIMARY KEY (cd_demo_sk)
+)
+--= create_date_dim
+CREATE TABLE date_dim (
+
+    d_date_sk                  integer NOT NULL,
+    d_date_id                  varchar(16),
+    d_date                     datetime,
+    d_month_seq                integer,
+    d_week_seq                 integer,
+    d_quarter_seq              integer,
+    d_year                     integer,
+    d_dow                      integer,
+    d_moy                      integer,
+    d_dom                      integer,
+    d_qoy                      integer,
+    d_fy_year                  integer,
+    d_fy_quarter_seq           integer,
+    d_fy_week_seq              integer,
+    d_day_name                 varchar(9),
+    d_quarter_name             varchar(6),
+    d_holiday                  varchar(1),
+    d_weekend                  varchar(1),
+    d_following_holiday        varchar(1),
+    d_first_dom                integer,
+    d_last_dom                 integer,
+    d_same_day_ly              integer,
+    d_same_day_lq              integer,
+    d_current_day              varchar(1),
+    d_current_week             varchar(1),
+    d_current_month            varchar(1),
+    d_current_quarter          varchar(1),
+    d_current_year             varchar(1),
+    PRIMARY KEY (d_date_sk)
+)
+--= create_time_dim
+CREATE TABLE time_dim (
+
+    t_time_sk                  integer NOT NULL,
+    t_time_id                  varchar(16),
+    t_time                     integer,
+    t_hour                     integer,
+    t_minute                   integer,
+    t_second                   integer,
+    t_am_pm                    varchar(2),
+    t_shift                    varchar(20),
+    t_sub_shift                varchar(20),
+    t_meal_time                varchar(20),
+    PRIMARY KEY (t_time_sk)
+)
+--= create_warehouse
+CREATE TABLE warehouse (
+
+    w_warehouse_sk             integer NOT NULL,
+    w_warehouse_id             varchar(16),
+    w_warehouse_name           varchar(20),
+    w_warehouse_sq_ft          integer,
+    w_street_number            varchar(10),
+    w_street_name              varchar(60),
+    w_street_type              varchar(15),
+    w_suite_number             varchar(10),
+    w_city                     varchar(60),
+    w_county                   varchar(30),
+    w_state                    varchar(2),
+    w_zip                      varchar(10),
+    w_country                  varchar(20),
+    w_gmt_offset               decimal(5,2),
+    PRIMARY KEY (w_warehouse_sk)
+)
+--= create_web_page
+CREATE TABLE web_page (
+
+    wp_web_page_sk             integer NOT NULL,
+    wp_web_page_id             varchar(16),
+    wp_rec_start_date          datetime,
+    wp_rec_end_date            datetime,
+    wp_creation_date_sk        integer,
+    wp_access_date_sk          integer,
+    wp_autogen_flag            varchar(1),
+    wp_customer_sk             integer,
+    wp_url                     varchar(100),
+    wp_type                    varchar(50),
+    wp_char_count              integer,
+    wp_link_count              integer,
+    wp_image_count             integer,
+    wp_max_ad_count            integer,
+    PRIMARY KEY (wp_web_page_sk)
+)
+--= create_web_site
+CREATE TABLE web_site (
+
+    web_site_sk                integer NOT NULL,
+    web_site_id                varchar(16),
+    web_rec_start_date         datetime,
+    web_rec_end_date           datetime,
+    web_name                   varchar(50),
+    web_open_date_sk           integer,
+    web_close_date_sk          integer,
+    web_class                  varchar(50),
+    web_manager                varchar(40),
+    web_mkt_id                 integer,
+    web_mkt_class              varchar(50),
+    web_mkt_desc               varchar(100),
+    web_market_manager         varchar(40),
+    web_company_id             integer,
+    web_company_name           varchar(50),
+    web_street_number          varchar(10),
+    web_street_name            varchar(60),
+    web_street_type            varchar(15),
+    web_suite_number           varchar(10),
+    web_city                   varchar(60),
+    web_county                 varchar(30),
+    web_state                  varchar(2),
+    web_zip                    varchar(10),
+    web_country                varchar(20),
+    web_gmt_offset             decimal(5,2),
+    web_tax_percentage         decimal(5,2),
+    PRIMARY KEY (web_site_sk)
+)
+--= create_catalog_page
+CREATE TABLE catalog_page (
+
+    cp_catalog_page_sk         integer NOT NULL,
+    cp_catalog_page_id         varchar(16),
+    cp_start_date_sk           integer,
+    cp_end_date_sk             integer,
+    cp_department              varchar(50),
+    cp_catalog_number          integer,
+    cp_catalog_page_number     integer,
+    cp_description             varchar(100),
+    cp_type                    varchar(100),
+    PRIMARY KEY (cp_catalog_page_sk)
+)
+--= create_customer_address
+CREATE TABLE customer_address (
+
+    ca_address_sk              integer NOT NULL,
+    ca_address_id              varchar(16),
+    ca_street_number           varchar(10),
+    ca_street_name             varchar(60),
+    ca_street_type             varchar(15),
+    ca_suite_number            varchar(10),
+    ca_city                    varchar(60),
+    ca_county                  varchar(30),
+    ca_state                   varchar(2),
+    ca_zip                     varchar(10),
+    ca_country                 varchar(20),
+    ca_gmt_offset              decimal(5,2),
+    ca_location_type           varchar(20),
+    PRIMARY KEY (ca_address_sk)
+)
+--= create_customer
+CREATE TABLE customer (
+
+    c_customer_sk              integer NOT NULL,
+    c_customer_id              varchar(16),
+    c_current_cdemo_sk         integer,
+    c_current_hdemo_sk         integer,
+    c_current_addr_sk          integer,
+    c_first_shipto_date_sk     integer,
+    c_first_sales_date_sk      integer,
+    c_salutation               varchar(10),
+    c_first_name               varchar(20),
+    c_last_name                varchar(30),
+    c_preferred_cust_flag      varchar(1),
+    c_birth_day                integer,
+    c_birth_month              integer,
+    c_birth_year               integer,
+    c_birth_country            varchar(20),
+    c_login                    varchar(13),
+    c_email_address            varchar(50),
+    c_last_review_date         varchar(10),
+    PRIMARY KEY (c_customer_sk)
+)
+--= create_call_center
+CREATE TABLE call_center (
+
+    cc_call_center_sk          integer NOT NULL,
+    cc_call_center_id          varchar(16),
+    cc_rec_start_date          datetime,
+    cc_rec_end_date            datetime,
+    cc_closed_date_sk          integer,
+    cc_open_date_sk            integer,
+    cc_name                    varchar(50),
+    cc_class                   varchar(50),
+    cc_employees               integer,
+    cc_sq_ft                   integer,
+    cc_hours                   varchar(20),
+    cc_manager                 varchar(40),
+    cc_mkt_id                  integer,
+    cc_mkt_class               varchar(50),
+    cc_mkt_desc                varchar(100),
+    cc_market_manager          varchar(40),
+    cc_division                integer,
+    cc_division_name           varchar(50),
+    cc_company                 integer,
+    cc_company_name            varchar(50),
+    cc_street_number           varchar(10),
+    cc_street_name             varchar(60),
+    cc_street_type             varchar(15),
+    cc_suite_number            varchar(10),
+    cc_city                    varchar(60),
+    cc_county                  varchar(30),
+    cc_state                   varchar(2),
+    cc_zip                     varchar(10),
+    cc_country                 varchar(20),
+    cc_gmt_offset              decimal(5,2),
+    cc_tax_percentage          decimal(5,2),
+    PRIMARY KEY (cc_call_center_sk)
+)
+--= create_store
+CREATE TABLE store (
+
+    s_store_sk                 integer NOT NULL,
+    s_store_id                 varchar(16),
+    s_rec_start_date           datetime,
+    s_rec_end_date             datetime,
+    s_closed_date_sk           integer,
+    s_store_name               varchar(50),
+    s_number_employees         integer,
+    s_floor_space              integer,
+    s_hours                    varchar(20),
+    s_manager                  varchar(40),
+    s_market_id                integer,
+    s_geography_class          varchar(100),
+    s_market_desc              varchar(100),
+    s_market_manager           varchar(40),
+    s_division_id              integer,
+    s_division_name            varchar(50),
+    s_company_id               integer,
+    s_company_name             varchar(50),
+    s_street_number            varchar(10),
+    s_street_name              varchar(60),
+    s_street_type              varchar(15),
+    s_suite_number             varchar(10),
+    s_city                     varchar(60),
+    s_county                   varchar(30),
+    s_state                    varchar(2),
+    s_zip                      varchar(10),
+    s_country                  varchar(20),
+    s_gmt_offset               decimal(5,2),
+    s_tax_precentage           decimal(5,2),
+    PRIMARY KEY (s_store_sk)
+)
+--= create_promotion
+CREATE TABLE promotion (
+
+    p_promo_sk                 integer NOT NULL,
+    p_promo_id                 varchar(16),
+    p_start_date_sk            integer,
+    p_end_date_sk              integer,
+    p_item_sk                  integer,
+    p_cost                     decimal(15,2),
+    p_response_target          integer,
+    p_promo_name               varchar(50),
+    p_channel_dmail            varchar(1),
+    p_channel_email            varchar(1),
+    p_channel_catalog          varchar(1),
+    p_channel_tv               varchar(1),
+    p_channel_radio            varchar(1),
+    p_channel_press            varchar(1),
+    p_channel_event            varchar(1),
+    p_channel_demo             varchar(1),
+    p_channel_details          varchar(100),
+    p_purpose                  varchar(15),
+    p_discount_active          varchar(1),
+    PRIMARY KEY (p_promo_sk)
+)
+--= create_item
+CREATE TABLE item (
+
+    i_item_sk                  integer NOT NULL,
+    i_item_id                  varchar(16),
+    i_rec_start_date           datetime,
+    i_rec_end_date             datetime,
+    i_item_desc                varchar(200),
+    i_current_price            decimal(7,2),
+    i_wholesale_cost           decimal(7,2),
+    i_brand_id                 integer,
+    i_brand                    varchar(50),
+    i_class_id                 integer,
+    i_class                    varchar(50),
+    i_category_id              integer,
+    i_category                 varchar(50),
+    i_manufact_id              integer,
+    i_manufact                 varchar(50),
+    i_size                     varchar(20),
+    i_formulation              varchar(20),
+    i_color                    varchar(20),
+    i_units                    varchar(10),
+    i_container                varchar(10),
+    i_manager_id               integer,
+    i_product_name             varchar(50),
+    PRIMARY KEY (i_item_sk)
+)
+--= create_inventory
+CREATE TABLE inventory (
+
+    inv_date_sk                integer NOT NULL,
+    inv_item_sk                integer NOT NULL,
+    inv_warehouse_sk           integer NOT NULL,
+    inv_quantity_on_hand       integer,
+    PRIMARY KEY (inv_date_sk, inv_item_sk, inv_warehouse_sk)
+)
+--= create_store_sales
+CREATE TABLE store_sales (
+
+    ss_sold_date_sk            integer,
+    ss_sold_time_sk            integer,
+    ss_item_sk                 integer NOT NULL,
+    ss_customer_sk             integer,
+    ss_cdemo_sk                integer,
+    ss_hdemo_sk                integer,
+    ss_addr_sk                 integer,
+    ss_store_sk                integer,
+    ss_promo_sk                integer,
+    ss_ticket_number           integer NOT NULL,
+    ss_quantity                integer,
+    ss_wholesale_cost          decimal(7,2),
+    ss_list_price              decimal(7,2),
+    ss_sales_price             decimal(7,2),
+    ss_ext_discount_amt        decimal(7,2),
+    ss_ext_sales_price         decimal(7,2),
+    ss_ext_wholesale_cost      decimal(7,2),
+    ss_ext_list_price          decimal(7,2),
+    ss_ext_tax                 decimal(7,2),
+    ss_coupon_amt              decimal(7,2),
+    ss_net_paid                decimal(7,2),
+    ss_net_paid_inc_tax        decimal(7,2),
+    ss_net_profit              decimal(7,2),
+    PRIMARY KEY (ss_item_sk, ss_ticket_number)
+)
+--= create_store_returns
+CREATE TABLE store_returns (
+
+    sr_returned_date_sk        integer,
+    sr_return_time_sk          integer,
+    sr_item_sk                 integer NOT NULL,
+    sr_customer_sk             integer,
+    sr_cdemo_sk                integer,
+    sr_hdemo_sk                integer,
+    sr_addr_sk                 integer,
+    sr_store_sk                integer,
+    sr_reason_sk               integer,
+    sr_ticket_number           integer NOT NULL,
+    sr_return_quantity         integer,
+    sr_return_amt              decimal(7,2),
+    sr_return_tax              decimal(7,2),
+    sr_return_amt_inc_tax      decimal(7,2),
+    sr_fee                     decimal(7,2),
+    sr_return_ship_cost        decimal(7,2),
+    sr_refunded_cash           decimal(7,2),
+    sr_reversed_charge         decimal(7,2),
+    sr_store_credit            decimal(7,2),
+    sr_net_loss                decimal(7,2),
+    PRIMARY KEY (sr_item_sk, sr_ticket_number)
+)
+--= create_catalog_sales
+CREATE TABLE catalog_sales (
+
+    cs_sold_date_sk            integer,
+    cs_sold_time_sk            integer,
+    cs_ship_date_sk            integer,
+    cs_bill_customer_sk        integer,
+    cs_bill_cdemo_sk           integer,
+    cs_bill_hdemo_sk           integer,
+    cs_bill_addr_sk            integer,
+    cs_ship_customer_sk        integer,
+    cs_ship_cdemo_sk           integer,
+    cs_ship_hdemo_sk           integer,
+    cs_ship_addr_sk            integer,
+    cs_call_center_sk          integer,
+    cs_catalog_page_sk         integer,
+    cs_ship_mode_sk            integer,
+    cs_warehouse_sk            integer,
+    cs_item_sk                 integer NOT NULL,
+    cs_promo_sk                integer,
+    cs_order_number            integer NOT NULL,
+    cs_quantity                integer,
+    cs_wholesale_cost          decimal(7,2),
+    cs_list_price              decimal(7,2),
+    cs_sales_price             decimal(7,2),
+    cs_ext_discount_amt        decimal(7,2),
+    cs_ext_sales_price         decimal(7,2),
+    cs_ext_wholesale_cost      decimal(7,2),
+    cs_ext_list_price          decimal(7,2),
+    cs_ext_tax                 decimal(7,2),
+    cs_coupon_amt              decimal(7,2),
+    cs_ext_ship_cost           decimal(7,2),
+    cs_net_paid                decimal(7,2),
+    cs_net_paid_inc_tax        decimal(7,2),
+    cs_net_paid_inc_ship       decimal(7,2),
+    cs_net_paid_inc_ship_tax   decimal(7,2),
+    cs_net_profit              decimal(7,2),
+    PRIMARY KEY (cs_item_sk, cs_order_number)
+)
+--= create_catalog_returns
+CREATE TABLE catalog_returns (
+
+    cr_returned_date_sk        integer,
+    cr_returned_time_sk        integer,
+    cr_item_sk                 integer NOT NULL,
+    cr_refunded_customer_sk    integer,
+    cr_refunded_cdemo_sk       integer,
+    cr_refunded_hdemo_sk       integer,
+    cr_refunded_addr_sk        integer,
+    cr_returning_customer_sk   integer,
+    cr_returning_cdemo_sk      integer,
+    cr_returning_hdemo_sk      integer,
+    cr_returning_addr_sk       integer,
+    cr_call_center_sk          integer,
+    cr_catalog_page_sk         integer,
+    cr_ship_mode_sk            integer,
+    cr_warehouse_sk            integer,
+    cr_reason_sk               integer,
+    cr_order_number            integer NOT NULL,
+    cr_return_quantity         integer,
+    cr_return_amount           decimal(7,2),
+    cr_return_tax              decimal(7,2),
+    cr_return_amt_inc_tax      decimal(7,2),
+    cr_fee                     decimal(7,2),
+    cr_return_ship_cost        decimal(7,2),
+    cr_refunded_cash           decimal(7,2),
+    cr_reversed_charge         decimal(7,2),
+    cr_store_credit            decimal(7,2),
+    cr_net_loss                decimal(7,2),
+    PRIMARY KEY (cr_item_sk, cr_order_number)
+)
+--= create_web_sales
+CREATE TABLE web_sales (
+
+    ws_sold_date_sk            integer,
+    ws_sold_time_sk            integer,
+    ws_ship_date_sk            integer,
+    ws_item_sk                 integer NOT NULL,
+    ws_bill_customer_sk        integer,
+    ws_bill_cdemo_sk           integer,
+    ws_bill_hdemo_sk           integer,
+    ws_bill_addr_sk            integer,
+    ws_ship_customer_sk        integer,
+    ws_ship_cdemo_sk           integer,
+    ws_ship_hdemo_sk           integer,
+    ws_ship_addr_sk            integer,
+    ws_web_page_sk             integer,
+    ws_web_site_sk             integer,
+    ws_ship_mode_sk            integer,
+    ws_warehouse_sk            integer,
+    ws_promo_sk                integer,
+    ws_order_number            integer NOT NULL,
+    ws_quantity                integer,
+    ws_wholesale_cost          decimal(7,2),
+    ws_list_price              decimal(7,2),
+    ws_sales_price             decimal(7,2),
+    ws_ext_discount_amt        decimal(7,2),
+    ws_ext_sales_price         decimal(7,2),
+    ws_ext_wholesale_cost      decimal(7,2),
+    ws_ext_list_price          decimal(7,2),
+    ws_ext_tax                 decimal(7,2),
+    ws_coupon_amt              decimal(7,2),
+    ws_ext_ship_cost           decimal(7,2),
+    ws_net_paid                decimal(7,2),
+    ws_net_paid_inc_tax        decimal(7,2),
+    ws_net_paid_inc_ship       decimal(7,2),
+    ws_net_paid_inc_ship_tax   decimal(7,2),
+    ws_net_profit              decimal(7,2),
+    PRIMARY KEY (ws_item_sk, ws_order_number)
+)
+--= create_web_returns
+CREATE TABLE web_returns (
+
+    wr_returned_date_sk        integer,
+    wr_returned_time_sk        integer,
+    wr_item_sk                 integer NOT NULL,
+    wr_refunded_customer_sk    integer,
+    wr_refunded_cdemo_sk       integer,
+    wr_refunded_hdemo_sk       integer,
+    wr_refunded_addr_sk        integer,
+    wr_returning_customer_sk   integer,
+    wr_returning_cdemo_sk      integer,
+    wr_returning_hdemo_sk      integer,
+    wr_returning_addr_sk       integer,
+    wr_web_page_sk             integer,
+    wr_reason_sk               integer,
+    wr_order_number            integer NOT NULL,
+    wr_return_quantity         integer,
+    wr_return_amt              decimal(7,2),
+    wr_return_tax              decimal(7,2),
+    wr_return_amt_inc_tax      decimal(7,2),
+    wr_fee                     decimal(7,2),
+    wr_return_ship_cost        decimal(7,2),
+    wr_refunded_cash           decimal(7,2),
+    wr_reversed_charge         decimal(7,2),
+    wr_account_credit          decimal(7,2),
+    wr_net_loss                decimal(7,2),
+    PRIMARY KEY (wr_item_sk, wr_order_number)
+)
+
+--+ create_indexes
+-- dimension keys (fact tables join to these)
+--= i_d_date_sk
+create index i_d_date_sk on date_dim (d_date_sk);
+--= i_d_year
+create index i_d_year on date_dim (d_year);
+--= i_d_month_seq
+create index i_d_month_seq on date_dim (d_month_seq);
+--= i_d_week_seq
+create index i_d_week_seq on date_dim (d_week_seq);
+--= i_t_time_sk
+create index i_t_time_sk on time_dim (t_time_sk);
+--= i_i_item_sk
+create index i_i_item_sk on item (i_item_sk);
+--= i_i_category
+create index i_i_category on item (i_category);
+--= i_c_customer_sk
+create index i_c_customer_sk on customer (c_customer_sk);
+--= i_c_current_addr_sk
+create index i_c_current_addr_sk on customer (c_current_addr_sk);
+--= i_c_current_cdemo_sk
+create index i_c_current_cdemo_sk on customer (c_current_cdemo_sk);
+--= i_c_current_hdemo_sk
+create index i_c_current_hdemo_sk on customer (c_current_hdemo_sk);
+--= i_ca_address_sk
+create index i_ca_address_sk on customer_address (ca_address_sk);
+--= i_cd_demo_sk
+create index i_cd_demo_sk on customer_demographics (cd_demo_sk);
+--= i_hd_demo_sk
+create index i_hd_demo_sk on household_demographics (hd_demo_sk);
+--= i_hd_income_band_sk
+create index i_hd_income_band_sk on household_demographics (hd_income_band_sk);
+--= i_ib_income_band_sk
+create index i_ib_income_band_sk on income_band (ib_income_band_sk);
+--= i_s_store_sk
+create index i_s_store_sk on store (s_store_sk);
+--= i_w_warehouse_sk
+create index i_w_warehouse_sk on warehouse (w_warehouse_sk);
+--= i_p_promo_sk
+create index i_p_promo_sk on promotion (p_promo_sk);
+--= i_cc_call_center_sk
+create index i_cc_call_center_sk on call_center (cc_call_center_sk);
+--= i_cp_catalog_page_sk
+create index i_cp_catalog_page_sk on catalog_page (cp_catalog_page_sk);
+--= i_wp_web_page_sk
+create index i_wp_web_page_sk on web_page (wp_web_page_sk);
+--= i_web_site_sk
+create index i_web_site_sk on web_site (web_site_sk);
+--= i_sm_ship_mode_sk
+create index i_sm_ship_mode_sk on ship_mode (sm_ship_mode_sk);
+--= i_r_reason_sk
+create index i_r_reason_sk on reason (r_reason_sk);
+-- store_sales / store_returns
+--= i_ss_sold_date_sk
+create index i_ss_sold_date_sk on store_sales (ss_sold_date_sk);
+--= i_ss_item_sk
+create index i_ss_item_sk on store_sales (ss_item_sk);
+--= i_ss_customer_sk
+create index i_ss_customer_sk on store_sales (ss_customer_sk);
+--= i_ss_cdemo_sk
+create index i_ss_cdemo_sk on store_sales (ss_cdemo_sk);
+--= i_ss_hdemo_sk
+create index i_ss_hdemo_sk on store_sales (ss_hdemo_sk);
+--= i_ss_addr_sk
+create index i_ss_addr_sk on store_sales (ss_addr_sk);
+--= i_ss_store_sk
+create index i_ss_store_sk on store_sales (ss_store_sk);
+--= i_ss_promo_sk
+create index i_ss_promo_sk on store_sales (ss_promo_sk);
+--= i_ss_ticket_number
+create index i_ss_ticket_number on store_sales (ss_ticket_number);
+--= i_sr_returned_date_sk
+create index i_sr_returned_date_sk on store_returns (sr_returned_date_sk);
+--= i_sr_item_sk
+create index i_sr_item_sk on store_returns (sr_item_sk);
+--= i_sr_customer_sk
+create index i_sr_customer_sk on store_returns (sr_customer_sk);
+--= i_sr_ticket_number
+create index i_sr_ticket_number on store_returns (sr_ticket_number);
+-- catalog_sales / catalog_returns
+--= i_cs_sold_date_sk
+create index i_cs_sold_date_sk on catalog_sales (cs_sold_date_sk);
+--= i_cs_ship_date_sk
+create index i_cs_ship_date_sk on catalog_sales (cs_ship_date_sk);
+--= i_cs_item_sk
+create index i_cs_item_sk on catalog_sales (cs_item_sk);
+--= i_cs_bill_customer_sk
+create index i_cs_bill_customer_sk on catalog_sales (cs_bill_customer_sk);
+--= i_cs_bill_cdemo_sk
+create index i_cs_bill_cdemo_sk on catalog_sales (cs_bill_cdemo_sk);
+--= i_cs_bill_hdemo_sk
+create index i_cs_bill_hdemo_sk on catalog_sales (cs_bill_hdemo_sk);
+--= i_cs_bill_addr_sk
+create index i_cs_bill_addr_sk on catalog_sales (cs_bill_addr_sk);
+--= i_cs_warehouse_sk
+create index i_cs_warehouse_sk on catalog_sales (cs_warehouse_sk);
+--= i_cs_order_number
+create index i_cs_order_number on catalog_sales (cs_order_number);
+--= i_cr_returned_date_sk
+create index i_cr_returned_date_sk on catalog_returns (cr_returned_date_sk);
+--= i_cr_item_sk
+create index i_cr_item_sk on catalog_returns (cr_item_sk);
+--= i_cr_order_number
+create index i_cr_order_number on catalog_returns (cr_order_number);
+--= i_cr_returning_customer_sk
+create index i_cr_returning_customer_sk on catalog_returns (cr_returning_customer_sk);
+--= i_cr_returning_addr_sk
+create index i_cr_returning_addr_sk on catalog_returns (cr_returning_addr_sk);
+-- web_sales / web_returns
+--= i_ws_sold_date_sk
+create index i_ws_sold_date_sk on web_sales (ws_sold_date_sk);
+--= i_ws_ship_date_sk
+create index i_ws_ship_date_sk on web_sales (ws_ship_date_sk);
+--= i_ws_item_sk
+create index i_ws_item_sk on web_sales (ws_item_sk);
+--= i_ws_bill_customer_sk
+create index i_ws_bill_customer_sk on web_sales (ws_bill_customer_sk);
+--= i_ws_order_number
+create index i_ws_order_number on web_sales (ws_order_number);
+--= i_wr_returned_date_sk
+create index i_wr_returned_date_sk on web_returns (wr_returned_date_sk);
+--= i_wr_item_sk
+create index i_wr_item_sk on web_returns (wr_item_sk);
+--= i_wr_order_number
+create index i_wr_order_number on web_returns (wr_order_number);
+-- inventory
+--= i_inv_date_sk
+create index i_inv_date_sk on inventory (inv_date_sk);
+--= i_inv_item_sk
+create index i_inv_item_sk on inventory (inv_item_sk);
+--= i_inv_warehouse_sk
+create index i_inv_warehouse_sk on inventory (inv_warehouse_sk);

--- a/workloads/tpcds/tpcds.ts
+++ b/workloads/tpcds/tpcds.ts
@@ -75,11 +75,13 @@ const _sqlByDriver: Record<string, string> = {
   postgres: "./pg.sql",
   mysql: "./mysql.sql",
   ydb: "./ydb.sql",
+  picodata: "./pico.sql",
 };
 const _schemaByDriver: Record<string, string> = {
   postgres: "./schema.pg.sql",
   mysql: "./schema.mysql.sql",
   ydb: "./schema.ydb.sql",
+  picodata: "./schema.pico.sql",
 };
 
 // YDB storage layout. Default 'column': the OLAP column store is the right
@@ -156,6 +158,16 @@ const answersSf1: AnswersFile | null = VALIDATE_ANSWERS ? readAnswersSf1() : nul
 const baked =
   !THROUGHPUT && QUERY_STREAM === "" ? parse_sql(open(SQL_FILE)) : null;
 
+// picodata's sbroad engine has no rank()/dense_rank()/lag()/lead() and no
+// correlated-subquery support to emulate them, so pico.sql omits these 8
+// queries. Log the skip once so a run makes clear why the count is 95, not 103.
+if (driverConfig.driverType === "picodata" && baked) {
+  console.log(
+    "[tpcds] picodata: 8 queries skipped — sbroad lacks rank/dense_rank/lag/lead " +
+      "(query_36, query_44, query_47, query_49, query_57, query_67, query_70, query_86).",
+  );
+}
+
 // resolveQueries returns this VU's query list. Throughput: VU N runs stream N
 // (in-process generated + permuted). Single QUERY_STREAM: that stream. Otherwise
 // the baked canonical set. Memoized per VU.
@@ -187,9 +199,9 @@ function prepareDatabase(): void {
   // "cannot drop table ... because other objects depend on it". MySQL accepts and
   // ignores the CASCADE keyword, so the same statement is portable.
   Step("drop_schema", () => {
-    if (driverConfig.driverType === "ydb") {
-      // YDB has no CASCADE keyword; drop from the schema file's drop_schema
-      // section (per-table `DROP TABLE IF EXISTS`, reverse load order).
+    if (driverConfig.driverType === "ydb" || driverConfig.driverType === "picodata") {
+      // YDB and picodata have no CASCADE keyword; drop from the schema file's
+      // drop_schema section (per-table `DROP TABLE IF EXISTS`, reverse load order).
       execEachLogged(schema("drop_schema"), (q) => driver.exec(q, {}));
       return;
     }
@@ -254,6 +266,8 @@ function prepareDatabase(): void {
         driver.exec(`ANALYZE TABLE ${table}` as unknown as { name: string }, {});
       }
     }
+    // ydb / picodata: no ANALYZE statement (sbroad rejects it); planner runs
+    // without refreshed stats. Indexes built in create_indexes carry it.
   });
 }
 


### PR DESCRIPTION
## Summary

Adds Picodata as a **load target** for TPC-DS. Schema + 24-table bulk load verified end-to-end. The 99-query suite is **out of scope** for this PR — sbroad (picodata's SQL engine) cannot parse it yet (blocker documented below with examples). `pico.sql` ships as the mechanical-transform skeleton and the port starting point.

Also ships a cross-driver fix found along the way: the bulk-insert bind-parameter clamp moved centrally so Picodata (and a latent YDB path) stop overflowing on wide tables.

## What works (picodata)

```bash
./build/stroppy run tpcds/tpcds -d pico \
    -D url=postgres://admin:T0psecret@localhost:1336/admin \
    -e SCALE_FACTOR=1 --no-steps workload
```

- `drop_schema` / `create_schema` / `create_indexes`: all 24 tables + indexes, green.
- `load_data`: **0/24 table errors**, all 24 tables populated.
- Schema (`schema.pico.sql`): `char(N)`→`varchar(N)`, `date`→`datetime`, a `PRIMARY KEY` per Tarantool space (engine-required), no FK. Plain `DROP TABLE IF EXISTS` (picodata has no `CASCADE`). `ANALYZE` skipped (sbroad rejects it).
- `tpcds.ts`: picodata wired into the dialect maps; drop/analyze branches handled.

## What does NOT work — query execution (documented blocker)

sbroad (picodata 26.3) accepts **only** explicit `INNER JOIN ... ON`. It has no comma join, no `CROSS JOIN`, no `PRAGMA` (so no YDB-style `AnsiImplicitCrossJoin`), and no session setting for implicit cross joins. TPC-DS query templates use comma joins pervasively, so **~88 of 95 queries fail at parse time**.

Concrete examples, run against a live picodata 26.3 container:

```sql
SELECT count(*) FROM store_sales, date_dim WHERE ss_sold_date_sk = d_date_sk;
-- ERROR: sbroad: rule parsing error: --> 1:33
--   expected EOI, IndexedByExpr, or DqlOption

SELECT count(*) FROM store_sales CROSS JOIN date_dim WHERE ss_sold_date_sk = d_date_sk;
-- ERROR: sbroad: rule parsing error: --> 1:54
--   expected Identifier

PRAGMA AnsiImplicitCrossJoin;
-- ERROR: sbroad: rule parsing error: --> 1:1
--   expected EOI, ... SetParam, SetTransaction, ...
```

Dominant query failures (all the parser hitting `,` in a FROM list): `expected EOI` ×47, `expected OrderBy` ×21, `expected IndexedByExpr` ×21.

Secondary gaps behind the comma-join wall: `rollup`/`grouping sets` (7 q), `INTERSECT` (4 q; `EXCEPT` works), `FULL OUTER JOIN` (2 q), `rank()`/`dense_rank()`/`lag()`/`lead()` (8 q, engine-missing — already skipped+logged in `tpcds.ts`), correlated subqueries, `datetime+int`, `round()`. `pico.sql`'s header lists them.

`pico.sql` is kept (not stubbed) as the port starting point: date/char/cast fixes and date+N offsets are already baked. Run the workload step only after that port lands; today use `--no-steps workload`.

## Included fix — central batch clamp (independent value)

The 65535 bound-parameter cap (pgwire extended protocol = MySQL prepared Error 1390) was enforced only in the MySQL driver (`capBatchByColumns`). Moved it into the shared `sqldriver.RunBulkInsert` so every sql.DB-backed dialect is protected:

- **picodata**: `date_dim` (28 cols), `catalog_sales`/`web_sales` (34 cols) previously aborted with `extended protocol limited to 65535 parameters` and loaded 0 rows. Fixed.
- **ydb** plain_bulk: was unclamped (latent; tpcds uses native BulkUpsert so never triggered). Now protected.
- **mysql**: behavior identical (central clamp subsumes the per-driver helper, which is removed).

One constant (`maxBoundParameters = 65535`), one place. Net: less code, wider coverage.

## Verification

- `make linter_fix` → 0 issues.
- `make tests` → all packages `ok` (race + coverage).
- Live picodata 26.3 docker, TPC-DS load **0/24 table errors** at both **SCALE_FACTOR=0.01** and **SCALE_FACTOR=1** (SF=1 → 20.45M rows; all 24 tables populated, fact tables at correct SF1 magnitude: inventory 11.7M, store_sales 2.88M, catalog_sales 1.44M, web_sales 719K, customer_demographics 1.92M).

## Follow-ups (not in this PR)

- TPC-DS picodata query port — separate epic. Preferred path: AST comma-join rewrite (parse → lift join predicates from WHERE into ON → nested `INNER JOIN` → deparse), then targeted rollup/intersect/full-outer rewrites; or upstream sbroad implicit-cross-join support.
- File picodata upstream issue for comma-join / `AnsiImplicitCrossJoin` parity with YDB (would also fix tpch-pico queries, which were never actually validated — `TestTpchLoadOnPicodata` only asserts queries are logged, not that they pass).

---
Refs #86 (partial: schema + load + wiring landed; query dialect still open — blocked on sbroad comma-join gap).
