### PR TITLE
perf(xk6air): drop hot step/metrics locks that serialized all VUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ## [Unreleased]
 
+### Changed
+
+- Stroppy runs scale better at high VU counts. A single shared mutex guarded the active-step tag and was write-locked on every `Step()` plus read on every metric sample, so all VUs serialized on it — a 30s CPU profile of a `tpcb` run showed ~940 of ~1000 goroutines parked waiting for it while the database sat idle. The step tag now lives per-VU (lock-free), and the per-transaction metrics snapshot path no longer takes a mutex (pointers are immutable after one-time registration). Microbenchmarks of both paths drop ~140 ns/op to under 1 ns/op at 8 cores. ([#NN](https://github.com/stroppy-io/stroppy/pull/NN))
+
 ## [5.7.0] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
-- Stroppy runs scale better at high VU counts. A single shared mutex guarded the active-step tag and was write-locked on every `Step()` plus read on every metric sample, so all VUs serialized on it — a 30s CPU profile of a `tpcb` run showed ~940 of ~1000 goroutines parked waiting for it while the database sat idle. The step tag now lives per-VU (lock-free), and the per-transaction metrics snapshot path no longer takes a mutex (pointers are immutable after one-time registration). Microbenchmarks of both paths drop ~140 ns/op to under 1 ns/op at 8 cores. ([#NN](https://github.com/stroppy-io/stroppy/pull/NN))
+- Stroppy runs scale better at high VU counts. A single shared mutex guarded the active-step tag and was write-locked on every `Step()` plus read on every metric sample, so all VUs serialized on it — a 30s CPU profile of a `tpcb` run showed ~940 of ~1000 goroutines parked waiting for it while the database sat idle. The step tag now lives per-VU (lock-free), and the per-transaction metrics snapshot path no longer takes a mutex (pointers are immutable after one-time registration). Microbenchmarks of both paths drop ~140 ns/op to under 1 ns/op at 8 cores. ([#109](https://github.com/stroppy-io/stroppy/pull/109))
 
 ## [5.7.0] - 2026-07-22
 

--- a/cmd/xk6air/contention_bench_test.go
+++ b/cmd/xk6air/contention_bench_test.go
@@ -1,0 +1,51 @@
+package xk6air
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/lib"
+)
+
+// minimal VU stub: State()==nil makes SetStepTag return right after the
+// step-state update, so the benchmark measures exactly the synchronization
+// cost of the step-tag path — the code that serialized every VU.
+type benchVU struct{}
+
+func (benchVU) Context() context.Context             { return context.Background() }
+func (benchVU) Events() common.Events                { return common.Events{} }
+func (benchVU) InitEnv() *common.InitEnvironment     { return nil }
+func (benchVU) State() *lib.State                    { return nil }
+func (benchVU) Runtime() *sobek.Runtime              { return nil }
+func (benchVU) RegisterCallback() func(func() error) { return nil }
+
+var _ modules.VU = benchVU{}
+
+// BenchmarkStepTagParallel mirrors the real load: one Instance per VU, all
+// flipping their step tag every iteration. With a shared mutex this serializes
+// across VUs; with a per-VU field it scales linearly. Run at -cpu=1,8,16 to
+// surface contention regressions.
+func BenchmarkStepTagParallel(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		i := &Instance{vu: benchVU{}} // one Instance per worker, like k6 per VU
+		for pb.Next() {
+			i.SetStepTag("load_data")
+			i.ClearStepTag("load_data")
+		}
+	})
+}
+
+// BenchmarkTxMetricsSnapshotParallel stresses the metric-snapshot read path
+// hit by every tx/query/insert. Snapshots return immutable pointers set once
+// at registration, so the read path must stay lock-free.
+func BenchmarkTxMetricsSnapshotParallel(b *testing.B) {
+	m := &txMetrics{}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _, _ = m.snapshotCountMetric()
+		}
+	})
+}

--- a/cmd/xk6air/instance.go
+++ b/cmd/xk6air/instance.go
@@ -29,6 +29,11 @@ type Instance struct {
 
 	// drivers tracks all DriverWrappers created by this instance for teardown.
 	drivers []*DriverWrapper
+
+	// activeStep is the logical Stroppy step this VU is currently in.
+	// Per-VU and single-goroutine (k6 drives one VU on one goroutine), so no
+	// lock needed. A shared mutex here serialized every VU on every Step().
+	activeStep string
 }
 
 // NewInstance creates new instance of module.
