### PR TITLE
fix(tpcb): retry transactions on serialization conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Fixed
 
-- TPC-B transactions now retry on serialization conflicts instead of failing the run. The `tpcb/tx` workload issued its transaction with no retry wrapper, so under concurrent VUs the first serializable abort — PostgreSQL `40001`/`40P01`, MySQL `1213`, or YDB `Transaction locks invalidated` — was thrown straight to the error log and aborted the whole run, even though every other transactional workload (tpcc/tpch/tpcds) already retries these. tpcb now applies the same retry policy, so transient contention is replayed instead of surfaced (visible as the new `tpcb_retry_attempts` counter).
+- TPC-B transactions now retry on serialization conflicts instead of failing the run. The `tpcb/tx` workload issued its transaction with no retry wrapper, so under concurrent VUs the first serializable abort — PostgreSQL `40001`/`40P01`, MySQL `1213`, or YDB `Transaction locks invalidated` — was thrown straight to the error log and aborted the whole run, even though every other transactional workload (tpcc/tpch/tpcds) already retries these. tpcb now applies the same retry policy, so transient contention is replayed instead of surfaced (visible as the new `tpcb_retry_attempts` counter). ([#108](https://github.com/stroppy-io/stroppy/pull/108))
 
 ## [5.7.0] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ## [Unreleased]
 
+### Fixed
+
+- TPC-B transactions now retry on serialization conflicts instead of failing the run. The `tpcb/tx` workload issued its transaction with no retry wrapper, so under concurrent VUs the first serializable abort — PostgreSQL `40001`/`40P01`, MySQL `1213`, or YDB `Transaction locks invalidated` — was thrown straight to the error log and aborted the whole run, even though every other transactional workload (tpcc/tpch/tpcds) already retries these. tpcb now applies the same retry policy, so transient contention is replayed instead of surfaced (visible as the new `tpcb_retry_attempts` counter).
+
 ## [5.7.0] - 2026-07-22
 
 ### Added

--- a/workloads/tpcb/tpcb_common.ts
+++ b/workloads/tpcb/tpcb_common.ts
@@ -5,6 +5,7 @@
 // prepare/measure lifecycle, the scenario, and teardown.
 import { Teardown } from "k6/x/stroppy";
 import {
+  Counter,
   DriverX,
   Step,
   execEachLogged,
@@ -29,6 +30,8 @@ declare const __VU: number;
 
 // TPC-B Configuration Constants
 export const SCALE_FACTOR = ENV(["SCALE_FACTOR", "BRANCHES"], 1, "TPC-B scale factor");
+export const RETRY_ATTEMPTS = ENV("RETRY_ATTEMPTS", 3, "Max attempts for serialization-failure retries (1 = no retry)");
+export const tpcbRetryAttempts = new Counter("tpcb_retry_attempts");
 const POOL_SIZE = ENV("POOL_SIZE", 50, "Connection pool size");
 const LOAD_WORKERS = ENV("LOAD_WORKERS", 0, "Load-time worker count per spec (0 = framework default)") as number;
 // PostgreSQL only: create LOGGED, flip to UNLOGGED for a WAL-free bulk load,

--- a/workloads/tpcb/tx.ts
+++ b/workloads/tpcb/tx.ts
@@ -4,7 +4,7 @@
 // materializes client-side (that is what pgbench measures). Shares all
 // load/prepare/config logic with procs.ts via tpcb_common.ts; supports all four
 // drivers (pg/mysql/picodata/ydb).
-import { Step } from "./helpers.ts";
+import { Step, retryWithPolicy, txRetryPolicy } from "./helpers.ts";
 import {
   driver,
   sql,
@@ -17,11 +17,26 @@ import {
   bidGen,
   deltaGen,
   nextHid,
+  driverType,
+  RETRY_ATTEMPTS,
+  tpcbRetryAttempts,
 } from "./tpcb_common.ts";
 
 // options re-declared (not `export { … }`) so the catalog's entrypoint scan finds it.
 export const options = scenarioOptions;
 export { teardown };
+
+// Retry serialization/transient failures (PG SQLSTATE 40001/40P01, MySQL 1213,
+// YDB operation/ABORTED + "Transaction locks invalidated") the same way tpcc
+// does: at SF=1 every VU contends on the single pgbench_branches row, so
+// serializable aborts are expected and must be replayed, not thrown.
+const tpcbTxRetryPolicy = txRetryPolicy(driverType, {
+  maxAttempts: RETRY_ATTEMPTS,
+  onRetry: () => { tpcbRetryAttempts.add(1); },
+});
+function tpcbRetry<T>(fn: () => T): T {
+  return retryWithPolicy(tpcbTxRetryPolicy, fn);
+}
 
 export default function (): void {
   // Load runs once across all VUs (process-global); the measured workload is a
@@ -35,7 +50,7 @@ export default function (): void {
   const hid = nextHid();
 
   Step("workload", () => {
-    driver.beginTx({ isolation: TX_ISOLATION, name: "tpcb" }, (tx) => {
+    tpcbRetry(() => driver.beginTx({ isolation: TX_ISOLATION, name: "tpcb" }, (tx) => {
       tx.exec(sql("workload_tx_tpcb", "update_account")!, { aid, delta });
 
       const abalance = tx.queryValue<number>(
@@ -48,6 +63,6 @@ export default function (): void {
       tx.exec(sql("workload_tx_tpcb", "update_teller")!, { tid, delta });
       tx.exec(sql("workload_tx_tpcb", "update_branch")!, { bid, delta });
       tx.exec(sql("workload_tx_tpcb", "insert_history")!, { hid, tid, bid, aid, delta });
-    });
+    }));
   }, { silent: true });
 }


### PR DESCRIPTION
## Problem
`tpcb/tx` failed on YDB (and would on any driver) under concurrent VUs:

```
GoError: operation/ABORTED (code = 400040 ... 'Transaction locks invalidated. Table: /local/pgbench_branches')
```

The transaction aborted and was **thrown** instead of retried.

## Root cause
`workloads/tpcb/tx.ts` called `driver.beginTx(...)` directly with **no retry wrapper**. Every other transactional workload wraps its tx body in `retryWithPolicy(txRetryPolicy(...))` (tpcc/tpch/tpcds). `txRetryPolicy` already classifies these aborts (including YDB's `Transaction locks invalidated`), but tpcb never applied it. At `SCALE_FACTOR=1` there is a single branch row, so concurrent VUs inevitably contend on `pgbench_branches`.

## Fix
Mirror the tpcc pattern:
- `tpcb_common.ts`: add `RETRY_ATTEMPTS` env (default 3) + `tpcb_retry_attempts` counter.
- `tx.ts`: build a `txRetryPolicy(driverType, …)` and wrap the `beginTx` body in `retryWithPolicy(...)`.

## Verification
Reproduced against the 4-DB tmpfs harness (`make tmpfs-all-up`, YDB):

```
# before: VUS=2 ITER=1 → level=error ... Transaction locks invalidated
# after:  VUS=2 ITER=1 → exit 0, 0 error lines; tpcb_retry_attempts counter increments
```

The heavier single-branch contention at SF=1 can still exhaust the 3-attempt budget under `STROPPY_ERROR_MODE=throw`, but that is inherent to a single contended row at smoke scale — the fix makes tpcb behave like tpcc.

Found during the #89 workload×target matrix run. Fixes #106.