### PR TITLE
fix(metrics): bound memory and restore OTLP export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,18 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ## [Unreleased]
 
+### Added
+
+- Metrics can again be exported to an OpenTelemetry collector through the existing `global.exporter.otlpExport` gRPC or HTTP configuration.
+
 ### Changed
 
+- Benchmark metrics now use standard OpenTelemetry counters, gauges, and fixed-bucket histograms. Query throughput and error rates are derived from monotonic `*_total` counters instead of k6-style sampled rates.
 - The `stroppy help <topic>` topics (drivers, config-file, steps, resolution, sql, envs, datagen, probe) now describe the Go-native binary — the previous text still documented the removed TypeScript/k6 workflow (`k6Args`, `declareDriverSetup`, `.ts` script mode, the `--` passthrough).
+
+### Fixed
+
+- Long high-throughput workloads keep bounded metric memory instead of retaining every latency observation until the final summary.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,16 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
-- Metrics can again be exported to an OpenTelemetry collector through the existing `global.exporter.otlpExport` gRPC or HTTP configuration.
+- Metrics can again be exported to an OpenTelemetry collector through the existing `global.exporter.otlpExport` gRPC or HTTP configuration. ([#125](https://github.com/stroppy-io/stroppy/pull/125))
 
 ### Changed
 
-- Benchmark metrics now use standard OpenTelemetry counters, gauges, and fixed-bucket histograms. Query throughput and error rates are derived from monotonic `*_total` counters instead of k6-style sampled rates.
+- Benchmark metrics now use standard OpenTelemetry counters, gauges, and fixed-bucket histograms. Query throughput and error rates are derived from monotonic `*_total` counters instead of k6-style sampled rates. ([#125](https://github.com/stroppy-io/stroppy/pull/125))
 - The `stroppy help <topic>` topics (drivers, config-file, steps, resolution, sql, envs, datagen, probe) now describe the Go-native binary — the previous text still documented the removed TypeScript/k6 workflow (`k6Args`, `declareDriverSetup`, `.ts` script mode, the `--` passthrough).
 
 ### Fixed
 
-- Long high-throughput workloads keep bounded metric memory instead of retaining every latency observation until the final summary.
+- Long high-throughput workloads keep bounded metric memory instead of retaining every latency observation until the final summary. ([#125](https://github.com/stroppy-io/stroppy/pull/125))
 
 ### Removed
 

--- a/cmd/stroppy/commands/help/topic_config_file.go
+++ b/cmd/stroppy/commands/help/topic_config_file.go
@@ -54,6 +54,15 @@ Example stroppy-config.json:
     steps    []string          Step allowlist (same as CLI --steps)
     noSteps  []string          Step blocklist (same as CLI --no-steps)
 
+  OTLP METRICS
+
+    Configure either otlpGrpcEndpoint or otlpHttpEndpoint. If both are set,
+    gRPC wins. otlpEndpointInsecure disables TLS, otlpHeaders accepts a
+    comma-separated key=value list, and otlpMetricsPrefix defaults to
+    "stroppy_". HTTP uses /v1/metrics unless otlpHttpExporterUrlPath overrides
+    it. OTEL_METRIC_EXPORT_INTERVAL sets the export interval in milliseconds
+    (default 10000). With no endpoint, metrics still appear in the local summary.
+
   Driver types: postgres, mysql, picodata, ydb, noop, csv
   Error modes:  silent, log, throw, fail, abort
   Insert methods: native, plain_bulk, plain_query (set per InsertSpec in code)

--- a/cmd/stroppy/commands/run/metrics_test.go
+++ b/cmd/stroppy/commands/run/metrics_test.go
@@ -42,6 +42,15 @@ func TestMetricsConfig(t *testing.T) {
 	require.Equal(t, map[string]string{"environment": "test"}, got.ResourceAttributes)
 }
 
+func TestMetricsConfigWithGlobalWithoutExporter(t *testing.T) {
+	t.Parallel()
+
+	got := metricsConfig(&stroppy.RunConfig{Global: &stroppy.GlobalConfig{RunId: "run-42"}})
+	require.Equal(t, "run-42", got.RunID)
+	require.Empty(t, got.GRPCEndpoint)
+	require.Empty(t, got.HTTPEndpoint)
+}
+
 func TestMetricsConfigWithoutFile(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/stroppy/commands/run/metrics_test.go
+++ b/cmd/stroppy/commands/run/metrics_test.go
@@ -1,0 +1,51 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+)
+
+func TestMetricsConfig(t *testing.T) {
+	t.Parallel()
+
+	grpcEndpoint := "collector:4317"
+	httpEndpoint := "collector:4318"
+	httpPath := "/custom/metrics"
+	headers := "Authorization=secret"
+	insecure := true
+	prefix := "bench_"
+
+	config := &stroppy.RunConfig{Global: &stroppy.GlobalConfig{
+		RunId:    "run-42",
+		Metadata: map[string]string{"environment": "test"},
+		Exporter: &stroppy.ExporterConfig{OtlpExport: &stroppy.OtlpExport{
+			OtlpGrpcEndpoint:        &grpcEndpoint,
+			OtlpHttpEndpoint:        &httpEndpoint,
+			OtlpHttpExporterUrlPath: &httpPath,
+			OtlpHeaders:             &headers,
+			OtlpEndpointInsecure:    &insecure,
+			OtlpMetricsPrefix:       &prefix,
+		}},
+	}}
+
+	got := metricsConfig(config)
+	require.Equal(t, grpcEndpoint, got.GRPCEndpoint)
+	require.Equal(t, httpEndpoint, got.HTTPEndpoint)
+	require.Equal(t, httpPath, got.HTTPPath)
+	require.Equal(t, headers, got.Headers)
+	require.True(t, got.Insecure)
+	require.Equal(t, prefix, got.Prefix)
+	require.Equal(t, "run-42", got.RunID)
+	require.Equal(t, map[string]string{"environment": "test"}, got.ResourceAttributes)
+}
+
+func TestMetricsConfigWithoutFile(t *testing.T) {
+	t.Parallel()
+
+	got := metricsConfig(nil)
+	require.Empty(t, got.GRPCEndpoint)
+	require.Empty(t, got.HTTPEndpoint)
+}

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
+	"github.com/stroppy-io/stroppy/internal/version"
 	"github.com/stroppy-io/stroppy/pkg/bench"
 	"github.com/stroppy-io/stroppy/pkg/common/logger"
 	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
@@ -171,17 +172,42 @@ Config file flags:
 				envOverrides["SQL_FILE"] = file
 			}
 
-			return runGoWorkload(name, steps, noSteps, envOverrides, driverConfigs)
+			return runGoWorkload(name, steps, noSteps, envOverrides, driverConfigs, metricsConfig(fileConfig))
 		}
 
 		// Go-native workload: if a Go workload is registered under the bare
 		// script name, dispatch to bench.Run.
 		if _, ok := bench.Lookup(scriptArg); ok {
-			return runGoWorkload(scriptArg, steps, noSteps, envOverrides, driverConfigs)
+			return runGoWorkload(scriptArg, steps, noSteps, envOverrides, driverConfigs, metricsConfig(fileConfig))
 		}
 
 		return invalidConfig(fmt.Errorf("%w: %q", errUnknownWorkload, scriptArg))
 	},
+}
+
+func metricsConfig(config *stroppy.RunConfig) *bench.MetricsConfig {
+	metrics := &bench.MetricsConfig{ServiceVersion: version.Version}
+	if config == nil || config.GetGlobal() == nil {
+		return metrics
+	}
+
+	global := config.GetGlobal()
+	metrics.RunID = global.GetRunId()
+	metrics.ResourceAttributes = global.GetMetadata()
+
+	export := global.GetExporter().GetOtlpExport()
+	if export == nil {
+		return metrics
+	}
+
+	metrics.GRPCEndpoint = export.GetOtlpGrpcEndpoint()
+	metrics.HTTPEndpoint = export.GetOtlpHttpEndpoint()
+	metrics.HTTPPath = export.GetOtlpHttpExporterUrlPath()
+	metrics.Headers = export.GetOtlpHeaders()
+	metrics.Insecure = export.GetOtlpEndpointInsecure()
+	metrics.Prefix = export.GetOtlpMetricsPrefix()
+
+	return metrics
 }
 
 func invalidConfig(err error) error {
@@ -220,6 +246,7 @@ func runGoWorkload(
 	steps, noSteps []string,
 	envOverrides map[string]string,
 	driverConfigs runner.DriverCLIConfigs,
+	metrics *bench.MetricsConfig,
 ) error {
 	drivers := map[int]*stroppy.DriverConfig{}
 
@@ -254,7 +281,7 @@ func runGoWorkload(
 	}
 
 	ctx := context.Background()
-	if err := bench.Run(ctx, name, drivers, envOverrides, logger.Global()); err != nil {
+	if err := bench.Run(ctx, name, drivers, envOverrides, logger.Global(), metrics); err != nil {
 		return fmt.Errorf("failed to run go workload: %w", err)
 	}
 

--- a/docs/dashboard.json
+++ b/docs/dashboard.json
@@ -425,7 +425,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum(increase(${prefix}tx_errors_total{job=~\"$job\", step=~\"$step\", tx_name=~\"$tx_name\"}[$__range])) or vector(0)) / clamp_min(sum(increase(${prefix}transactions_total{job=~\"$job\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range])), 1)",
+          "expr": "(sum(increase(${prefix}tx_errors_total{job=~\"$job\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range])) or vector(0)) / clamp_min(sum(increase(${prefix}transactions_total{job=~\"$job\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range])), 1)",
           "legendFormat": "errors",
           "range": false,
           "refId": "A",

--- a/docs/dashboard.json
+++ b/docs/dashboard.json
@@ -80,7 +80,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range])) / $__range_s",
+          "expr": "sum(increase(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range])) / $__range_s",
           "legendFormat": "tx/s",
           "range": false,
           "refId": "A",
@@ -149,7 +149,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range]))",
+          "expr": "sum(increase(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range]))",
           "legendFormat": "tx",
           "range": false,
           "refId": "A",
@@ -218,7 +218,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(${prefix}run_query_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", name=~\"$query_name\", type=~\"$query_type\"}[$__range])) / $__range_s",
+          "expr": "sum(increase(${prefix}run_query_operations_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", name=~\"$query_name\", type=~\"$query_type\"}[$__range])) / $__range_s",
           "legendFormat": "queries/s",
           "range": false,
           "refId": "A",
@@ -425,7 +425,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum(increase({__name__=\"${prefix}tx_error_rate_total\", condition=\"nonzero\", job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range])) or vector(0)) / clamp_min(sum(increase({__name__=\"${prefix}tx_error_rate_total\", job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range])), 1e-9)",
+          "expr": "(sum(increase(${prefix}tx_errors_total{job=~\"$job\", step=~\"$step\", tx_name=~\"$tx_name\"}[$__range])) or vector(0)) / clamp_min(sum(increase(${prefix}transactions_total{job=~\"$job\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__range])), 1)",
           "legendFormat": "errors",
           "range": false,
           "refId": "A",
@@ -676,7 +676,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))",
+          "expr": "sum(rate(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))",
           "legendFormat": "tx/s",
           "range": true,
           "refId": "A"
@@ -687,7 +687,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(${prefix}run_query_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", name=~\"$query_name\", type=~\"$query_type\"}[$__rate_interval]))",
+          "expr": "sum(rate(${prefix}run_query_operations_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", name=~\"$query_name\", type=~\"$query_type\"}[$__rate_interval]))",
           "legendFormat": "queries/s",
           "range": true,
           "refId": "B"
@@ -922,7 +922,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "quantile_over_time(0.01, sum(rate(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))[$__range:])",
+          "expr": "quantile_over_time(0.01, sum(rate(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))[$__range:])",
           "legendFormat": "p1",
           "range": false,
           "refId": "A",
@@ -934,7 +934,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "quantile_over_time(0.05, sum(rate(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))[$__range:])",
+          "expr": "quantile_over_time(0.05, sum(rate(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))[$__range:])",
           "legendFormat": "p5",
           "range": false,
           "refId": "B",
@@ -946,7 +946,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "quantile_over_time(0.10, sum(rate(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))[$__range:])",
+          "expr": "quantile_over_time(0.10, sum(rate(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))[$__range:])",
           "legendFormat": "p10",
           "range": false,
           "refId": "C",
@@ -1016,7 +1016,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, quantile_over_time(0.01, sum by (tx_name) (rate(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__rate_interval]))[$__range:]))",
+          "expr": "topk(10, quantile_over_time(0.01, sum by (tx_name) (rate(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__rate_interval]))[$__range:]))",
           "legendFormat": "{{tx_name}}",
           "range": false,
           "refId": "A",
@@ -1086,7 +1086,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, quantile_over_time(0.05, sum by (tx_name) (rate(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__rate_interval]))[$__range:]))",
+          "expr": "topk(10, quantile_over_time(0.05, sum by (tx_name) (rate(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__rate_interval]))[$__range:]))",
           "legendFormat": "{{tx_name}}",
           "range": false,
           "refId": "A",
@@ -1156,7 +1156,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, quantile_over_time(0.10, sum by (tx_name) (rate(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__rate_interval]))[$__range:]))",
+          "expr": "topk(10, quantile_over_time(0.10, sum by (tx_name) (rate(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__rate_interval]))[$__range:]))",
           "legendFormat": "{{tx_name}}",
           "range": false,
           "refId": "A",
