### PR TITLE
chore(workloads): default PG_UNLOGGED to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
-- PostgreSQL data loads now keep tables `LOGGED` by default instead of flipping them to `UNLOGGED` for the bulk load. The `UNLOGGED` optimization (WAL-free load, then flip back) is now opt-in via `-e PG_UNLOGGED=true`. It traded load speed for a sharp footgun: a `prepare` that ran twice on the same schema failed with `could not change table "warehouse" to unlogged because it references logged table "district" (42P16)`, because the foreign keys added at the end of the first prepare block the unlogged flip at the start of the second — so re-running a workload without dropping the schema aborted every iteration. Logged-by-default removes that failure mode entirely.
+- PostgreSQL data loads now keep tables `LOGGED` by default instead of flipping them to `UNLOGGED` for the bulk load. The `UNLOGGED` optimization (WAL-free load, then flip back) is now opt-in via `-e PG_UNLOGGED=true`. It traded load speed for a sharp footgun: a `prepare` that ran twice on the same schema failed with `could not change table "warehouse" to unlogged because it references logged table "district" (42P16)`, because the foreign keys added at the end of the first prepare block the unlogged flip at the start of the second — so re-running a workload without dropping the schema aborted every iteration. Logged-by-default removes that failure mode entirely. ([#111](https://github.com/stroppy-io/stroppy/pull/111))
 
 ## [5.7.1] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ## [Unreleased]
 
+### Changed
+
+- PostgreSQL data loads now keep tables `LOGGED` by default instead of flipping them to `UNLOGGED` for the bulk load. The `UNLOGGED` optimization (WAL-free load, then flip back) is now opt-in via `-e PG_UNLOGGED=true`. It traded load speed for a sharp footgun: a `prepare` that ran twice on the same schema failed with `could not change table "warehouse" to unlogged because it references logged table "district" (42P16)`, because the foreign keys added at the end of the first prepare block the unlogged flip at the start of the second — so re-running a workload without dropping the schema aborted every iteration. Logged-by-default removes that failure mode entirely.
+
 ## [5.7.1] - 2026-07-23
 
 ### Changed

--- a/workloads/tpcb/README.md
+++ b/workloads/tpcb/README.md
@@ -79,7 +79,7 @@ All TPC workloads share one set of run knobs (set with `-e KEY=VALUE`, **not** t
 - `DURATION` set → fixed-duration throughput test (constant `VUS`); result is TPS.
 - `DURATION` unset → power test (`ITER` iterations); result is elapsed time.
 - `MAX_DURATION` (default `24h`) lifts k6's 10-minute per-iteration cap for large loads.
-- `PG_UNLOGGED=false` disables the PostgreSQL `UNLOGGED` bulk-load dance.
+- `PG_UNLOGGED=true` enables the PostgreSQL `UNLOGGED` bulk-load dance (off by default).
 
 The measured workload is a single gatable `workload` step, so prep and measurement
 can run as two passes for a throughput number uncontaminated by load time:

--- a/workloads/tpcb/pg.sql
+++ b/workloads/tpcb/pg.sql
@@ -46,7 +46,7 @@ CREATE TABLE pgbench_history (
 
 --+ set_unlogged
 -- Flip tables to UNLOGGED for a WAL-free bulk load; set_logged restores
--- durability after population. Gated by PG_UNLOGGED (default true), pg-only.
+-- durability after population. Gated by PG_UNLOGGED (default false), pg-only.
 --= branches
 ALTER TABLE pgbench_branches SET UNLOGGED;
 --= tellers

--- a/workloads/tpcb/tpcb_common.ts
+++ b/workloads/tpcb/tpcb_common.ts
@@ -35,8 +35,8 @@ export const tpcbRetryAttempts = new Counter("tpcb_retry_attempts");
 const POOL_SIZE = ENV("POOL_SIZE", 50, "Connection pool size");
 const LOAD_WORKERS = ENV("LOAD_WORKERS", 0, "Load-time worker count per spec (0 = framework default)") as number;
 // PostgreSQL only: create LOGGED, flip to UNLOGGED for a WAL-free bulk load,
-// then back to LOGGED before the workload. Disable with PG_UNLOGGED=false.
-const PG_UNLOGGED = ENV("PG_UNLOGGED", "true", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") !== "false";
+// then back to LOGGED before the workload. Off by default; enable with PG_UNLOGGED=true.
+const PG_UNLOGGED = ENV("PG_UNLOGGED", "false", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") === "true";
 
 const BRANCHES = SCALE_FACTOR;
 const TELLERS = 10 * SCALE_FACTOR;

--- a/workloads/tpcc/README.md
+++ b/workloads/tpcc/README.md
@@ -146,7 +146,7 @@ All TPC workloads share one set of run knobs (set with `-e KEY=VALUE`, **not** t
 - `DURATION` set → fixed-duration throughput test (constant `VUS`); result is TPS.
 - `DURATION` unset → power test (`ITER` iterations); result is elapsed time.
 - `MAX_DURATION` (default `24h`) lifts k6's 10-minute per-iteration cap for large loads.
-- `PG_UNLOGGED=false` disables the PostgreSQL `UNLOGGED` bulk-load dance.
+- `PG_UNLOGGED=true` enables the PostgreSQL `UNLOGGED` bulk-load dance (off by default).
 
 The measured workload is a single gatable `workload` step, so prep and measurement
 can run as two passes for a throughput number uncontaminated by load time:

--- a/workloads/tpcc/pg.sql
+++ b/workloads/tpcc/pg.sql
@@ -135,7 +135,7 @@ CREATE TABLE stock (
 
 --+ set_unlogged
 -- Flip tables to UNLOGGED for a WAL-free bulk load; set_logged restores
--- durability after population. Gated by PG_UNLOGGED (default true), pg-only.
+-- durability after population. Gated by PG_UNLOGGED (default false), pg-only.
 --= warehouse
 ALTER TABLE warehouse  SET UNLOGGED;
 --= district

--- a/workloads/tpcc/tpcc_common.ts
+++ b/workloads/tpcc/tpcc_common.ts
@@ -69,8 +69,8 @@ const LOAD_ITEMS = ENV(
 const LOAD_WORKERS = ENV("LOAD_WORKERS", 0, "Load-time worker count per spec (0 = framework default)") as number;
 export const RETRY_ATTEMPTS = ENV("RETRY_ATTEMPTS", 3, "Max attempts for serialization-failure retries (1 = no retry)");
 // PostgreSQL only: flip to UNLOGGED for a WAL-free bulk load, back to LOGGED
-// after. Disable with PG_UNLOGGED=false. The driverType test stays per-variant.
-export const PG_UNLOGGED = ENV("PG_UNLOGGED", "true", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") !== "false";
+// after. Off by default; enable with PG_UNLOGGED=true. The driverType test stays per-variant.
+export const PG_UNLOGGED = ENV("PG_UNLOGGED", "false", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") === "true";
 
 export const DISTRICTS_PER_WAREHOUSE = 10;
 export const CUSTOMERS_PER_DISTRICT  = 3000;

--- a/workloads/tpcc/tx.ts
+++ b/workloads/tpcc/tx.ts
@@ -121,8 +121,8 @@ const TX_ISOLATION = (
 const driver = DriverX.create().setup(driverConfig);
 
 // PostgreSQL only: flip to UNLOGGED for a WAL-free bulk load, back to LOGGED
-// after. Disable with PG_UNLOGGED=false.
-const PG_UNLOGGED = ENV("PG_UNLOGGED", "true", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") !== "false";
+// after. Off by default; enable with PG_UNLOGGED=true.
+const PG_UNLOGGED = ENV("PG_UNLOGGED", "false", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") === "true";
 const useUnlogged = PG_UNLOGGED && driverConfig.driverType === "postgres";
 
 // picodata/sbroad doesn't support SELECT ... OFFSET, so the by-name

--- a/workloads/tpcds/README.md
+++ b/workloads/tpcds/README.md
@@ -193,7 +193,7 @@ All TPC workloads share one set of run knobs (set with `-e KEY=VALUE`, **not** t
 - `DURATION` set → fixed-duration throughput test (constant `VUS`); result is TPS.
 - `DURATION` unset → power test (`ITER` iterations); result is elapsed time.
 - `MAX_DURATION` (default `24h`) lifts k6's 10-minute per-iteration cap for large loads.
-- `PG_UNLOGGED=false` disables the PostgreSQL `UNLOGGED` bulk-load dance.
+- `PG_UNLOGGED=true` enables the PostgreSQL `UNLOGGED` bulk-load dance (off by default).
 
 The measured workload is a single gatable `workload` step, so prep and measurement
 can run as two passes for a throughput number uncontaminated by load time:

--- a/workloads/tpcds/tpcds.ts
+++ b/workloads/tpcds/tpcds.ts
@@ -63,8 +63,8 @@ const driverConfig = declareDriverSetup(0, {
 const driver = DriverX.create().setup(driverConfig);
 
 // PostgreSQL only: flip to UNLOGGED for a WAL-free bulk load of the 24 tables,
-// back to LOGGED after. Disable with PG_UNLOGGED=false.
-const PG_UNLOGGED = ENV("PG_UNLOGGED", "true", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") !== "false";
+// back to LOGGED after. Off by default; enable with PG_UNLOGGED=true.
+const PG_UNLOGGED = ENV("PG_UNLOGGED", "false", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") === "true";
 const useUnlogged = PG_UNLOGGED && driverConfig.driverType === "postgres";
 
 // The 99 TPC-DS queries, generated per dialect from the official query templates

--- a/workloads/tpch/README.md
+++ b/workloads/tpch/README.md
@@ -99,7 +99,7 @@ All TPC workloads share one set of run knobs (set with `-e KEY=VALUE`, **not** t
 - `DURATION` set → fixed-duration throughput test (constant `VUS`); result is TPS.
 - `DURATION` unset → power test (`ITER` iterations); result is elapsed time.
 - `MAX_DURATION` (default `24h`) lifts k6's 10-minute per-iteration cap for large loads.
-- `PG_UNLOGGED=false` disables the PostgreSQL `UNLOGGED` bulk-load dance.
+- `PG_UNLOGGED=true` enables the PostgreSQL `UNLOGGED` bulk-load dance (off by default).
 
 The measured workload is a single gatable `workload` step, so prep and measurement
 can run as two passes for a throughput number uncontaminated by load time:

--- a/workloads/tpch/pg.sql
+++ b/workloads/tpch/pg.sql
@@ -118,7 +118,7 @@ CREATE TABLE lineitem (
 
 --+ set_unlogged
 -- Flip tables to UNLOGGED for a WAL-free bulk load; set_logged restores
--- durability after population. Gated by PG_UNLOGGED (default true), pg-only.
+-- durability after population. Gated by PG_UNLOGGED (default false), pg-only.
 --= region
 ALTER TABLE region   SET UNLOGGED;
 --= nation

--- a/workloads/tpch/tx.ts
+++ b/workloads/tpch/tx.ts
@@ -270,8 +270,8 @@ const TX_ISOLATION = (
 void TX_ISOLATION; // queries are read-only; kept for symmetry with other workloads.
 
 // PostgreSQL only: create LOGGED, flip to UNLOGGED for a WAL-free bulk load,
-// then back to LOGGED before the workload. Disable with PG_UNLOGGED=false.
-const PG_UNLOGGED = ENV("PG_UNLOGGED", "true", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") !== "false";
+// then back to LOGGED before the workload. Off by default; enable with PG_UNLOGGED=true.
+const PG_UNLOGGED = ENV("PG_UNLOGGED", "false", "pg only: bulk-load with UNLOGGED tables, flip back to LOGGED after") === "true";
 const useUnlogged = PG_UNLOGGED && driverConfig.driverType === "postgres";
 
 const driver = DriverX.create().setup(driverConfig);


### PR DESCRIPTION
## What

Flip `PG_UNLOGGED` default from `true` → `false` across all PostgreSQL workloads (tpcc, tpcb, tpch, tpcds). The UNLOGGED bulk-load optimization is now opt-in via `-e PG_UNLOGGED=true`.

## Why

The UNLOGGED flip (logged → unlogged for the bulk load, back to logged before the workload) traded load speed for a sharp re-run footgun.

`prepareDatabase()` runs in order: `set_unlogged` → `load_data` → … → `set_logged` → `create_foreign_keys`. The foreign keys land only at the very end. A second `prepare` on the **same** schema hits those persisted FKs at `set_unlogged` and aborts every iteration:

```
GoError: global once "tpcc.prepare" failed: GoError: ERROR: could not change
table "warehouse" to unlogged because it references logged table "district"
(SQLSTATE 42P16)
```

Each stroppy process re-runs `GlobalOnce("tpcc.prepare")` fresh, so re-running a workload without dropping the schema (a normal iterate/tune loop) trips this. Surfaced while profiling — a degenerate run logged the error 7.7M times and dominated the heap profile.

The `UNLOGGED` flip is correct and works on a fresh schema; it just shouldn't be the default given how easily it breaks re-runs.

## Changes

- 5 TS definitions: `ENV("PG_UNLOGGED", "true", …) !== "false"` → `ENV("PG_UNLOGGED", "false", …) === "true"` (opt-in)
- `pg.sql` `(default true)` → `(default false)` comments (tpcc/tpcb/tpch)
- README env docs: `=false disables` → `=true enables (off by default)`

## Verification

- `make build` clean (embedded `workloads/` rebuilt)
- `stroppy probe tpcc/tx` → `PG_UNLOGGED="" (default: false)`
- Functional (pg 17.10): load SF=1 → run tx (default) → run tx again on same schema (no drop): both succeed, **0 × 42P16, 0 prepare failures** — the re-run failure mode is gone

`make ts-typecheck` and `make ts-test` fail on this machine on pre-existing toolchain issues unrelated to this change (`tsconfig` `moduleResolution=node10` removed; `vitest` not installed).