### PR TITLE
perf(xk6air): memoize Instance exports table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ## [Unreleased]
 
+### Changed
+
+- Stroppy allocates far less memory in the hot transaction loop. Every reference to a named import (`Step`, `ENV`, `Rel`, `Draw`, `retry`, `DriverX`, …) had k6 rebuild the full module exports table from scratch, which a 30s heap profile showed as the single largest allocator. The exports table is now built once per VU and reused, cutting that churn entirely.
+
 ## [5.7.1] - 2026-07-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
-- Stroppy allocates far less memory in the hot transaction loop. Every reference to a named import (`Step`, `ENV`, `Rel`, `Draw`, `retry`, `DriverX`, …) had k6 rebuild the full module exports table from scratch, which a 30s heap profile showed as the single largest allocator. The exports table is now built once per VU and reused, cutting that churn entirely.
+- Stroppy allocates far less memory in the hot transaction loop. Every reference to a named import (`Step`, `ENV`, `Rel`, `Draw`, `retry`, `DriverX`, …) had k6 rebuild the full module exports table from scratch, which a 30s heap profile showed as the single largest allocator. The exports table is now built once per VU and reused, cutting that churn entirely. ([#110](https://github.com/stroppy-io/stroppy/pull/110))
 
 ## [5.7.1] - 2026-07-23
 

--- a/cmd/xk6air/instance.go
+++ b/cmd/xk6air/instance.go
@@ -34,6 +34,13 @@ type Instance struct {
 	// Per-VU and single-goroutine (k6 drives one VU on one goroutine), so no
 	// lock needed. A shared mutex here serialized every VU on every Step().
 	activeStep string
+
+	// exports memoizes the module exports table. k6 resolves each named-import
+	// binding through GetBindingValue, which calls Exports() on every read;
+	// rebuilding the map per binding access dominated VU allocation. Static
+	// after NewInstance (closures capture this stable pointer), single
+	// goroutine, so no lock.
+	exports modules.Exports
 }
 
 // NewInstance creates new instance of module.
@@ -51,7 +58,10 @@ func NewInstance(vu modules.VU) modules.Instance {
 }
 
 func (i *Instance) Exports() modules.Exports {
-	return modules.Exports{
+	if i.exports.Named != nil {
+		return i.exports
+	}
+	i.exports = modules.Exports{
 		Default: i,
 		Named: map[string]any{
 			"NotifyStep":   rootModule.NotifyStep,
@@ -91,6 +101,7 @@ func (i *Instance) Exports() modules.Exports {
 			"NewDrawGrammar":      NewDrawGrammar,
 		},
 	}
+	return i.exports
 }
 
 // SetStepTag marks subsequent VU metric samples with the logical Stroppy step.


### PR DESCRIPTION
## What

Memoize the per-VU module exports table in `cmd/xk6air.Instance`.

## Why

A 30s heap profile of a `tpcb` run showed `(*Instance).Exports` as the single largest allocator (~518 GB alloc_space / ~4.8B objects, second only to sobek's own `baseObject._put`).

Root cause: k6 resolves each named ES-module import binding through `goModuleInstance.GetBindingValue` (`go.k6.io/k6/js/modules/gomodule.go`), which calls `Exports()` on **every read**:

```go
func (gmi *goModuleInstance) GetBindingValue(name string) (v sobek.Value) {
	if name == jsDefaultExportIdentifier {
		return gmi.getDefaultExport()
	}
	exports := gmi.mi.Exports()              // rebuilt on every binding access
	if exports.Named != nil {
		return gmi.rt.ToValue(exports.Named[name])
	}
}
```

The TS transaction loop references named imports (`Step`, `ENV`, `Rel`, `Draw`, `retry`, `DriverX`, …) on every iteration, so the 30-entry `map[string]any` plus its bound-method values were rebuilt per binding access per VU.

## How

The exports table is static after `NewInstance` — `Default` is the `Instance`, named entries are closures over that stable pointer plus package-level funcs. `Instance` runs on a single goroutine (k6 drives one VU on one goroutine; the same reason `activeStep` needs no lock). So memoize it in a field, no lock.

## Verification

- `make build` clean
- `make tests` green
- `make linter` 0 issues

## Profiles

Before (`~/tmp/2/heap`):
```
645.32GB  sobek.(*baseObject)._put
518.75GB  stroppy/cmd/xk6air.(*Instance).Exports   <-- this PR
230   GB  sobek.(*Runtime).toValue
```