@@ -1226,7 +1226,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (tx_name) (increase(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__range])) / $__range_s)",
+          "expr": "topk(10, sum by (tx_name) (increase(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__range])) / $__range_s)",
           "legendFormat": "{{tx_name}}",
           "range": false,
           "refId": "A",
@@ -1466,7 +1466,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (tx_name) (rate(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__rate_interval]))",
+          "expr": "sum by (tx_name) (rate(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\", tx_name!=\"\"}[$__rate_interval]))",
           "legendFormat": "{{tx_name}}",
           "range": true,
           "refId": "A"
@@ -1565,7 +1565,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (tx_action) (rate(${prefix}tx_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))",
+          "expr": "sum by (tx_action) (rate(${prefix}transactions_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", tx_name=~\"$tx_name\", tx_action=~\"$tx_action\", tx_isolation=~\"$tx_isolation\"}[$__rate_interval]))",
           "legendFormat": "{{tx_action}}",
           "range": true,
           "refId": "A"
@@ -1647,7 +1647,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by (name) (increase(${prefix}run_query_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", name=~\"$query_name\", type=~\"$query_type\", name=~\"$query_name\", name!=\"\", type=~\"$query_type\"}[$__range])) / $__range_s)",
+          "expr": "topk(20, sum by (name) (increase(${prefix}run_query_operations_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", name=~\"$query_name\", type=~\"$query_type\", name=~\"$query_name\", name!=\"\", type=~\"$query_type\"}[$__range])) / $__range_s)",
           "legendFormat": "{{name}}",
           "range": false,
           "refId": "A",
@@ -1882,7 +1882,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (type) (rate(${prefix}run_query_count_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", name=~\"$query_name\", type=~\"$query_type\", type!=\"\"}[$__rate_interval]))",
+          "expr": "sum by (type) (rate(${prefix}run_query_operations_total{job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", name=~\"$query_name\", type=~\"$query_type\", type!=\"\"}[$__rate_interval]))",
           "legendFormat": "{{type}}",
           "range": true,
           "refId": "A"
@@ -2296,7 +2296,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum by (table_name) (max_over_time({__name__=\"${prefix}insert_error_rate_total\", condition=\"nonzero\", job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", table_name=~\"$table_name\"}[$__range])) or sum by (table_name) (max_over_time({__name__=\"${prefix}insert_error_rate_total\", job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", table_name=~\"$table_name\"}[$__range])) * 0) / clamp_min(sum by (table_name) (max_over_time({__name__=\"${prefix}insert_error_rate_total\", job=~\"$job\", scenario=~\"$scenario\", step=~\"$step\", table_name=~\"$table_name\"}[$__range])), 1e-9)",
+          "expr": "(sum by (table_name) (increase(${prefix}insert_errors_total{job=~\"$job\", step=~\"$step\", table_name=~\"$table_name\"}[$__range])) or sum by (table_name) (increase(${prefix}insert_operations_total{job=~\"$job\", step=~\"$step\", table_name=~\"$table_name\"}[$__range])) * 0) / clamp_min(sum by (table_name) (increase(${prefix}insert_operations_total{job=~\"$job\", step=~\"$step\", table_name=~\"$table_name\"}[$__range])), 1)",
           "legendFormat": "{{table_name}}",
           "range": false,
           "refId": "A",
@@ -3435,7 +3435,7 @@
         "multi": true,
         "name": "tx_name",
         "options": [],
-        "query": "label_values({__name__=\"${prefix}tx_count\", job=~\"$job\", step=~\"$step\"}, tx_name)",
+        "query": "label_values({__name__=\"${prefix}transactions_total\", job=~\"$job\", step=~\"$step\"}, tx_name)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -3455,7 +3455,7 @@
         "multi": true,
         "name": "tx_action",
         "options": [],
-        "query": "label_values({__name__=\"${prefix}tx_count\", job=~\"$job\", step=~\"$step\"}, tx_action)",
+        "query": "label_values({__name__=\"${prefix}transactions_total\", job=~\"$job\", step=~\"$step\"}, tx_action)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -3475,7 +3475,7 @@
         "multi": true,
         "name": "tx_isolation",
         "options": [],
-        "query": "label_values({__name__=\"${prefix}tx_count\", job=~\"$job\", step=~\"$step\"}, tx_isolation)",
+        "query": "label_values({__name__=\"${prefix}transactions_total\", job=~\"$job\", step=~\"$step\"}, tx_isolation)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -3495,7 +3495,7 @@
         "multi": true,
         "name": "query_name",
         "options": [],
-        "query": "label_values({__name__=\"${prefix}run_query_count\", job=~\"$job\", step=~\"$step\"}, name)",
+        "query": "label_values({__name__=\"${prefix}run_query_operations_total\", job=~\"$job\", step=~\"$step\"}, name)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -3515,7 +3515,7 @@
         "multi": true,
         "name": "query_type",
         "options": [],
-        "query": "label_values({__name__=\"${prefix}run_query_count\", job=~\"$job\", step=~\"$step\"}, type)",
+        "query": "label_values({__name__=\"${prefix}run_query_operations_total\", job=~\"$job\", step=~\"$step\"}, type)",
         "refresh": 2,
         "sort": 1,
         "type": "query"

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,12 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/ydb-platform/ydb-go-sdk/v3 v3.141.2
 	github.com/ydb-platform/ydb-go-yc-metadata v0.6.1
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0
+	go.opentelemetry.io/otel/metric v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.21.0
 	google.golang.org/grpc v1.81.1
@@ -24,31 +30,36 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20240226150601-1dcf7310316a // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/testcontainers/testcontainers-go v0.41.0 // indirect
 	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
+	go.opentelemetry.io/otel/trace v1.44.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260810153831-ec0a7760b754 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260807164820-c8921c73eeea // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -34,7 +36,6 @@ github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7np
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -59,6 +60,7 @@ github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDD
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -103,6 +105,8 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -152,7 +156,6 @@ github.com/pashagolub/pgxmock/v4 v4.8.0 h1:RBtNUZXNG/ZwyOT7sJdSEx9RlAw19sgVPlnmE
 github.com/pashagolub/pgxmock/v4 v4.8.0/go.mod h1:9L57pC193h2aKRHVyiiE817avasIPZnPwPlw3JczWvM=
 github.com/picodata/picodata-go v1.1.0 h1:vP6uUEG9O6d7RcYqe1Af5tR6pNsUjZV3AOyoRvjITU4=
 github.com/picodata/picodata-go v1.1.0/go.mod h1:XjBlGTF19NiuPX1+2XhyXZOQoh79nPH4y6JnP+MUHlE=
-github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -164,7 +167,6 @@ github.com/rekby/fixenv v0.3.2/go.mod h1:/b5LRc06BYJtslRtHKxsPWFT/ySpHV+rWvzTg+X
 github.com/rekby/fixenv v0.6.1 h1:jUFiSPpajT4WY2cYuc++7Y1zWrnCxnovGCIX72PZniM=
 github.com/rekby/fixenv v0.6.1/go.mod h1:/b5LRc06BYJtslRtHKxsPWFT/ySpHV+rWvzTg+XWk4c=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -210,8 +212,14 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 h1:SUplec5dp06reu1zaXmOXdvqH398taqrDXqUl99jxSc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0/go.mod h1:ho2g4N+ane+swq5I/VBkKWnRDY4kUINH3FuqyZqX/Ug=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 h1:RuynHbfU8JUEw7DyONgkVYg2SVtsoF28y0LGIr69jgA=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0/go.mod h1:qZF+/lBs71APw8mlnEZcqZHMzqrYrsFiJOv83lX1OGo=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
+go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=
+go.opentelemetry.io/otel/metric/x v0.66.0/go.mod h1:d1+BDj9t96do0/1LoU1ayfCv79ZgNE41qbhBvnMOBZk=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
 go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=
@@ -219,6 +227,8 @@ go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
@@ -313,8 +323,10 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d h1:mpAgMyM9vQHxycBlDq50y1VHpfSfVwzXvrQKtYbXuUY=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/api v0.0.0-20260810153831-ec0a7760b754 h1:dWeMvEJ3JhYgqSCAHUZZJgMUyfniiiCvDc72x5EqJP0=
+google.golang.org/genproto/googleapis/api v0.0.0-20260810153831-ec0a7760b754/go.mod h1:q/3oV3jAi5vwelxsVAprMBC8BcM2zmNe+IjRGd+9/ks=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260807164820-c8921c73eeea h1:kVhQEPTpKQahD5+JSBTfBB19wcgQTTjAIn45MBqnyHk=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260807164820-c8921c73eeea/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/pkg/bench/metrics.go
+++ b/pkg/bench/metrics.go
@@ -1,7 +1,6 @@
 package bench
 
 import (
-	"context"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -12,57 +11,60 @@ import (
 	"github.com/stroppy-io/stroppy/pkg/driver/insertprogress"
 )
 
-const throughputInterval = time.Second
-
-// Named numeric constants for the magic-number linter (see metrics.go, retry.go,
-// root.go, runtime.go, step.go). Kept package-local and purpose-named.
 const (
-	millisPerSecond       = 1000.0 // seconds→milliseconds conversion factor
-	sampleChannelCapacity = 4096   // buffered sample channel depth
-	samplerStopGrace      = 2 * time.Second
-	percentScale          = 100.0 // ratio→percent
-	medianP               = 0.5   // p50 percentile argument
-	p90                   = 0.9
-	p95                   = 0.95
-	p99                   = 0.99
+	millisPerSecond = 1000.0
+	percentScale    = 100.0
+	medianP         = 0.5
+	p90             = 0.9
+	p95             = 0.95
+	p99             = 0.99
 )
 
 type txMetrics struct {
-	mu           sync.Mutex
-	registered   atomic.Bool
-	txCount      *metric
-	txTPS        *metric
-	runQueryQPS  *metric
-	insertRows   *metric
-	progressRows *metric
-	progressRPS  *metric
-	tags         *TagSet
+	mu         sync.Mutex
+	registered atomic.Bool
 
-	// Per-operation metrics mirroring the TS DriverX wrapper.
-	runQueryDuration *metric
-	runQueryCount    *metric
-	runQueryErrRate  *metric
+	transactions     *metric
+	queryOperations  *metric
+	queryErrors      *metric
+	insertRows       *metric
+	progressRows     *metric
+	progressRPS      *metric
+	queryDuration    *metric
+	insertOperations *metric
+	insertErrors     *metric
 	insertDuration   *metric
-	insertErrRate    *metric
 	iterationDur     *metric
 	iterations       *metric
 	txTotalDuration  *metric
-	txCommitRate     *metric
-	txErrorRate      *metric
+	txCommits        *metric
+	txErrors         *metric
 	txQueriesPerTx   *metric
-
-	txTotal    uint64
-	queryTotal uint64
-
-	txSampler    throughputSampler
-	querySampler throughputSampler
+	stepAttrs        attributeCache
+	tableAttrs       attributeCache
+	txAttrs          attributeCache
+	progressAttrs    attributeCache
 }
 
-type throughputSampler struct {
-	started atomic.Bool
-	stopped atomic.Bool
-	stopCh  chan struct{}
-	doneCh  chan struct{}
+type attributeCache struct {
+	values sync.Map
+	size   atomic.Int64
+}
+
+type tableAttributeKey struct {
+	step  string
+	table string
+}
+
+type txAttributeKey struct {
+	step      string
+	action    string
+	name      string
+	isolation string
+}
+
+type progressAttributeKey struct {
+	step, table, method, event, rowKind string
 }
 
 func (m *txMetrics) ensureRegistered(vu *VU, lg *zap.Logger) {
@@ -87,68 +89,119 @@ func (m *txMetrics) ensureRegistered(vu *VU, lg *zap.Logger) {
 		return mm
 	}
 
-	m.txCount = newMetric("tx_count", Counter)
-	m.txTPS = newMetric("tx_tps", Trend)
-	m.runQueryQPS = newMetric("run_query_qps", Trend)
+	m.transactions = newMetric("transactions_total", Counter)
+	m.queryOperations = newMetric("run_query_operations_total", Counter)
+	m.queryErrors = newMetric("run_query_errors_total", Counter)
 	m.insertRows = newMetric("insert_rows_total", Counter)
 	m.progressRows = newMetric("insert_progress_rows_total", Counter)
-	m.progressRPS = newMetric("insert_progress_rows_per_second", Trend)
-	m.runQueryDuration = newMetric("run_query_duration", Trend)
-	m.runQueryCount = newMetric("run_query_count", Counter)
-	m.runQueryErrRate = newMetric("run_query_error_rate", Rate)
+	m.progressRPS = newMetric("insert_progress_rows_per_second", Gauge)
+	m.queryDuration = newMetric("run_query_duration", Trend)
+	m.insertOperations = newMetric("insert_operations_total", Counter)
+	m.insertErrors = newMetric("insert_errors_total", Counter)
 	m.insertDuration = newMetric("insert_duration", Trend)
-	m.insertErrRate = newMetric("insert_error_rate", Rate)
 	m.iterationDur = newMetric("iteration_duration", Trend)
-	m.iterations = newMetric("iterations", Counter)
+	m.iterations = newMetric("iterations_total", Counter)
 	m.txTotalDuration = newMetric("tx_total_duration", Trend)
-	m.txCommitRate = newMetric("tx_commit_rate", Rate)
+	m.txCommits = newMetric("tx_commits_total", Counter)
+	m.txErrors = newMetric("tx_errors_total", Counter)
 	m.txQueriesPerTx = newMetric("tx_queries_per_tx", Trend)
-	m.txErrorRate = newMetric("tx_error_rate", Rate)
-	m.tags = r.RootTagSet()
 	m.registered.Store(true)
 }
 
-func applyStepTag(tags *TagSet, step string) *TagSet {
-	if step != "" {
-		return tags.With("step", step)
+func (m *txMetrics) emit(vu *VU, metric *metric, value float64, attrs metricAttributes) {
+	if metric != nil {
+		metric.add(vu.Context(), value, attrs)
 	}
-
-	return tags
 }
 
-func (m *txMetrics) emit(vu *VU, metric *metric, value float64, tags *TagSet) {
-	if metric == nil {
-		return
+func cachedAttributes(cache *attributeCache, key any, tags ...string) metricAttributes {
+	if cached, ok := cache.values.Load(key); ok {
+		attrs, valid := cached.(metricAttributes)
+		if valid {
+			return attrs
+		}
 	}
 
-	PushIfNotDone(vu.Context(), vu.root.samples, Sample{
-		Metric: metric, Tags: tags,
-		Time: time.Now(), Value: value,
-	})
+	attrs := attributes(tags...)
+
+	if cache.size.Add(1) > metricCardinalityLimit {
+		cache.size.Add(-1)
+
+		return attrs
+	}
+
+	cached, loaded := cache.values.LoadOrStore(key, attrs)
+	if loaded {
+		cache.size.Add(-1)
+	}
+
+	result, valid := cached.(metricAttributes)
+	if !valid {
+		return attrs
+	}
+
+	return result
 }
 
-// recordQueryResult emits the per-query metrics (duration/count/error_rate),
-// mirroring the TS DriverX wrapper. elapsed is the driver-reported duration;
-// on error only the error rate is recorded (no count/duration).
+func (m *txMetrics) stepAttributes(step string) metricAttributes {
+	if step == "" {
+		return cachedAttributes(&m.stepAttrs, step)
+	}
+
+	return cachedAttributes(&m.stepAttrs, step, "step", step)
+}
+
+func (m *txMetrics) tableAttributes(step, table string) metricAttributes {
+	key := tableAttributeKey{step: step, table: table}
+	if step == "" {
+		return cachedAttributes(&m.tableAttrs, key, "table_name", table)
+	}
+
+	return cachedAttributes(&m.tableAttrs, key, "step", step, "table_name", table)
+}
+
+func (m *txMetrics) txAttributes(step, action, name, isolation string) metricAttributes {
+	key := txAttributeKey{step: step, action: action, name: name, isolation: isolation}
+
+	return cachedAttributes(
+		&m.txAttrs, key,
+		"step", step,
+		"tx_action", action,
+		"tx_name", name,
+		"tx_isolation", isolation,
+	)
+}
+
+func (m *txMetrics) progressAttributes(snapshot *insertprogress.Snapshot, step string) metricAttributes {
+	key := progressAttributeKey{
+		step: step, table: snapshot.Table, method: snapshot.Method,
+		event: string(snapshot.Event), rowKind: snapshot.RowKind,
+	}
+
+	return cachedAttributes(
+		&m.progressAttrs, key,
+		"step", step,
+		"table_name", snapshot.Table,
+		"method", snapshot.Method,
+		"event", string(snapshot.Event),
+		"row_kind", snapshot.RowKind,
+	)
+}
+
 func (m *txMetrics) recordQueryResult(vu *VU, elapsed time.Duration, queryErr error) {
 	m.ensureRegistered(vu, root.lg)
-	m.start(vu.root.samples, vu.root.ctx)
-	atomic.AddUint64(&m.queryTotal, 1)
+	attrs := m.stepAttributes(vu.stepTag)
+	m.emit(vu, m.queryOperations, 1, attrs)
 
-	tags := applyStepTag(m.tags, vu.stepTag)
 	if queryErr != nil {
-		m.emit(vu, m.runQueryErrRate, 1, tags)
+		m.emit(vu, m.queryErrors, 1, attrs)
 
 		return
 	}
 
-	m.emit(vu, m.runQueryDuration, elapsed.Seconds()*millisPerSecond, tags)
-	m.emit(vu, m.runQueryErrRate, 0, tags)
-	m.emit(vu, m.runQueryCount, 1, tags)
+	m.emit(vu, m.queryDuration, elapsed.Seconds()*millisPerSecond, attrs)
 }
 
-// recordInsertResult emits insert_duration / insert_error_rate for one InsertSpec
-// call. insert_rows_total is emitted separately by recordInsert.
 func (m *txMetrics) recordInsertResult(vu *VU, table string, elapsed time.Duration, insertErr error) {
 	m.ensureRegistered(vu, root.lg)
 
@@ -156,84 +209,52 @@ func (m *txMetrics) recordInsertResult(vu *VU, table string, elapsed time.Durati
 		table = "unknown"
 	}
 
-	tags := applyStepTag(m.tags, vu.stepTag).With("table_name", table)
+	attrs := m.tableAttributes(vu.stepTag, table)
+	m.emit(vu, m.insertOperations, 1, attrs)
+
 	if insertErr != nil {
-		m.emit(vu, m.insertErrRate, 1, tags)
+		m.emit(vu, m.insertErrors, 1, attrs)
 
 		return
 	}
 
-	m.emit(vu, m.insertDuration, elapsed.Seconds()*millisPerSecond, tags)
-	m.emit(vu, m.insertErrRate, 0, tags)
+	m.emit(vu, m.insertDuration, elapsed.Seconds()*millisPerSecond, attrs)
 }
 
-// recordIteration emits iteration_duration + iterations for one Iterate call.
 func (m *txMetrics) recordIteration(vu *VU, elapsed time.Duration) {
 	m.ensureRegistered(vu, root.lg)
-	tags := applyStepTag(m.tags, vu.stepTag)
-	m.emit(vu, m.iterationDur, elapsed.Seconds()*millisPerSecond, tags)
-	m.emit(vu, m.iterations, 1, tags)
+	attrs := m.stepAttributes(vu.stepTag)
+	m.emit(vu, m.iterationDur, elapsed.Seconds()*millisPerSecond, attrs)
+	m.emit(vu, m.iterations, 1, attrs)
 }
 
-// recordTxEnd emits the per-transaction summary metrics mirroring the TS TxX:
-// total wall duration, commit success rate, and query count per transaction.
 func (m *txMetrics) recordTxEnd(vu *VU, name string, elapsed time.Duration, queries int, committed bool) {
 	m.ensureRegistered(vu, root.lg)
 
-	tags := applyStepTag(m.tags, vu.stepTag)
-	if name != "" {
-		tags = tags.With("tx_name", name)
-	}
-
+	attrs := m.txAttributes(vu.stepTag, "", name, "")
 	if committed {
-		m.emit(vu, m.txCommitRate, 1, tags)
-		m.emit(vu, m.txErrorRate, 0, tags)
+		m.emit(vu, m.txCommits, 1, attrs)
 	} else {
-		m.emit(vu, m.txCommitRate, 0, tags)
-		m.emit(vu, m.txErrorRate, 1, tags)
+		m.emit(vu, m.txErrors, 1, attrs)
 	}
 
-	m.emit(vu, m.txTotalDuration, elapsed.Seconds()*millisPerSecond, tags)
-	m.emit(vu, m.txQueriesPerTx, float64(queries), tags)
+	m.emit(vu, m.txTotalDuration, elapsed.Seconds()*millisPerSecond, attrs)
+	m.emit(vu, m.txQueriesPerTx, float64(queries), attrs)
 }
 
 func (m *txMetrics) recordInsertProgress(vu *VU, snapshot *insertprogress.Snapshot) {
 	m.ensureRegistered(vu, root.lg)
 
-	progressRows, progressRPS, tags, ok := m.snapshotProgressMetrics()
-	if !ok {
-		return
-	}
-
-	tags = applyStepTag(tags, vu.stepTag)
-	tags = tags.With("table_name", snapshot.Table).
-		With("method", snapshot.Method).
-		With("event", string(snapshot.Event)).
-		With("row_kind", snapshot.RowKind)
-
-	now := time.Now()
+	attrs := m.progressAttributes(snapshot, vu.stepTag)
 	if snapshot.DeltaRows > 0 {
-		PushIfNotDone(vu.Context(), vu.root.samples, Sample{
-			Metric: progressRows, Tags: tags,
-			Time: now, Value: float64(snapshot.DeltaRows),
-		})
+		m.emit(vu, m.progressRows, float64(snapshot.DeltaRows), attrs)
 	}
 
-	PushIfNotDone(vu.Context(), vu.root.samples, Sample{
-		Metric: progressRPS, Tags: tags,
-		Time: now, Value: snapshot.CurrentRowsPerSecond,
-	})
+	m.emit(vu, m.progressRPS, snapshot.CurrentRowsPerSecond, attrs)
 }
 
 func (m *txMetrics) recordInsert(vu *VU, table string, rows int64) {
 	m.ensureRegistered(vu, root.lg)
-
-	insertRows, tags, ok := m.snapshotInsertMetrics()
-	if !ok {
-		return
-	}
-
-	tags = applyStepTag(tags, vu.stepTag)
 
 	if table == "" {
 		table = "unknown"
@@ -243,158 +264,12 @@ func (m *txMetrics) recordInsert(vu *VU, table string, rows int64) {
 		rows = 0
 	}
 
-	now := time.Now()
-	tags = tags.With("table_name", table)
-	PushIfNotDone(vu.Context(), vu.root.samples, Sample{
-		Metric: insertRows, Tags: tags,
-		Time: now, Value: float64(rows),
-	})
+	m.emit(vu, m.insertRows, float64(rows), m.tableAttributes(vu.stepTag, table))
 }
 
 func (m *txMetrics) record(vu *VU, action, name string, isolation stroppy.TxIsolationLevel) {
 	m.ensureRegistered(vu, root.lg)
-	m.start(vu.root.samples, vu.root.ctx)
-	atomic.AddUint64(&m.txTotal, 1)
-
-	txCount, tags, ok := m.snapshotCountMetric()
-	if !ok {
-		return
-	}
-
-	tags = applyStepTag(tags, vu.stepTag)
-	now := time.Now()
-
-	tags = tags.With("tx_action", action)
-	if name != "" {
-		tags = tags.With("tx_name", name)
-	}
-
-	if iso := txIsolationName(isolation); iso != "" {
-		tags = tags.With("tx_isolation", iso)
-	}
-
-	PushIfNotDone(vu.Context(), vu.root.samples, Sample{
-		Metric: txCount, Tags: tags,
-		Time: now, Value: 1,
-	})
-}
-
-func (m *txMetrics) start(samples chan<- SampleContainer, ctx context.Context) {
-	m.startSampler(&m.txSampler, &m.txTotal, ctx, samples, m.txTPS, m.tags)
-	m.startSampler(&m.querySampler, &m.queryTotal, ctx, samples, m.runQueryQPS, m.tags)
-}
-
-func (m *txMetrics) stop() {
-	m.stopSampler(&m.txSampler)
-	m.stopSampler(&m.querySampler)
-}
-
-func (m *txMetrics) startSampler(
-	sampler *throughputSampler, total *uint64, ctx context.Context,
-	samples chan<- SampleContainer, metric *metric, tags *TagSet,
-) {
-	if metric == nil || tags == nil || sampler.stopped.Load() {
-		return
-	}
-
-	if !sampler.started.CompareAndSwap(false, true) {
-		return
-	}
-
-	sampler.stopCh = make(chan struct{})
-
-	sampler.doneCh = make(chan struct{})
-	go runThroughputSampler(ctx, samples, metric, tags, total, sampler.stopCh, sampler.doneCh)
-}
-
-func (m *txMetrics) stopSampler(sampler *throughputSampler) {
-	if !sampler.stopped.CompareAndSwap(false, true) {
-		return
-	}
-
-	if !sampler.started.Load() {
-		return
-	}
-
-	close(sampler.stopCh)
-
-	select {
-	case <-sampler.doneCh:
-	case <-time.After(samplerStopGrace):
-	}
-}
-
-func (m *txMetrics) snapshotCountMetric() (*metric, *TagSet, bool) {
-	if !m.registered.Load() {
-		return nil, nil, false
-	}
-
-	return m.txCount, m.tags, true
-}
-
-func (m *txMetrics) snapshotInsertMetrics() (*metric, *TagSet, bool) {
-	if !m.registered.Load() {
-		return nil, nil, false
-	}
-
-	return m.insertRows, m.tags, true
-}
-
-func (m *txMetrics) snapshotProgressMetrics() (rowsMetric, rpsMetric *metric, tags *TagSet, ok bool) {
-	if !m.registered.Load() {
-		return nil, nil, nil, false
-	}
-
-	return m.progressRows, m.progressRPS, m.tags, true
-}
-
-func runThroughputSampler(
-	ctx context.Context, samples chan<- SampleContainer, metric *metric,
-	tags *TagSet, total *uint64, stopCh <-chan struct{}, doneCh chan<- struct{},
-) {
-	defer close(doneCh)
-
-	ticker := time.NewTicker(throughputInterval)
-	defer ticker.Stop()
-
-	prevTotal := atomic.LoadUint64(total)
-	prevTime := time.Now()
-
-	for {
-		select {
-		case now := <-ticker.C:
-			prevTotal, prevTime = emitThroughput(ctx, samples, metric, tags, total, prevTotal, prevTime, now, true)
-		case <-stopCh:
-			return
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func emitThroughput(
-	ctx context.Context, samples chan<- SampleContainer, metric *metric,
-	tags *TagSet, totalCounter *uint64, prevTotal uint64, prevTime time.Time,
-	now time.Time, emitZero bool,
-) (uint64, time.Time) {
-	elapsed := now.Sub(prevTime)
-	if elapsed <= 0 {
-		return prevTotal, prevTime
-	}
-
-	total := atomic.LoadUint64(totalCounter)
-
-	delta := total - prevTotal
-	if delta == 0 && !emitZero {
-		return total, now
-	}
-
-	PushIfNotDone(ctx, samples, Sample{
-		Metric: metric, Tags: tags,
-		Time: now, Value: float64(delta) / elapsed.Seconds(),
-	})
-
-	return total, now
+	m.emit(vu, m.transactions, 1, m.txAttributes(vu.stepTag, action, name, txIsolationName(isolation)))
 }
 
 func txIsolationName(isolation stroppy.TxIsolationLevel) string {

--- a/pkg/bench/metrics.go
+++ b/pkg/bench/metrics.go
@@ -47,8 +47,9 @@ type txMetrics struct {
 }
 
 type attributeCache struct {
-	values sync.Map
-	size   atomic.Int64
+	values   sync.Map
+	size     atomic.Int64
+	overflow atomic.Pointer[metricAttributes]
 }
 
 type tableAttributeKey struct {
@@ -114,6 +115,19 @@ func (m *txMetrics) emit(vu *VU, metric *metric, value float64, attrs metricAttr
 	}
 }
 
+func overflowAttributes(cache *attributeCache) metricAttributes {
+	if attrs := cache.overflow.Load(); attrs != nil {
+		return *attrs
+	}
+
+	attrs := attributes("otel.metric.overflow", "true")
+	if cache.overflow.CompareAndSwap(nil, &attrs) {
+		return attrs
+	}
+
+	return *cache.overflow.Load()
+}
+
 func cachedAttributes(cache *attributeCache, key any, tags ...string) metricAttributes {
 	if cached, ok := cache.values.Load(key); ok {
 		attrs, valid := cached.(metricAttributes)
@@ -122,13 +136,13 @@ func cachedAttributes(cache *attributeCache, key any, tags ...string) metricAttr
 		}
 	}
 
-	attrs := attributes(tags...)
-
 	if cache.size.Add(1) > metricCardinalityLimit {
 		cache.size.Add(-1)
 
-		return attrs
+		return overflowAttributes(cache)
 	}
+
+	attrs := attributes(tags...)
 
 	cached, loaded := cache.values.LoadOrStore(key, attrs)
 	if loaded {
@@ -228,10 +242,17 @@ func (m *txMetrics) recordIteration(vu *VU, elapsed time.Duration) {
 	m.emit(vu, m.iterations, 1, attrs)
 }
 
-func (m *txMetrics) recordTxEnd(vu *VU, name string, elapsed time.Duration, queries int, committed bool) {
+func (m *txMetrics) recordTxEnd(
+	vu *VU,
+	action, name string,
+	isolation stroppy.TxIsolationLevel,
+	elapsed time.Duration,
+	queries int,
+	committed bool,
+) {
 	m.ensureRegistered(vu, root.lg)
 
-	attrs := m.txAttributes(vu.stepTag, "", name, "")
+	attrs := m.txAttributes(vu.stepTag, action, name, txIsolationName(isolation))
 	if committed {
 		m.emit(vu, m.txCommits, 1, attrs)
 	} else {

--- a/pkg/bench/metrics_provider.go
+++ b/pkg/bench/metrics_provider.go
@@ -3,6 +3,7 @@ package bench
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -38,6 +39,10 @@ func newMeterProvider(
 	ctx context.Context,
 	config *MetricsConfig,
 ) (*sdkmetric.MeterProvider, *sdkmetric.ManualReader, string, error) {
+	if config == nil {
+		config = &MetricsConfig{}
+	}
+
 	manualReader := sdkmetric.NewManualReader()
 	options := []sdkmetric.Option{
 		sdkmetric.WithReader(manualReader),
@@ -72,7 +77,10 @@ func newMeterProvider(
 }
 
 func newMetricExporter(ctx context.Context, config *MetricsConfig) (sdkmetric.Exporter, bool, error) {
-	headers := parseOTLPHeaders(config.Headers)
+	headers, err := parseOTLPHeaders(config.Headers)
+	if err != nil {
+		return nil, false, err
+	}
 
 	if config.GRPCEndpoint != "" {
 		options := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(config.GRPCEndpoint)}
@@ -134,21 +142,28 @@ func metricsResource(config *MetricsConfig) (*resource.Resource, error) {
 	return resource.Merge(resource.Default(), resource.NewSchemaless(attrs...))
 }
 
-func parseOTLPHeaders(raw string) map[string]string {
+func parseOTLPHeaders(raw string) (map[string]string, error) {
 	if raw == "" {
-		return nil
+		return map[string]string{}, nil
 	}
 
 	headers := make(map[string]string)
 
 	for part := range strings.SplitSeq(raw, ",") {
 		key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
-		if ok && key != "" {
-			headers[key] = value
+		if !ok || key == "" {
+			continue
 		}
+
+		decoded, err := url.PathUnescape(value)
+		if err != nil {
+			return nil, fmt.Errorf("decode OTLP header %q: %w", key, err)
+		}
+
+		headers[key] = strings.TrimSpace(decoded)
 	}
 
-	return headers
+	return headers, nil
 }
 
 func metricExportInterval() time.Duration {

--- a/pkg/bench/metrics_provider.go
+++ b/pkg/bench/metrics_provider.go
@@ -1,0 +1,166 @@
+package bench
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+)
+
+const (
+	defaultMetricsPrefix        = "stroppy_"
+	defaultMetricExportInterval = 10 * time.Second
+	metricCardinalityLimit      = 2000
+)
+
+type MetricsConfig struct {
+	GRPCEndpoint       string
+	HTTPEndpoint       string
+	HTTPPath           string
+	Headers            string
+	Insecure           bool
+	Prefix             string
+	ServiceVersion     string
+	RunID              string
+	ResourceAttributes map[string]string
+}
+
+func newMeterProvider(
+	ctx context.Context,
+	config *MetricsConfig,
+) (*sdkmetric.MeterProvider, *sdkmetric.ManualReader, string, error) {
+	manualReader := sdkmetric.NewManualReader()
+	options := []sdkmetric.Option{
+		sdkmetric.WithReader(manualReader),
+		sdkmetric.WithCardinalityLimit(metricCardinalityLimit),
+	}
+
+	res, err := metricsResource(config)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("create metrics resource: %w", err)
+	}
+
+	options = append(options, sdkmetric.WithResource(res))
+
+	exporter, enabled, err := newMetricExporter(ctx, config)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	if enabled {
+		options = append(options, sdkmetric.WithReader(sdkmetric.NewPeriodicReader(
+			exporter,
+			sdkmetric.WithInterval(metricExportInterval()),
+		)))
+	}
+
+	prefix := config.Prefix
+	if prefix == "" {
+		prefix = defaultMetricsPrefix
+	}
+
+	return sdkmetric.NewMeterProvider(options...), manualReader, prefix, nil
+}
+
+func newMetricExporter(ctx context.Context, config *MetricsConfig) (sdkmetric.Exporter, bool, error) {
+	headers := parseOTLPHeaders(config.Headers)
+
+	if config.GRPCEndpoint != "" {
+		options := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(config.GRPCEndpoint)}
+		if config.Insecure {
+			options = append(options, otlpmetricgrpc.WithInsecure())
+		}
+
+		if len(headers) > 0 {
+			options = append(options, otlpmetricgrpc.WithHeaders(headers))
+		}
+
+		exporter, err := otlpmetricgrpc.New(ctx, options...)
+		if err != nil {
+			return nil, false, fmt.Errorf("create OTLP gRPC metrics exporter: %w", err)
+		}
+
+		return exporter, true, nil
+	}
+
+	if config.HTTPEndpoint == "" {
+		return nil, false, nil
+	}
+
+	options := []otlpmetrichttp.Option{otlpmetrichttp.WithEndpoint(config.HTTPEndpoint)}
+	if config.HTTPPath != "" {
+		options = append(options, otlpmetrichttp.WithURLPath(config.HTTPPath))
+	}
+
+	if config.Insecure {
+		options = append(options, otlpmetrichttp.WithInsecure())
+	}
+
+	if len(headers) > 0 {
+		options = append(options, otlpmetrichttp.WithHeaders(headers))
+	}
+
+	exporter, err := otlpmetrichttp.New(ctx, options...)
+	if err != nil {
+		return nil, false, fmt.Errorf("create OTLP HTTP metrics exporter: %w", err)
+	}
+
+	return exporter, true, nil
+}
+
+func metricsResource(config *MetricsConfig) (*resource.Resource, error) {
+	attrs := []attribute.KeyValue{semconv.ServiceName("stroppy")}
+	if config.ServiceVersion != "" {
+		attrs = append(attrs, semconv.ServiceVersion(config.ServiceVersion))
+	}
+
+	if config.RunID != "" {
+		attrs = append(attrs, attribute.String("stroppy.run.id", config.RunID))
+	}
+
+	for key, value := range config.ResourceAttributes {
+		attrs = append(attrs, attribute.String(key, value))
+	}
+
+	return resource.Merge(resource.Default(), resource.NewSchemaless(attrs...))
+}
+
+func parseOTLPHeaders(raw string) map[string]string {
+	if raw == "" {
+		return nil
+	}
+
+	headers := make(map[string]string)
+
+	for part := range strings.SplitSeq(raw, ",") {
+		key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if ok && key != "" {
+			headers[key] = value
+		}
+	}
+
+	return headers
+}
+
+func metricExportInterval() time.Duration {
+	raw := os.Getenv("OTEL_METRIC_EXPORT_INTERVAL")
+	if raw == "" {
+		return defaultMetricExportInterval
+	}
+
+	milliseconds, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || milliseconds <= 0 {
+		return defaultMetricExportInterval
+	}
+
+	return time.Duration(milliseconds) * time.Millisecond
+}

--- a/pkg/bench/metrics_test.go
+++ b/pkg/bench/metrics_test.go
@@ -170,7 +170,10 @@ func TestTransactionEndKeepsActionAndIsolationAttributes(t *testing.T) {
 		txMetrics: &txMetrics{},
 	}
 	vu := &VU{root: rootState, ctx: context.Background(), stepTag: "workload"}
+	previousRoot := root
 	root = rootState
+
+	t.Cleanup(func() { root = previousRoot })
 
 	rootState.txMetrics.recordTxEnd(
 		vu, "commit", "payment", stroppy.TxIsolationLevel_READ_COMMITTED, time.Millisecond, 3, true,

--- a/pkg/bench/metrics_test.go
+++ b/pkg/bench/metrics_test.go
@@ -3,9 +3,13 @@ package bench
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
 )
 
 func TestTrendUsesBoundedHistogram(t *testing.T) {
@@ -58,13 +62,70 @@ func TestRateUsesEventCounters(t *testing.T) {
 	require.InDelta(t, 2.0, findSum(t, data, prefix+"checks_true_total"), 0)
 }
 
+func TestMeterProviderAcceptsNilConfig(t *testing.T) {
+	t.Parallel()
+
+	provider, reader, prefix, err := newMeterProvider(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	require.Equal(t, defaultMetricsPrefix, prefix)
+	require.NoError(t, provider.Shutdown(context.Background()))
+}
+
 func TestParseOTLPHeaders(t *testing.T) {
 	t.Parallel()
 
+	headers, err := parseOTLPHeaders("Authorization=Bearer%20token, x-tenant=benchmark")
+	require.NoError(t, err)
 	require.Equal(t, map[string]string{
 		"Authorization": "Bearer token",
 		"x-tenant":      "benchmark",
-	}, parseOTLPHeaders("Authorization=Bearer token, x-tenant=benchmark"))
+	}, headers)
+
+	_, err = parseOTLPHeaders("Authorization=%ZZ")
+	require.Error(t, err)
+}
+
+func TestGenericMetricCachesAttributes(t *testing.T) {
+	t.Parallel()
+
+	provider, _, prefix, err := newMeterProvider(context.Background(), &MetricsConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	registry := NewRegistry(provider.Meter("test"), prefix)
+	trend, err := registry.NewMetric("custom_duration", Trend)
+	require.NoError(t, err)
+
+	first := trend.taggedAttributes([]string{"step", "workload"})
+	second := trend.taggedAttributes([]string{"step", "workload"})
+	require.Same(t, &first.add[0], &second.add[0])
+
+	odd := trend.taggedAttributes([]string{"step", "workload", "orphan"})
+	require.Equal(t, first.set, odd.set)
+}
+
+func TestGenericMetricUsesOverflowAfterCardinalityLimit(t *testing.T) {
+	t.Parallel()
+
+	provider, _, prefix, err := newMeterProvider(context.Background(), &MetricsConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	registry := NewRegistry(provider.Meter("test"), prefix)
+	counter, err := registry.NewMetric("custom_total", Counter)
+	require.NoError(t, err)
+	counter.tagCount.Store(metricCardinalityLimit)
+
+	got := counter.taggedAttributes([]string{"key", "new-value"})
+	require.Equal(t, counter.overflow.set, got.set)
+}
+
+func TestGaugeSummarySumsAllSeries(t *testing.T) {
+	t.Parallel()
+
+	points := []metricdata.DataPoint[float64]{{Value: 2}, {Value: 3.5}}
+	require.InDelta(t, 5.5, sumGauge(points), 0)
 }
 
 func TestHistogramQuantileUsesBoundedBuckets(t *testing.T) {
@@ -76,6 +137,8 @@ func TestHistogramQuantileUsesBoundedBuckets(t *testing.T) {
 	require.InDelta(t, 1.0, histogramQuantile(bounds, buckets, 10, 0), 0)
 	require.InDelta(t, 5.0, histogramQuantile(bounds, buckets, 10, 0.25), 0)
 	require.InDelta(t, 10.0, histogramQuantile(bounds, buckets, 10, 0.9), 0)
+	require.InDelta(t, 10.0, histogramQuantile(bounds, buckets, 10, 1), 0)
+	require.InDelta(t, 0.0, histogramQuantile(nil, nil, 0, 0.5), 0)
 }
 
 func BenchmarkTrendRecord(b *testing.B) {
@@ -95,6 +158,61 @@ func BenchmarkTrendRecord(b *testing.B) {
 	for b.Loop() {
 		trend.add(context.Background(), 1, attrs)
 	}
+}
+
+func TestTransactionEndKeepsActionAndIsolationAttributes(t *testing.T) {
+	provider, reader, prefix, err := newMeterProvider(context.Background(), &MetricsConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	rootState := &RootState{
+		registry:  NewRegistry(provider.Meter("test"), prefix),
+		txMetrics: &txMetrics{},
+	}
+	vu := &VU{root: rootState, ctx: context.Background(), stepTag: "workload"}
+	root = rootState
+
+	rootState.txMetrics.recordTxEnd(
+		vu, "commit", "payment", stroppy.TxIsolationLevel_READ_COMMITTED, time.Millisecond, 3, true,
+	)
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+
+	histogram := findHistogram(t, data, prefix+"tx_total_duration")
+	require.Len(t, histogram.DataPoints, 1)
+	attrs := histogram.DataPoints[0].Attributes
+	require.Equal(t, "commit", attributeValue(attrs, "tx_action"))
+	require.Equal(t, "read_committed", attributeValue(attrs, "tx_isolation"))
+}
+
+func BenchmarkMetricAdd(b *testing.B) {
+	provider, _, prefix, err := newMeterProvider(context.Background(), &MetricsConfig{})
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, provider.Shutdown(context.Background())) })
+
+	registry := NewRegistry(provider.Meter("benchmark"), prefix)
+	trend, err := registry.NewMetric("custom_duration", Trend)
+	require.NoError(b, err)
+
+	metric := &Metric{m: trend}
+	metric.Add(1, "step", "workload")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		metric.Add(1, "step", "workload")
+	}
+}
+
+func attributeValue(set attribute.Set, key string) string {
+	value, ok := set.Value(attribute.Key(key))
+	if !ok {
+		return ""
+	}
+
+	return value.AsString()
 }
 
 func findHistogram(

--- a/pkg/bench/metrics_test.go
+++ b/pkg/bench/metrics_test.go
@@ -1,0 +1,147 @@
+package bench
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestTrendUsesBoundedHistogram(t *testing.T) {
+	t.Parallel()
+
+	provider, reader, prefix, err := newMeterProvider(context.Background(), &MetricsConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	registry := NewRegistry(provider.Meter("test"), prefix)
+	trend, err := registry.NewMetric("run_query_duration", Trend)
+	require.NoError(t, err)
+
+	attrs := attributes("step", "workload")
+
+	const observations = 1_000_000
+	for range observations {
+		trend.add(context.Background(), 1, attrs)
+	}
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+
+	histogram := findHistogram(t, data, prefix+"run_query_duration")
+	require.Len(t, histogram.DataPoints, 1)
+	require.Equal(t, uint64(observations), histogram.DataPoints[0].Count)
+	require.Equal(t, durationMillisecondsBounds, histogram.DataPoints[0].Bounds)
+	require.Len(t, histogram.DataPoints[0].BucketCounts, len(durationMillisecondsBounds)+1)
+}
+
+func TestRateUsesEventCounters(t *testing.T) {
+	t.Parallel()
+
+	provider, reader, prefix, err := newMeterProvider(context.Background(), &MetricsConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	registry := NewRegistry(provider.Meter("test"), prefix)
+	rate, err := registry.NewMetric("checks", Rate)
+	require.NoError(t, err)
+
+	attrs := attributes("step", "workload")
+	rate.add(context.Background(), 0, attrs)
+	rate.add(context.Background(), 1, attrs)
+	rate.add(context.Background(), 1, attrs)
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+	require.InDelta(t, 3.0, findSum(t, data, prefix+"checks_events_total"), 0)
+	require.InDelta(t, 2.0, findSum(t, data, prefix+"checks_true_total"), 0)
+}
+
+func TestParseOTLPHeaders(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, map[string]string{
+		"Authorization": "Bearer token",
+		"x-tenant":      "benchmark",
+	}, parseOTLPHeaders("Authorization=Bearer token, x-tenant=benchmark"))
+}
+
+func TestHistogramQuantileUsesBoundedBuckets(t *testing.T) {
+	t.Parallel()
+
+	bounds := []float64{1, 5, 10}
+	buckets := []uint64{1, 3, 5, 1}
+
+	require.InDelta(t, 1.0, histogramQuantile(bounds, buckets, 10, 0), 0)
+	require.InDelta(t, 5.0, histogramQuantile(bounds, buckets, 10, 0.25), 0)
+	require.InDelta(t, 10.0, histogramQuantile(bounds, buckets, 10, 0.9), 0)
+}
+
+func BenchmarkTrendRecord(b *testing.B) {
+	provider, _, prefix, err := newMeterProvider(context.Background(), &MetricsConfig{})
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, provider.Shutdown(context.Background())) })
+
+	registry := NewRegistry(provider.Meter("benchmark"), prefix)
+	trend, err := registry.NewMetric("run_query_duration", Trend)
+	require.NoError(b, err)
+
+	attrs := attributes("step", "workload")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		trend.add(context.Background(), 1, attrs)
+	}
+}
+
+func findHistogram(
+	t *testing.T,
+	data metricdata.ResourceMetrics,
+	name string,
+) metricdata.Histogram[float64] {
+	t.Helper()
+
+	for _, scope := range data.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == name {
+				histogram, ok := metric.Data.(metricdata.Histogram[float64])
+				require.True(t, ok)
+
+				return histogram
+			}
+		}
+	}
+
+	t.Fatalf("metric %q not found", name)
+
+	return metricdata.Histogram[float64]{}
+}
+
+func findSum(t *testing.T, data metricdata.ResourceMetrics, name string) float64 {
+	t.Helper()
+
+	for _, scope := range data.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+
+			sum, ok := metric.Data.(metricdata.Sum[float64])
+			require.True(t, ok)
+
+			var value float64
+			for _, point := range sum.DataPoints {
+				value += point.Value
+			}
+
+			return value
+		}
+	}
+
+	t.Fatalf("metric %q not found", name)
+
+	return 0
+}

--- a/pkg/bench/metrics_types.go
+++ b/pkg/bench/metrics_types.go
@@ -1,18 +1,22 @@
 package bench
 
-// stroppy-owned metrics substrate — mirrors the subset of go.k6.io/k6/metrics
-// that pkg/bench consumes, so the k6 dependency can be dropped from the Go
-// runtime path. Tags are carried for parity but the floor sink ignores them.
-
 import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
-	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
-var errMetricAlreadyRegistered = errors.New("metric already registered")
+const tagPairSize = 2
+
+var (
+	errMetricAlreadyRegistered = errors.New("metric already registered")
+	errUnknownMetricType       = errors.New("unknown metric type")
+)
 
 type metricType int
 
@@ -20,23 +24,62 @@ const (
 	Counter metricType = iota
 	Trend
 	Rate
+	Gauge
 )
 
+var (
+	durationMillisecondsBounds = []float64{
+		0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100,
+		250, 500, 1000, 2500, 5000, 10000, 30000, 60000,
+	}
+	countBounds = []float64{0, 1, 2, 5, 10, 20, 50, 100, 250, 500, 1000}
+)
+
+type metricAttributes struct {
+	set    attribute.Set
+	add    []otelmetric.AddOption
+	record []otelmetric.RecordOption
+}
+
 type metric struct {
-	Name string
-	Type metricType
+	Name      string
+	Type      metricType
+	counter   otelmetric.Float64Counter
+	histogram otelmetric.Float64Histogram
+	gauge     otelmetric.Float64Gauge
+	rateTrue  otelmetric.Float64Counter
+	rateTotal otelmetric.Float64Counter
+}
+
+func (m *metric) add(ctx context.Context, value float64, attrs metricAttributes) {
+	switch m.Type {
+	case Counter:
+		m.counter.Add(ctx, value, attrs.add...)
+	case Trend:
+		m.histogram.Record(ctx, value, attrs.record...)
+	case Rate:
+		m.rateTotal.Add(ctx, 1, attrs.add...)
+
+		if value != 0 {
+			m.rateTrue.Add(ctx, 1, attrs.add...)
+		}
+	case Gauge:
+		m.gauge.Record(ctx, value, attrs.record...)
+	}
 }
 
 type Registry struct {
 	mu      sync.Mutex
+	meter   otelmetric.Meter
+	prefix  string
 	metrics map[string]*metric
 }
 
-func NewRegistry() *Registry {
-	return &Registry{metrics: map[string]*metric{}}
+func NewRegistry(meter otelmetric.Meter, prefix string) *Registry {
+	return &Registry{meter: meter, prefix: prefix, metrics: map[string]*metric{}}
 }
 
-func (r *Registry) NewMetric(name string, t metricType) (*metric, error) {
+func (r *Registry) NewMetric(name string, typ metricType) (*metric, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -44,49 +87,68 @@ func (r *Registry) NewMetric(name string, t metricType) (*metric, error) {
 		return nil, fmt.Errorf("%w: %q", errMetricAlreadyRegistered, name)
 	}
 
-	m := &metric{Name: name, Type: t}
+	m := &metric{Name: name, Type: typ}
+	exportedName := r.prefix + name
+
+	var err error
+
+	switch typ {
+	case Counter:
+		m.counter, err = r.meter.Float64Counter(exportedName)
+	case Trend:
+		options := []otelmetric.Float64HistogramOption{
+			otelmetric.WithExplicitBucketBoundaries(histogramBounds(name)...),
+		}
+		if strings.HasSuffix(name, "_duration") {
+			options = append(options, otelmetric.WithUnit("ms"))
+		}
+
+		m.histogram, err = r.meter.Float64Histogram(exportedName, options...)
+	case Rate:
+		m.rateTotal, err = r.meter.Float64Counter(exportedName + "_events_total")
+		if err == nil {
+			m.rateTrue, err = r.meter.Float64Counter(exportedName + "_true_total")
+		}
+	case Gauge:
+		m.gauge, err = r.meter.Float64Gauge(exportedName)
+	default:
+		err = fmt.Errorf("%w: %d", errUnknownMetricType, typ)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("create metric %q: %w", name, err)
+	}
+
 	r.metrics[name] = m
 
 	return m, nil
 }
 
-// RootTagSet returns an empty tag set sentinel.
-func (r *Registry) RootTagSet() *TagSet { return &TagSet{} }
-
-// TagSet is an immutable, copy-on-extend set of tag key/value pairs.
-type TagSet struct {
-	pairs [][2]string
-}
-
-func (t *TagSet) With(k, v string) *TagSet {
-	if t == nil {
-		t = &TagSet{}
+func histogramBounds(name string) []float64 {
+	if strings.HasSuffix(name, "_duration") {
+		return durationMillisecondsBounds
 	}
 
-	out := &TagSet{pairs: make([][2]string, 0, len(t.pairs)+1)}
-	out.pairs = append(out.pairs, t.pairs...)
-	out.pairs = append(out.pairs, [2]string{k, v})
-
-	return out
+	return countBounds
 }
 
-type Sample struct {
-	Metric *metric
-	Tags   *TagSet
-	Time   time.Time
-	Value  float64
-}
+func attributes(tags ...string) metricAttributes {
+	var set attribute.Set
 
-type SampleContainer interface{ GetSamples() []Sample }
+	if len(tags) >= tagPairSize {
+		pairs := make([]attribute.KeyValue, 0, len(tags)/tagPairSize)
+		for i := 0; i+1 < len(tags); i += tagPairSize {
+			pairs = append(pairs, attribute.String(tags[i], tags[i+1]))
+		}
 
-type sampleContainer []Sample
+		set = attribute.NewSet(pairs...)
+	} else {
+		set = attribute.NewSet()
+	}
 
-func (s sampleContainer) GetSamples() []Sample { return []Sample(s) }
-
-// PushIfNotDone sends s on ch unless ctx is already done. Blocks until either.
-func PushIfNotDone(ctx context.Context, ch chan<- SampleContainer, s Sample) {
-	select {
-	case <-ctx.Done():
-	case ch <- sampleContainer{s}:
+	return metricAttributes{
+		set:    set,
+		add:    []otelmetric.AddOption{otelmetric.WithAttributeSet(set)},
+		record: []otelmetric.RecordOption{otelmetric.WithAttributeSet(set)},
 	}
 }

--- a/pkg/bench/metrics_types.go
+++ b/pkg/bench/metrics_types.go
@@ -6,12 +6,16 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
-const tagPairSize = 2
+const (
+	tagPairSize       = 2
+	maxCachedTagParts = 16
+)
 
 var (
 	errMetricAlreadyRegistered = errors.New("metric already registered")
@@ -41,14 +45,23 @@ type metricAttributes struct {
 	record []otelmetric.RecordOption
 }
 
+type metricTagKey struct {
+	count uint8
+	parts [maxCachedTagParts]string
+}
+
 type metric struct {
-	Name      string
-	Type      metricType
-	counter   otelmetric.Float64Counter
-	histogram otelmetric.Float64Histogram
-	gauge     otelmetric.Float64Gauge
-	rateTrue  otelmetric.Float64Counter
-	rateTotal otelmetric.Float64Counter
+	Name       string
+	Type       metricType
+	counter    otelmetric.Float64Counter
+	histogram  otelmetric.Float64Histogram
+	gauge      otelmetric.Float64Gauge
+	rateTrue   otelmetric.Float64Counter
+	rateTotal  otelmetric.Float64Counter
+	emptyAttrs metricAttributes
+	overflow   metricAttributes
+	tagAttrs   sync.Map
+	tagCount   atomic.Int64
 }
 
 func (m *metric) add(ctx context.Context, value float64, attrs metricAttributes) {
@@ -87,7 +100,12 @@ func (r *Registry) NewMetric(name string, typ metricType) (*metric, error) {
 		return nil, fmt.Errorf("%w: %q", errMetricAlreadyRegistered, name)
 	}
 
-	m := &metric{Name: name, Type: typ}
+	m := &metric{
+		Name:       name,
+		Type:       typ,
+		emptyAttrs: attributes(),
+		overflow:   attributes("otel.metric.overflow", "true"),
+	}
 	exportedName := r.prefix + name
 
 	var err error
@@ -122,6 +140,54 @@ func (r *Registry) NewMetric(name string, typ metricType) (*metric, error) {
 	r.metrics[name] = m
 
 	return m, nil
+}
+
+func (m *metric) taggedAttributes(tags []string) metricAttributes {
+	if len(tags) == 0 {
+		return m.emptyAttrs
+	}
+
+	if len(tags)%tagPairSize != 0 {
+		tags = tags[:len(tags)-1]
+	}
+
+	if len(tags) == 0 {
+		return m.emptyAttrs
+	}
+
+	if len(tags) > maxCachedTagParts {
+		return m.overflow
+	}
+
+	var key metricTagKey
+
+	key.count = uint8(len(tags)) //nolint:gosec // bounded by maxCachedTagParts
+	copy(key.parts[:], tags)
+
+	if cached, ok := m.tagAttrs.Load(key); ok {
+		if attrs, valid := cached.(metricAttributes); valid {
+			return attrs
+		}
+	}
+
+	if m.tagCount.Add(1) > metricCardinalityLimit {
+		m.tagCount.Add(-1)
+
+		return m.overflow
+	}
+
+	attrs := attributes(tags...)
+
+	cached, loaded := m.tagAttrs.LoadOrStore(key, attrs)
+	if loaded {
+		m.tagCount.Add(-1)
+	}
+
+	if result, valid := cached.(metricAttributes); valid {
+		return result
+	}
+
+	return m.overflow
 }
 
 func histogramBounds(name string) []float64 {

--- a/pkg/bench/query.go
+++ b/pkg/bench/query.go
@@ -333,7 +333,7 @@ func (t *TxX) Commit(ctx context.Context) error {
 	}
 
 	t.b.root.txMetrics.record(t.b.vu, "commit", t.name, t.iso)
-	t.recordEnd(committed)
+	t.recordEnd("commit", committed)
 
 	return nil
 }
@@ -346,20 +346,22 @@ func (t *TxX) Rollback(ctx context.Context) error {
 	}
 
 	t.b.root.txMetrics.record(t.b.vu, "rollback", t.name, t.iso)
-	t.recordEnd(false)
+	t.recordEnd("rollback", false)
 
 	return nil
 }
 
 // recordEnd emits the per-transaction summary metrics (total duration, commit
 // rate, query count) once. Idempotent — safe if a workload calls both paths.
-func (t *TxX) recordEnd(committed bool) {
+func (t *TxX) recordEnd(action string, committed bool) {
 	if t.done {
 		return
 	}
 
 	t.done = true
-	t.b.root.txMetrics.recordTxEnd(t.b.vu, t.name, time.Since(t.start), t.queries, committed)
+	t.b.root.txMetrics.recordTxEnd(
+		t.b.vu, action, t.name, t.iso, time.Since(t.start), t.queries, committed,
+	)
 }
 
 // Compile-tick: ensure zap import stays used if expanded later.

--- a/pkg/bench/root.go
+++ b/pkg/bench/root.go
@@ -5,39 +5,38 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"time"
 
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/zap"
 
 	"github.com/stroppy-io/stroppy/pkg/driver"
 )
 
+const metricsShutdownTimeout = 10 * time.Second
+
 // root is the process-wide engine state for the Go-native runner. Set once by Run.
 var root *RootState
 
-// RootState is the engine-wide singleton for a Go-workload run: owns the metrics
-// sink, dialer, shared-driver slots, and cross-VU once barriers. Cloud notify is
-// a no-op at the floor.
+// RootState is the engine-wide singleton for the Go-workload run.
 type RootState struct {
 	lg  *zap.Logger
 	ctx context.Context //nolint:containedctx // engine lifecycle ctx stored for async teardown/cancellation
 
-	// dialer backs shared and per-VU drivers.
 	dialer *net.Dialer
 
-	// metrics sink (k6/metrics substrate).
-	registry *Registry
-	samples  chan SampleContainer
+	registry      *Registry
+	meterProvider *sdkmetric.MeterProvider
+	manualReader  *sdkmetric.ManualReader
+	metricsPrefix string
 
 	txMetrics *txMetrics
 
 	sharedMu    sync.Mutex
 	sharedSlots map[uint64]*sharedDriverSlot
 
-	// env is the script env (-e overrides, config) passed to Run; consulted by
-	// Env after the real process environment (real env takes precedence).
 	env map[string]string
 
-	// stepFilter is built at Run start (after STROPPY_STEPS/NO_STEPS env is set).
 	stepFilter *stepFilterState
 }
 
@@ -45,18 +44,30 @@ type sharedDriverSlot struct {
 	drv driver.Driver
 }
 
-func newRootState(lg *zap.Logger, ctx context.Context, env map[string]string) *RootState {
-	return &RootState{
-		lg:          lg,
-		ctx:         ctx,
-		dialer:      &net.Dialer{},
-		registry:    NewRegistry(),
-		samples:     make(chan SampleContainer, sampleChannelCapacity),
-		txMetrics:   &txMetrics{},
-		sharedSlots: make(map[uint64]*sharedDriverSlot),
-		env:         env,
-		stepFilter:  newStepFilter(),
+func newRootState(
+	lg *zap.Logger,
+	ctx context.Context,
+	env map[string]string,
+	metricsConfig *MetricsConfig,
+) (*RootState, error) {
+	provider, reader, prefix, err := newMeterProvider(ctx, metricsConfig)
+	if err != nil {
+		return nil, err
 	}
+
+	return &RootState{
+		lg:            lg,
+		ctx:           ctx,
+		dialer:        &net.Dialer{},
+		registry:      NewRegistry(provider.Meter("github.com/stroppy-io/stroppy/pkg/bench"), prefix),
+		meterProvider: provider,
+		manualReader:  reader,
+		metricsPrefix: prefix,
+		txMetrics:     &txMetrics{},
+		sharedSlots:   make(map[uint64]*sharedDriverSlot),
+		env:           env,
+		stepFilter:    newStepFilter(),
+	}, nil
 }
 
 // NotifyStep is a no-op at the floor (cloud notification deferred).
@@ -64,8 +75,6 @@ func (r *RootState) NotifyStep(name string, status int32) {}
 
 // Teardown closes all shared drivers. (Workload.Teardown is invoked separately by Run.)
 func (r *RootState) Teardown() error {
-	r.txMetrics.stop()
-
 	var err error
 
 	r.sharedMu.Lock()
@@ -77,4 +86,13 @@ func (r *RootState) Teardown() error {
 	r.sharedMu.Unlock()
 
 	return err
+}
+
+func (r *RootState) shutdownMetrics() {
+	ctx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+	defer cancel()
+
+	if err := r.meterProvider.Shutdown(ctx); err != nil {
+		r.lg.Error("shutting down metrics", zap.Error(err))
+	}
 }

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/zap"
 
 	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
@@ -94,16 +95,23 @@ func Run(
 	drivers map[int]*stroppy.DriverConfig,
 	env map[string]string,
 	lg *zap.Logger,
+	metricsConfig *MetricsConfig,
 ) error {
 	wl, ok := Lookup(name)
 	if !ok {
 		return fmt.Errorf("%w as %q", errNoWorkloadRegistered, name)
 	}
 
-	root = newRootState(lg, ctx, env)
+	var err error
+
+	root, err = newRootState(lg, ctx, env, metricsConfig)
+	if err != nil {
+		return fmt.Errorf("initialize metrics: %w", err)
+	}
+
 	sum := newSummary(root)
 
-	sum.start(ctx)
+	defer root.shutdownMetrics()
 	defer sum.print()
 	defer func() { _ = root.Teardown() }()
 
@@ -265,8 +273,8 @@ func (b *Bench) Counter(name string) *Metric { return b.newMetric(name, Counter)
 func (b *Bench) Trend(name string) *Metric   { return b.newMetric(name, Trend) }
 func (b *Bench) Rate(name string) *Metric    { return b.newMetric(name, Rate) }
 
-func (b *Bench) newMetric(name string, t metricType) *Metric {
-	m, err := b.root.registry.NewMetric(name, t)
+func (b *Bench) newMetric(name string, typ metricType) *Metric {
+	m, err := b.root.registry.NewMetric(name, typ)
 	if err != nil {
 		b.lg.Fatal("can't register metric", zap.String("name", name), zap.Error(err))
 	}
@@ -274,138 +282,121 @@ func (b *Bench) newMetric(name string, t metricType) *Metric {
 	return &Metric{root: b.root, m: m}
 }
 
-// Add records a value with optional tag key/values.
-func (m *Metric) Add(v float64, tags ...string) {
-	tagSet := m.root.registry.RootTagSet()
-	for i := 0; i+1 < len(tags); i += 2 {
-		tagSet = tagSet.With(tags[i], tags[i+1])
-	}
-
-	PushIfNotDone(context.Background(), m.root.samples, Sample{
-		Metric: m.m, Tags: tagSet,
-		Time: time.Now(), Value: v,
-	})
+// Add records a value with optional tag key/value pairs.
+func (m *Metric) Add(value float64, tags ...string) {
+	m.m.add(context.Background(), value, attributes(tags...))
 }
 
-// --- summary (drain samples, print) ---
-
-type metricSink struct {
-	typ   metricType
-	count uint64
-	sum   float64
-	vals  []float64
-}
+// --- summary ---
 
 type summary struct {
-	root  *RootState
-	mu    sync.Mutex
-	sinks map[string]*metricSink
+	root *RootState
 }
 
-func newSummary(r *RootState) *summary { return &summary{root: r, sinks: map[string]*metricSink{}} }
-
-func (s *summary) start(ctx context.Context) {
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case sc, ok := <-s.root.samples:
-				if !ok {
-					return
-				}
-
-				s.ingest(sc)
-			}
-		}
-	}()
-}
-
-func (s *summary) ingest(sc SampleContainer) {
-	for _, sample := range sc.GetSamples() {
-		name := sample.Metric.Name
-
-		s.mu.Lock()
-
-		sk, ok := s.sinks[name]
-		if !ok {
-			sk = &metricSink{typ: sample.Metric.Type}
-			s.sinks[name] = sk
-		}
-
-		sk.count++
-
-		sk.sum += sample.Value
-		if sk.typ == Trend {
-			sk.vals = append(sk.vals, sample.Value)
-		}
-		s.mu.Unlock()
-	}
-}
+func newSummary(root *RootState) *summary { return &summary{root: root} }
 
 func (s *summary) print() {
-	close(s.root.samples)
+	var data metricdata.ResourceMetrics
+	if err := s.root.manualReader.Collect(context.Background(), &data); err != nil {
+		fmt.Fprintf(os.Stderr, "bench: collect metrics: %v\n", err)
 
-	for sc := range s.root.samples {
-		s.ingest(sc)
+		return
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	var lines []string
 
-	if len(s.sinks) == 0 {
+	for _, scope := range data.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			name := strings.TrimPrefix(metric.Name, s.root.metricsPrefix)
+			switch aggregation := metric.Data.(type) {
+			case metricdata.Sum[float64]:
+				var total float64
+				for _, point := range aggregation.DataPoints {
+					total += point.Value
+				}
+
+				lines = append(lines, fmt.Sprintf("  %-40s %.3f", name, total))
+			case metricdata.Gauge[float64]:
+				if len(aggregation.DataPoints) > 0 {
+					lastPoint := aggregation.DataPoints[len(aggregation.DataPoints)-1]
+					lines = append(lines, fmt.Sprintf("  %-40s %.3f", name, lastPoint.Value))
+				}
+			case metricdata.Histogram[float64]:
+				lines = append(lines, formatHistogramSummary(name, aggregation.DataPoints))
+			}
+		}
+	}
+
+	if len(lines) == 0 {
 		fmt.Fprintln(os.Stderr, "bench: no metrics recorded")
 
 		return
 	}
 
-	names := make([]string, 0, len(s.sinks))
-	for n := range s.sinks {
-		names = append(names, n)
-	}
-
-	sort.Strings(names)
 	fmt.Fprintln(os.Stderr, "\n=== bench summary ===")
 
-	for _, n := range names {
-		sk := s.sinks[n]
-		switch sk.typ {
-		case Counter:
-			fmt.Fprintf(os.Stderr, "  %-40s %d\n", n, uint64(sk.sum))
-		case Trend:
-			fmt.Fprintf(os.Stderr, "  %-40s count=%d avg=%.3f %s\n",
-				n, sk.count, sk.sum/float64(max1(sk.count)), percentiles(sk.vals))
-		case Rate:
-			pct := 0.0
-			if sk.count > 0 {
-				pct = percentScale * sk.sum / float64(sk.count)
-			}
+	for _, line := range lines {
+		fmt.Fprintln(os.Stderr, line)
+	}
+}
 
-			fmt.Fprintf(os.Stderr, "  %-40s %.2f%%  %d out of %d\n", n, pct, uint64(sk.sum), sk.count)
-		default:
-			fmt.Fprintf(os.Stderr, "  %-40s count=%d sum=%.3f\n", n, sk.count, sk.sum)
+func formatHistogramSummary(name string, points []metricdata.HistogramDataPoint[float64]) string {
+	var (
+		count   uint64
+		sum     float64
+		bounds  []float64
+		buckets []uint64
+	)
+
+	for _, point := range points {
+		count += point.Count
+
+		sum += point.Sum
+		if len(bounds) == 0 {
+			bounds = point.Bounds
+			buckets = make([]uint64, len(point.BucketCounts))
+		}
+
+		for i, bucketCount := range point.BucketCounts {
+			buckets[i] += bucketCount
 		}
 	}
-}
 
-func max1(n uint64) uint64 {
-	if n == 0 {
-		return 1
+	average := 0.0
+	if count > 0 {
+		average = sum / float64(count)
 	}
 
-	return n
+	return fmt.Sprintf(
+		"  %-40s count=%d avg=%.3f p(50)~=%.3f p(90)~=%.3f p(95)~=%.3f p(99)~=%.3f",
+		name, count, average,
+		histogramQuantile(bounds, buckets, count, medianP),
+		histogramQuantile(bounds, buckets, count, p90),
+		histogramQuantile(bounds, buckets, count, p95),
+		histogramQuantile(bounds, buckets, count, p99),
+	)
 }
 
-func percentiles(vals []float64) string {
-	if len(vals) == 0 {
-		return ""
+func histogramQuantile(bounds []float64, buckets []uint64, count uint64, quantile float64) float64 {
+	if count == 0 || len(buckets) == 0 {
+		return 0
 	}
 
-	s := make([]float64, len(vals))
-	copy(s, vals)
-	sort.Float64s(s)
+	target := uint64(float64(count-1)*quantile) + 1
 
-	pct := func(p float64) float64 { return s[int(float64(len(s)-1)*p)] }
+	var cumulative uint64
+	for i, bucketCount := range buckets {
+		cumulative += bucketCount
+		if cumulative >= target {
+			if i < len(bounds) {
+				return bounds[i]
+			}
 
-	return fmt.Sprintf("p(50)=%.3f p(90)=%.3f p(95)=%.3f p(99)=%.3f", pct(medianP), pct(p90), pct(p95), pct(p99))
+			if len(bounds) > 0 {
+				return bounds[len(bounds)-1]
+			}
+		}
+	}
+
+	return 0
 }

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -284,7 +284,7 @@ func (b *Bench) newMetric(name string, typ metricType) *Metric {
 
 // Add records a value with optional tag key/value pairs.
 func (m *Metric) Add(value float64, tags ...string) {
-	m.m.add(context.Background(), value, attributes(tags...))
+	m.m.add(context.Background(), value, m.m.taggedAttributes(tags))
 }
 
 // --- summary ---
@@ -317,10 +317,7 @@ func (s *summary) print() {
 
 				lines = append(lines, fmt.Sprintf("  %-40s %.3f", name, total))
 			case metricdata.Gauge[float64]:
-				if len(aggregation.DataPoints) > 0 {
-					lastPoint := aggregation.DataPoints[len(aggregation.DataPoints)-1]
-					lines = append(lines, fmt.Sprintf("  %-40s %.3f", name, lastPoint.Value))
-				}
+				lines = append(lines, fmt.Sprintf("  %-40s %.3f", name, sumGauge(aggregation.DataPoints)))
 			case metricdata.Histogram[float64]:
 				lines = append(lines, formatHistogramSummary(name, aggregation.DataPoints))
 			}
@@ -338,6 +335,15 @@ func (s *summary) print() {
 	for _, line := range lines {
 		fmt.Fprintln(os.Stderr, line)
 	}
+}
+
+func sumGauge(points []metricdata.DataPoint[float64]) float64 {
+	var total float64
+	for _, point := range points {
+		total += point.Value
+	}
+
+	return total
 }
 
 func formatHistogramSummary(name string, points []metricdata.HistogramDataPoint[float64]) string {


### PR DESCRIPTION
## Summary

- replace unbounded per-observation Trend retention with fixed-bucket OpenTelemetry histograms
- retain Stroppy metrics facade while backing counters, gauges, and histograms with a private per-run OTel SDK provider
- restore existing OTLP gRPC/HTTP configuration and update bundled Grafana dashboard to standard counter semantics
- cap OTel cardinality and Stroppy attribute caches; cache OTel record options for zero-allocation steady-state histogram recording

Closes #112.

## Validation

- `make linter`
- `make tests`
- `make build`
- `go test -run '^$' -bench BenchmarkTrendRecord -benchmem ./pkg/bench` (`0 B/op`, `0 allocs/op`)
- one million observations retained as one fixed-bucket histogram series
- Docker OpenTelemetry Collector OTLP/HTTP smoke test with Prometheus scrape verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenTelemetry metrics export via OTLP gRPC or HTTP, with configurable endpoints, headers, TLS, paths, prefixes, intervals, and run metadata.
  - Added local metric summaries when no export endpoint is configured.
  - Added bounded metric storage and cardinality controls for sustained, high-throughput workloads.
  - Expanded metrics for operations, errors, durations, transactions, iterations, inserts, and progress.

- **Bug Fixes**
  - Updated dashboards to use current transaction and query metrics for accurate rates and labels.

- **Documentation**
  - Documented OTLP metrics configuration and local-summary behavior in command help and the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->