@@ -52,7 +57,7 @@ func (i *Instance) Exports() modules.Exports {
 			"NotifyStep":   rootModule.NotifyStep,
 			"SetStepTag":   i.SetStepTag,
 			"ClearStepTag": i.ClearStepTag,
-			"CurrentStep":  rootModule.CurrentStep,
+			"CurrentStep":  i.CurrentStep,
 			"NewDriver":    i.NewDriver,
 			"Teardown":     rootModule.Teardown,
 			"NewPicker":    NewPicker,
@@ -90,7 +95,7 @@ func (i *Instance) Exports() modules.Exports {
 
 // SetStepTag marks subsequent VU metric samples with the logical Stroppy step.
 func (i *Instance) SetStepTag(name string) {
-	rootModule.SetCurrentStep(name)
+	i.activeStep = name
 
 	state := i.vu.State()
 	if state == nil || state.Tags == nil {
@@ -104,7 +109,9 @@ func (i *Instance) SetStepTag(name string) {
 
 // ClearStepTag removes the logical Stroppy step tag if it is still active.
 func (i *Instance) ClearStepTag(name string) {
-	rootModule.ClearCurrentStep(name)
+	if i.activeStep == name {
+		i.activeStep = ""
+	}
 
 	state := i.vu.State()
 	if state == nil || state.Tags == nil {
@@ -117,6 +124,11 @@ func (i *Instance) ClearStepTag(name string) {
 			tagsAndMeta.DeleteTag("step")
 		}
 	})
+}
+
+// CurrentStep returns the logical Stroppy step this VU is currently in.
+func (i *Instance) CurrentStep() string {
+	return i.activeStep
 }
 
 // NewDriver creates an empty DriverWrapper shell.

--- a/cmd/xk6air/metrics.go
+++ b/cmd/xk6air/metrics.go
@@ -16,8 +16,11 @@ import (
 const throughputInterval = time.Second
 
 type txMetrics struct {
-	mu sync.Mutex
-
+	// mu guards registration only. After registered is set, all metric/tag
+	// pointers below are immutable, so the hot snapshot/start/stop paths read
+	// them lock-free.
+	mu          sync.Mutex
+	registered  atomic.Bool
 	txCount      *k6metrics.Metric
 	txTPS        *k6metrics.Metric
 	runQueryQPS  *k6metrics.Metric
@@ -34,13 +37,17 @@ type txMetrics struct {
 }
 
 type throughputSampler struct {
-	started bool
-	stopped bool
+	started atomic.Bool
+	stopped atomic.Bool
 	stopCh  chan struct{}
 	doneCh  chan struct{}
 }
 
 func (m *txMetrics) ensureRegistered(vu modules.VU, lg *zap.Logger) {
+	if m.registered.Load() {
+		return
+	}
+
 	initEnv := vu.InitEnv()
 	if initEnv == nil {
 		return
@@ -48,8 +55,7 @@ func (m *txMetrics) ensureRegistered(vu modules.VU, lg *zap.Logger) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.txCount != nil && m.txTPS != nil && m.runQueryQPS != nil &&
-		m.insertRows != nil && m.progressRows != nil && m.progressRPS != nil {
+	if m.registered.Load() {
 		return
 	}
 
@@ -86,6 +92,7 @@ func (m *txMetrics) ensureRegistered(vu modules.VU, lg *zap.Logger) {
 	m.progressRows = progressRows
 	m.progressRPS = progressRPS
 	m.tags = registry.RootTagSet()
+	m.registered.Store(true)
 }
 
 func (m *txMetrics) recordQuery(vu modules.VU) {
@@ -112,8 +119,6 @@ func (m *txMetrics) recordInsertProgress(vu modules.VU, snapshot insertprogress.
 	}
 	if state.Tags != nil {
 		tags = currentVUTags(state.Tags.GetCurrentValues(), tags)
-	} else {
-		tags = withCurrentStepTag(tags)
 	}
 
 	tags = tags.With("table_name", snapshot.Table).
@@ -157,8 +162,6 @@ func (m *txMetrics) recordInsert(vu modules.VU, table string, rows int64) {
 	}
 	if state.Tags != nil {
 		tags = currentVUTags(state.Tags.GetCurrentValues(), tags)
-	} else {
-		tags = withCurrentStepTag(tags)
 	}
 
 	if table == "" {
@@ -198,8 +201,6 @@ func (m *txMetrics) record(vu modules.VU, action, name string, isolation stroppy
 	}
 	if state.Tags != nil {
 		tags = currentVUTags(state.Tags.GetCurrentValues(), tags)
-	} else {
-		tags = withCurrentStepTag(tags)
 	}
 	now := time.Now()
 	tags = tags.With("tx_action", action)
@@ -221,11 +222,8 @@ func (m *txMetrics) record(vu modules.VU, action, name string, isolation stroppy
 }
 
 func (m *txMetrics) start(samples chan<- k6metrics.SampleContainer, ctx context.Context) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.startSamplerLocked(&m.txSampler, &m.txTotal, ctx, samples, m.txTPS, m.tags)
-	m.startSamplerLocked(&m.querySampler, &m.queryTotal, ctx, samples, m.runQueryQPS, m.tags)
+	m.startSampler(&m.txSampler, &m.txTotal, ctx, samples, m.txTPS, m.tags)
+	m.startSampler(&m.querySampler, &m.queryTotal, ctx, samples, m.runQueryQPS, m.tags)
 }
 
 func (m *txMetrics) stop() {
@@ -233,7 +231,7 @@ func (m *txMetrics) stop() {
 	m.stopSampler(&m.querySampler)
 }
 
-func (m *txMetrics) startSamplerLocked(
+func (m *txMetrics) startSampler(
 	sampler *throughputSampler,
 	total *uint64,
 	ctx context.Context,
@@ -241,38 +239,35 @@ func (m *txMetrics) startSamplerLocked(
 	metric *k6metrics.Metric,
 	tags *k6metrics.TagSet,
 ) {
-	if sampler.started || sampler.stopped || metric == nil || tags == nil {
+	if metric == nil || tags == nil || sampler.stopped.Load() {
+		return
+	}
+	if !sampler.started.CompareAndSwap(false, true) {
 		return
 	}
 
-	sampler.started = true
 	sampler.stopCh = make(chan struct{})
 	sampler.doneCh = make(chan struct{})
 	go runThroughputSampler(ctx, samples, metric, tags, total, sampler.stopCh, sampler.doneCh)
 }
 
 func (m *txMetrics) stopSampler(sampler *throughputSampler) {
-	m.mu.Lock()
-	if !sampler.started || sampler.stopped {
-		m.mu.Unlock()
+	if !sampler.stopped.CompareAndSwap(false, true) {
 		return
 	}
-	stopCh := sampler.stopCh
-	doneCh := sampler.doneCh
-	sampler.stopped = true
-	close(stopCh)
-	m.mu.Unlock()
+	if !sampler.started.Load() {
+		return
+	}
 
+	close(sampler.stopCh)
 	select {
-	case <-doneCh:
+	case <-sampler.doneCh:
 	case <-time.After(2 * time.Second):
 	}
 }
 
 func (m *txMetrics) snapshotCountMetric() (*k6metrics.Metric, *k6metrics.TagSet, bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.txCount == nil || m.tags == nil {
+	if !m.registered.Load() {
 		return nil, nil, false
 	}
 	return m.txCount, m.tags, true
@@ -283,12 +278,9 @@ func (m *txMetrics) snapshotInsertMetrics() (
 	*k6metrics.TagSet,
 	bool,
 ) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.insertRows == nil || m.tags == nil {
+	if !m.registered.Load() {
 		return nil, nil, false
 	}
-
 	return m.insertRows, m.tags, true
 }
 
@@ -298,36 +290,20 @@ func (m *txMetrics) snapshotProgressMetrics() (
 	*k6metrics.TagSet,
 	bool,
 ) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.progressRows == nil || m.progressRPS == nil || m.tags == nil {
+	if !m.registered.Load() {
 		return nil, nil, nil, false
 	}
-
 	return m.progressRows, m.progressRPS, m.tags, true
 }
 
+// currentVUTags returns the VU's live tag set, which already carries the
+// "step" tag set by SetStepTag. Falls back to the metric's base tag set when
+// the VU has no tags yet (init phase).
 func currentVUTags(tagsAndMeta k6metrics.TagsAndMeta, fallback *k6metrics.TagSet) *k6metrics.TagSet {
-	tags := fallback
-	if tagsAndMeta.Tags == nil {
-		return withCurrentStepTag(tags)
+	if tagsAndMeta.Tags != nil {
+		return tagsAndMeta.Tags
 	}
-
-	tags = tagsAndMeta.Tags
-	return withCurrentStepTag(tags)
-}
-
-func withCurrentStepTag(tags *k6metrics.TagSet) *k6metrics.TagSet {
-	if tags == nil {
-		return nil
-	}
-	if _, ok := tags.Get("step"); ok {
-		return tags
-	}
-	if step := rootModule.CurrentStep(); step != "" {
-		return tags.With("step", step)
-	}
-	return tags
+	return fallback
 }
 
 func runThroughputSampler(

--- a/cmd/xk6air/module.go
+++ b/cmd/xk6air/module.go
@@ -80,9 +80,6 @@ type RootModule struct {
 	stepsMu sync.Mutex
 	steps   map[string]stroppy.StroppyRun_Status
 
-	activeStepMu sync.RWMutex
-	activeStep   string
-
 	txMetrics *txMetrics
 }
 
@@ -111,26 +108,6 @@ func (r *RootModule) NotifyStep(name string, status int32) {
 		Cmd:    "",
 		Steps:  snapshot,
 	})
-}
-
-func (r *RootModule) SetCurrentStep(name string) {
-	r.activeStepMu.Lock()
-	r.activeStep = name
-	r.activeStepMu.Unlock()
-}
-
-func (r *RootModule) ClearCurrentStep(name string) {
-	r.activeStepMu.Lock()
-	if r.activeStep == name {
-		r.activeStep = ""
-	}
-	r.activeStepMu.Unlock()
-}
-
-func (r *RootModule) CurrentStep() string {
-	r.activeStepMu.RLock()
-	defer r.activeStepMu.RUnlock()
-	return r.activeStep
 }
 
 func (r *RootModule) globalOnceSlot(name string) *globalOnceSlot {


### PR DESCRIPTION
## Problem

A CPU/heap/goroutine profile of a `tpcb` throughput run (captured via `--profiling-enabled`) showed ~**940 of ~1000 goroutines parked** on a single `sync.RWMutex` while the database sat idle (~2% of goroutines in pgx). The run was engine+lock bound, not DB bound.

Root cause: `RootModule.activeStepMu` — one shared `RWMutex` guarding one global `activeStep` string. Every VU write-locked it on each `Step()` (set + clear) and read-locked it on every metric sample. ~14 VUs hammering one writer-priority lock = serialization point. A second hot mutex (`txMetrics.mu`) locked on every tx/query/insert snapshot and sampler start.

## Fix

- **`activeStep` → per-VU `Instance` field.** k6 drives one VU on one goroutine, so no lock is needed. `RootModule.{Set,Clear,Current}Step` and `activeStepMu` deleted. `CurrentStep` export moved to `Instance.CurrentStep()`.
- **`txMetrics` registration gated by `atomic.Bool`.** After registration all metric/tag pointers are immutable, so `snapshot*` and sampler start/stop read them lock-free (`atomic.Bool` CAS for the sampler started/stopped flags). `mu` now guards registration only.
- Removed `withCurrentStepTag` — the VU's live tag set already carries the `step` tag set by `SetStepTag`, so the global fallback was redundant.

## Benchmark

New `cmd/xk6air/contention_bench_test.go` — two parallel benchmarks that degrade if a shared lock is reintroduced. Run `-cpu=1,8,16`:

| benchmark | before (8 cores) | after (8 cores) |
|---|---|---|
| `BenchmarkStepTagParallel` | 139.5 ns/op | 0.43 ns/op |
| `BenchmarkTxMetricsSnapshotParallel` | 78.9 ns/op | 0.08 ns/op |

Both now **scale down** with core count (linear, zero contention). `-race` clean.

## Audit

Other `cmd/xk6air` mutexes reviewed and left as-is — all cold/init-time: `sharedMu` (driver init), `globalOnceMu` (`GlobalOnce`), `instanceMu` (VU init + teardown), `stepsMu` (`NotifyStep`), `namedDictsMu` (dict registration).

## Out of scope (not addressed here)

The heap profile showed two allocation hotspots distinct from locking: `Instance.Exports()` churn and OTel `newAttributeSet` label rebuilding. Separate PR.

## Checklist

- [x] `make linter` — 0 issues
- [x] `make build` — ok
- [x] race detector clean on benches
- [x] CHANGELOG entry under `[Unreleased]` / Changed (PR link to be filled)