### PR TITLE
feat: make database error policy driver-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,15 @@ CSV example:
 ```
 
 Add driver: package under `pkg/driver/<name>/`, implement `driver.Driver`
-(`Insert`, `RunQuery`, `Begin`, `Teardown`), call `RegisterDriver()` in
-`init()`, and add a blank import in `cmd/stroppy/main.go`.
+(`Insert`, `RunQuery`, `Begin`, `ClassifyError`, `Teardown`), call
+`RegisterDriver()` in `init()`, and add a blank import in `cmd/stroppy/main.go`.
+
+Driver `ClassifyError` methods translate backend errors into `driver.ErrorFacts`;
+they do not choose workload behavior. Transactional workloads build policy with
+`b.TxRetryPolicy(opts)`. Defaults retry serialization, deadlock, lock-timeout,
+and unconditional transient facts; unknown facts return errors. Override selected
+facts per workload with `TxRetryPolicyOptions.Actions`; set `Idempotent` to allow
+conditional transient retries.
 
 ## CLI Usage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
-- Database errors are classified by each driver into shared facts, and Go workloads can override the default retry, error, ignore, or fatal action for each fact without matching backend-specific codes or messages.
+- Database errors are classified by each driver into shared facts, and Go workloads can override the default retry, error, ignore, or fatal action for each fact without matching backend-specific codes or messages. ([#127](https://github.com/stroppy-io/stroppy/pull/127))
 - New `pkg/gen` random-generation primitives library: deterministic, seekable, allocation-free scalar and text draws composed in plain Go, intended to replace the relational datagen expression framework for workload data loading.
 - `pkg/gen` now provides typed direct-output batches: a reusable columnar [Batch] with bound [Column] handles and an [IndexedSource] that fills rows through a plain Go row callback, so workload formulas write straight into prepared storage with zero generation-time allocations after preparation.
 - Insert-method ownership moves to the driver package: `driver.InsertMethod` is the Go-native enum for the typed insert path, with `ParseInsertMethod` for authoring strings (`plain_query`, `plain_bulk`, `columnar`, `native`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
+- Database errors are classified by each driver into shared facts, and Go workloads can override the default retry, error, ignore, or fatal action for each fact without matching backend-specific codes or messages.
 - New `pkg/gen` random-generation primitives library: deterministic, seekable, allocation-free scalar and text draws composed in plain Go, intended to replace the relational datagen expression framework for workload data loading.
 - `pkg/gen` now provides typed direct-output batches: a reusable columnar [Batch] with bound [Column] handles and an [IndexedSource] that fills rows through a plain Go row callback, so workload formulas write straight into prepared storage with zero generation-time allocations after preparation.
 - Insert-method ownership moves to the driver package: `driver.InsertMethod` is the Go-native enum for the typed insert path, with `ParseInsertMethod` for authoring strings (`plain_query`, `plain_bulk`, `columnar`, `native`).

--- a/internal/workloads/tpcb/tpcb.go
+++ b/internal/workloads/tpcb/tpcb.go
@@ -42,6 +42,7 @@ type workload struct {
 
 	retryMetricOnce sync.Once
 	retryMetric     *bench.Metric
+	retryPolicy     bench.RetryPolicy
 
 	vuStates sync.Map // uint64 -> *vuState
 }
@@ -100,6 +101,10 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	}
 
 	b.StepBegin("workload")
+	w.retryPolicy = b.TxRetryPolicy(bench.TxRetryPolicyOptions{
+		MaxAttempts: bench.EnvInt("RETRY_ATTEMPTS", 3),
+		OnRetry:     func(int, error, bench.RetryDecision) { w.retryCounter(b).Add(1) },
+	})
 
 	return nil
 }
@@ -112,11 +117,6 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 	delta := vs.delta.IntN(10001) - 5000
 	hid := vs.nextHid()
 
-	policy := b.TxRetryPolicy(bench.TxRetryPolicyOptions{
-		MaxAttempts: bench.EnvInt("RETRY_ATTEMPTS", 3),
-		OnRetry:     func(int, error, bench.RetryDecision) { w.retryCounter(b).Add(1) },
-	})
-
 	updateAccount, _ := w.sql.Query("workload_tx_tpcb", "update_account")
 	getBalance, _ := w.sql.Query("workload_tx_tpcb", "get_balance")
 	updateTeller, _ := w.sql.Query("workload_tx_tpcb", "update_teller")
@@ -124,7 +124,7 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 	insertHistory, _ := w.sql.Query("workload_tx_tpcb", "insert_history")
 
 	return b.Step("workload", func() error {
-		return bench.Retry0(ctx, policy, func() error {
+		return bench.Retry0(ctx, w.retryPolicy, func() error {
 			return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "tpcb"}, func(tx *bench.TxX) error {
 				if err := tx.Exec(ctx, updateAccount, map[string]any{"aid": aid, "delta": delta}); err != nil {
 					return err

--- a/internal/workloads/tpcb/tpcb.go
+++ b/internal/workloads/tpcb/tpcb.go
@@ -115,7 +115,7 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 	delta := vs.delta.IntN(10001) - 5000
 	hid := vs.nextHid()
 
-	policy := bench.TxRetryPolicy(w.driverType, bench.TxRetryPolicyOptions{
+	policy := b.TxRetryPolicy(bench.TxRetryPolicyOptions{
 		MaxAttempts: bench.EnvInt("RETRY_ATTEMPTS", 3),
 		OnRetry:     func(int, error, bench.RetryDecision) { w.retryCounter(b).Add(1) },
 	})
@@ -127,7 +127,7 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 	insertHistory, _ := w.sql.Query("workload_tx_tpcb", "insert_history")
 
 	return b.Step("workload", func() error {
-		return bench.Retry0(policy, func() error {
+		return bench.Retry0(ctx, policy, func() error {
 			return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "tpcb"}, func(tx *bench.TxX) error {
 				if err := tx.Exec(ctx, updateAccount, map[string]any{"aid": aid, "delta": delta}); err != nil {
 					return err

--- a/internal/workloads/tpcb/tpcb.go
+++ b/internal/workloads/tpcb/tpcb.go
@@ -53,10 +53,7 @@ func (*workload) Name() string { return "tpcb/tx" }
 func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	w.driverType = b.DriverTypeName()
 
-	w.scale = int64(bench.EnvInt("SCALE_FACTOR", 1))
-	if w.scale < 1 {
-		w.scale = 1
-	}
+	w.scale = int64(max(bench.EnvInt("SCALE_FACTOR", 1), 1))
 
 	w.iso = resolveIsolation(w.driverType)
 	w.sql = mustLoadSQL(w.driverType)

--- a/internal/workloads/tpcc/procs.go
+++ b/internal/workloads/tpcc/procs.go
@@ -71,7 +71,7 @@ func (w *workload) procNewOrder(ctx context.Context, b *bench.Bench, vs *vuState
 		"w_id": vs.homeWID, "min_w_id": w.warehouseStart, "max_w_id": w.wIDMax,
 		"d_id": dID, "c_id": cID, "ol_cnt": olCnt, "force_rollback": forceRollback,
 	}
-	err := bench.Retry0(w.retryPolicy(), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "new_order"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "new_order"), args)
 		})
@@ -121,7 +121,7 @@ func (w *workload) procPayment(ctx context.Context, b *bench.Bench, vs *vuState)
 		"p_w_id": vs.homeWID, "p_d_id": dID, "p_c_w_id": cWID, "p_c_d_id": cDID,
 		"p_c_id": cIDPick, "byname": bynameInt(isByName), "h_amount": amount, "c_last": cLastPick, "p_h_id": hID,
 	}
-	_ = bench.Retry0(w.retryPolicy(), func() error {
+	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "payment"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "payment"), args)
 		})
@@ -152,7 +152,7 @@ func (w *workload) procOrderStatus(ctx context.Context, b *bench.Bench, vs *vuSt
 	}
 	bynameObserved := false
 
-	_ = bench.Retry0(w.retryPolicy(), func() error {
+	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		bynameObserved = false
 
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "order_status"}, func(tx *bench.TxX) error {
@@ -174,7 +174,7 @@ func (w *workload) procDelivery(ctx context.Context, b *bench.Bench, vs *vuState
 
 	carrierID := vs.ri(vs.dCarrier, 1, districtsPerWarehouse)
 	args := map[string]any{"d_w_id": vs.homeWID, "d_o_carrier_id": carrierID}
-	_ = bench.Retry0(w.retryPolicy(), func() error {
+	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "delivery"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "delivery"), args)
 		})
@@ -190,7 +190,7 @@ func (w *workload) procStockLevel(ctx context.Context, b *bench.Bench, vs *vuSta
 	dID := vs.ri(vs.slDID, 1, districtsPerWarehouse)
 	threshold := vs.ri(vs.slThreshold, 10, 20)
 	args := map[string]any{"st_w_id": vs.homeWID, "st_d_id": dID, "threshold": threshold}
-	_ = bench.Retry0(w.retryPolicy(), func() error {
+	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "stock_level"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "stock_level"), args)
 		})

--- a/internal/workloads/tpcc/procs.go
+++ b/internal/workloads/tpcc/procs.go
@@ -32,6 +32,7 @@ func (w *workload) iterateProcs(ctx context.Context, b *bench.Bench, vs *vuState
 		}
 
 		var err error
+
 		switch idx {
 		case 0:
 			err = w.procNewOrder(ctx, b, vs)
@@ -44,6 +45,7 @@ func (w *workload) iterateProcs(ctx context.Context, b *bench.Bench, vs *vuState
 		case 4:
 			err = w.procStockLevel(ctx, b, vs)
 		}
+
 		if err != nil {
 			return err
 		}
@@ -75,7 +77,7 @@ func (w *workload) procNewOrder(ctx context.Context, b *bench.Bench, vs *vuState
 		"w_id": vs.homeWID, "min_w_id": w.warehouseStart, "max_w_id": w.wIDMax,
 		"d_id": dID, "c_id": cID, "ol_cnt": olCnt, "force_rollback": forceRollback,
 	}
-	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy, func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "new_order"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "new_order"), args)
 		})
@@ -128,7 +130,7 @@ func (w *workload) procPayment(ctx context.Context, b *bench.Bench, vs *vuState)
 		"p_w_id": vs.homeWID, "p_d_id": dID, "p_c_w_id": cWID, "p_c_d_id": cDID,
 		"p_c_id": cIDPick, "byname": bynameInt(isByName), "h_amount": amount, "c_last": cLastPick, "p_h_id": hID,
 	}
-	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy, func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "payment"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "payment"), args)
 		})
@@ -161,7 +163,7 @@ func (w *workload) procOrderStatus(ctx context.Context, b *bench.Bench, vs *vuSt
 	}
 	bynameObserved := false
 
-	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy, func() error {
 		bynameObserved = false
 
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "order_status"}, func(tx *bench.TxX) error {
@@ -185,7 +187,8 @@ func (w *workload) procDelivery(ctx context.Context, b *bench.Bench, vs *vuState
 
 	carrierID := vs.ri(vs.dCarrier, 1, districtsPerWarehouse)
 	args := map[string]any{"d_w_id": vs.homeWID, "d_o_carrier_id": carrierID}
-	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
+
+	return bench.Retry0(ctx, w.retryPolicy, func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "delivery"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "delivery"), args)
 		})
@@ -201,7 +204,8 @@ func (w *workload) procStockLevel(ctx context.Context, b *bench.Bench, vs *vuSta
 	dID := vs.ri(vs.slDID, 1, districtsPerWarehouse)
 	threshold := vs.ri(vs.slThreshold, 10, 20)
 	args := map[string]any{"st_w_id": vs.homeWID, "st_d_id": dID, "threshold": threshold}
-	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
+
+	return bench.Retry0(ctx, w.retryPolicy, func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "stock_level"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "stock_level"), args)
 		})

--- a/internal/workloads/tpcc/procs.go
+++ b/internal/workloads/tpcc/procs.go
@@ -31,17 +31,21 @@ func (w *workload) iterateProcs(ctx context.Context, b *bench.Bench, vs *vuState
 			sleepSeconds(float64(keyingTime[name]))
 		}
 
+		var err error
 		switch idx {
 		case 0:
-			w.procNewOrder(ctx, b, vs)
+			err = w.procNewOrder(ctx, b, vs)
 		case 1:
-			w.procPayment(ctx, b, vs)
+			err = w.procPayment(ctx, b, vs)
 		case 2:
-			w.procOrderStatus(ctx, b, vs)
+			err = w.procOrderStatus(ctx, b, vs)
 		case 3:
-			w.procDelivery(ctx, b, vs)
+			err = w.procDelivery(ctx, b, vs)
 		case 4:
-			w.procStockLevel(ctx, b, vs)
+			err = w.procStockLevel(ctx, b, vs)
+		}
+		if err != nil {
+			return err
 		}
 
 		if w.pacing {
@@ -52,7 +56,7 @@ func (w *workload) iterateProcs(ctx context.Context, b *bench.Bench, vs *vuState
 	})
 }
 
-func (w *workload) procNewOrder(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) procNewOrder(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.newOrderTotal.Add(1)
 
 	start := time.Now()
@@ -77,14 +81,17 @@ func (w *workload) procNewOrder(ctx context.Context, b *bench.Bench, vs *vuState
 		})
 	})
 	// Server-side rollback: the proc RAISEs/SIGNALs "tpcc_rollback:item_not_found" when
-	// force_rollback is set. Swallow it as a spec-mandated success (the retry policy also
-	// filters it).
+	// force_rollback is set. Treat it as a spec-mandated success.
 	if isRollbackSentinel(err) {
 		w.m.rollbackDone.Add(1)
+
+		return nil
 	}
+
+	return err
 }
 
-func (w *workload) procPayment(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) procPayment(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.paymentTotal.Add(1)
 
 	start := time.Now()
@@ -121,7 +128,7 @@ func (w *workload) procPayment(ctx context.Context, b *bench.Bench, vs *vuState)
 		"p_w_id": vs.homeWID, "p_d_id": dID, "p_c_w_id": cWID, "p_c_d_id": cDID,
 		"p_c_id": cIDPick, "byname": bynameInt(isByName), "h_amount": amount, "c_last": cLastPick, "p_h_id": hID,
 	}
-	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "payment"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "payment"), args)
 		})
@@ -130,9 +137,11 @@ func (w *workload) procPayment(ctx context.Context, b *bench.Bench, vs *vuState)
 	if isByName {
 		w.m.paymentByname.Add(1)
 	}
+
+	return err
 }
 
-func (w *workload) procOrderStatus(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) procOrderStatus(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.orderStatusTotal.Add(1)
 
 	start := time.Now()
@@ -152,7 +161,7 @@ func (w *workload) procOrderStatus(ctx context.Context, b *bench.Bench, vs *vuSt
 	}
 	bynameObserved := false
 
-	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		bynameObserved = false
 
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "order_status"}, func(tx *bench.TxX) error {
@@ -164,9 +173,11 @@ func (w *workload) procOrderStatus(ctx context.Context, b *bench.Bench, vs *vuSt
 	if bynameObserved {
 		w.m.orderStatusByname.Add(1)
 	}
+
+	return err
 }
 
-func (w *workload) procDelivery(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) procDelivery(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.deliveryTotal.Add(1)
 
 	start := time.Now()
@@ -174,14 +185,14 @@ func (w *workload) procDelivery(ctx context.Context, b *bench.Bench, vs *vuState
 
 	carrierID := vs.ri(vs.dCarrier, 1, districtsPerWarehouse)
 	args := map[string]any{"d_w_id": vs.homeWID, "d_o_carrier_id": carrierID}
-	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "delivery"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "delivery"), args)
 		})
 	})
 }
 
-func (w *workload) procStockLevel(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) procStockLevel(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.stockLevelTotal.Add(1)
 
 	start := time.Now()
@@ -190,7 +201,7 @@ func (w *workload) procStockLevel(ctx context.Context, b *bench.Bench, vs *vuSta
 	dID := vs.ri(vs.slDID, 1, districtsPerWarehouse)
 	threshold := vs.ri(vs.slThreshold, 10, 20)
 	args := map[string]any{"st_w_id": vs.homeWID, "st_d_id": dID, "threshold": threshold}
-	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "stock_level"}, func(tx *bench.TxX) error {
 			return tx.Exec(ctx, w.q("workload_procs", "stock_level"), args)
 		})

--- a/internal/workloads/tpcc/tpcc.go
+++ b/internal/workloads/tpcc/tpcc.go
@@ -899,11 +899,11 @@ func (w *workload) orderStatus(ctx context.Context, b *bench.Bench, vs *vuState)
 			}
 
 			oID := toInt64(lastRow[0])
-			_, _ = tx.QueryRows(ctx, w.q("workload_tx_order_status", "get_order_lines"), map[string]any{
+			_, err = tx.QueryRows(ctx, w.q("workload_tx_order_status", "get_order_lines"), map[string]any{
 				"o_id": oID, "d_id": dID, "w_id": wID,
 			})
 
-			return nil
+			return err
 		})
 	})
 
@@ -1049,13 +1049,17 @@ func (w *workload) stockLevel(ctx context.Context, b *bench.Bench, vs *vuState) 
 
 			tmpl := w.q("workload_tx_stock_level", "stock_count_in")
 			if w.isYdb {
-				_, _ = tx.QueryValue(ctx, tmpl, map[string]any{"w_id": wID, "threshold": threshold, "ids": idsToIntAny(ids)})
-			} else {
-				rendered := strings.ReplaceAll(tmpl, "{ids}", joinInt64s(ids))
-				_, _ = tx.QueryValue(ctx, rendered, map[string]any{"w_id": wID, "threshold": threshold})
+				_, err = tx.QueryValue(ctx, tmpl, map[string]any{
+					"w_id": wID, "threshold": threshold, "ids": idsToIntAny(ids),
+				})
+
+				return err
 			}
 
-			return nil
+			rendered := strings.ReplaceAll(tmpl, "{ids}", joinInt64s(ids))
+			_, err = tx.QueryValue(ctx, rendered, map[string]any{"w_id": wID, "threshold": threshold})
+
+			return err
 		})
 	})
 }

--- a/internal/workloads/tpcc/tpcc.go
+++ b/internal/workloads/tpcc/tpcc.go
@@ -50,7 +50,8 @@ type workload struct {
 	wIDMax         int64
 	loadItems      bool
 
-	m *metrics
+	m           *metrics
+	retryPolicy bench.RetryPolicy
 
 	vuStates sync.Map // uint64 -> *vuState
 }
@@ -108,6 +109,10 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	w.initConfig()
 	useUnlogged := bench.Env("PG_UNLOGGED", "false") == "true" && w.driverType == bench.DriverPostgres
 	w.m = w.initMetrics(b)
+	w.retryPolicy = b.TxRetryPolicy(bench.TxRetryPolicyOptions{
+		MaxAttempts: bench.EnvInt("RETRY_ATTEMPTS", 3),
+		OnRetry:     func(int, error, bench.RetryDecision) { w.m.retryAttempts.Add(1) },
+	})
 
 	loadDays := time.Now().UTC().Unix() / 86400
 
@@ -273,6 +278,7 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 		}
 
 		var err error
+
 		switch idx {
 		case 0:
 			err = w.newOrder(ctx, b, vs)
@@ -285,6 +291,7 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 		case 4:
 			err = w.stockLevel(ctx, b, vs)
 		}
+
 		if err != nil {
 			return err
 		}
@@ -311,13 +318,6 @@ func (w *workload) q(section, name string) string {
 	}
 
 	return s
-}
-
-func (w *workload) retryPolicy(b *bench.Bench) bench.RetryPolicy {
-	return b.TxRetryPolicy(bench.TxRetryPolicyOptions{
-		MaxAttempts: bench.EnvInt("RETRY_ATTEMPTS", 3),
-		OnRetry:     func(int, error, bench.RetryDecision) { w.m.retryAttempts.Add(1) },
-	})
 }
 
 // --- new_order ---
@@ -361,7 +361,7 @@ func (w *workload) newOrder(ctx context.Context, b *bench.Bench, vs *vuState) er
 		lineIID[olCnt-1] = items + 1 // nonexistent item → sentinel rollback
 	}
 
-	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	return bench.Retry0(ctx, w.retryPolicy, func() error {
 		tx, err := b.Begin(ctx, bench.BeginOpts{Isolation: w.iso, Name: "new_order"})
 		if err != nil {
 			return err
@@ -610,7 +610,7 @@ func (w *workload) payment(ctx context.Context, b *bench.Bench, vs *vuState) err
 
 	var wasBC bool
 
-	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy, func() error {
 		wasBC = false
 
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "payment"}, func(tx *bench.TxX) error {
@@ -841,7 +841,7 @@ func (w *workload) orderStatus(ctx context.Context, b *bench.Bench, vs *vuState)
 	}
 
 	bynameObserved := false
-	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy, func() error {
 		bynameObserved = false
 
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "order_status"}, func(tx *bench.TxX) error {
@@ -926,7 +926,7 @@ func (w *workload) delivery(ctx context.Context, b *bench.Bench, vs *vuState) er
 	wID := vs.homeWID
 	carrierID := vs.ri(vs.dCarrier, 1, 10)
 
-	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	return bench.Retry0(ctx, w.retryPolicy, func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "delivery"}, func(tx *bench.TxX) error {
 			for dID := int64(1); dID <= districtsPerWarehouse; dID++ {
 				minRow, err := tx.QueryRow(ctx, w.q("workload_tx_delivery", "get_min_new_order"), map[string]any{
@@ -1009,7 +1009,7 @@ func (w *workload) stockLevel(ctx context.Context, b *bench.Bench, vs *vuState) 
 	dID := vs.ri(vs.slDID, 1, districtsPerWarehouse)
 	threshold := vs.ri(vs.slThreshold, 10, 20)
 
-	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	return bench.Retry0(ctx, w.retryPolicy, func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "stock_level"}, func(tx *bench.TxX) error {
 			nextOIDv, err := tx.QueryValue(ctx, w.q("workload_tx_stock_level", "get_district"), map[string]any{
 				"w_id": wID, "d_id": dID,

--- a/internal/workloads/tpcc/tpcc.go
+++ b/internal/workloads/tpcc/tpcc.go
@@ -309,8 +309,8 @@ func (w *workload) q(section, name string) string {
 	return s
 }
 
-func (w *workload) retryPolicy() bench.RetryPolicy {
-	return bench.TxRetryPolicy(w.driverType, bench.TxRetryPolicyOptions{
+func (w *workload) retryPolicy(b *bench.Bench) bench.RetryPolicy {
+	return b.TxRetryPolicy(bench.TxRetryPolicyOptions{
 		MaxAttempts: bench.EnvInt("RETRY_ATTEMPTS", 3),
 		OnRetry:     func(int, error, bench.RetryDecision) { w.m.retryAttempts.Add(1) },
 	})
@@ -357,7 +357,7 @@ func (w *workload) newOrder(ctx context.Context, b *bench.Bench, vs *vuState) {
 		lineIID[olCnt-1] = items + 1 // nonexistent item → sentinel rollback
 	}
 
-	_ = bench.Retry0(w.retryPolicy(), func() error {
+	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		tx, err := b.Begin(ctx, bench.BeginOpts{Isolation: w.iso, Name: "new_order"})
 		if err != nil {
 			return err
@@ -606,7 +606,7 @@ func (w *workload) payment(ctx context.Context, b *bench.Bench, vs *vuState) {
 
 	var wasBC bool
 
-	_ = bench.Retry0(w.retryPolicy(), func() error {
+	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		wasBC = false
 
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "payment"}, func(tx *bench.TxX) error {
@@ -835,7 +835,7 @@ func (w *workload) orderStatus(ctx context.Context, b *bench.Bench, vs *vuState)
 	}
 
 	bynameObserved := false
-	_ = bench.Retry0(w.retryPolicy(), func() error {
+	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		bynameObserved = false
 
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "order_status"}, func(tx *bench.TxX) error {
@@ -918,7 +918,7 @@ func (w *workload) delivery(ctx context.Context, b *bench.Bench, vs *vuState) {
 	wID := vs.homeWID
 	carrierID := vs.ri(vs.dCarrier, 1, 10)
 
-	_ = bench.Retry0(w.retryPolicy(), func() error {
+	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "delivery"}, func(tx *bench.TxX) error {
 			for dID := int64(1); dID <= districtsPerWarehouse; dID++ {
 				minRow, err := tx.QueryRow(ctx, w.q("workload_tx_delivery", "get_min_new_order"), map[string]any{
@@ -1001,7 +1001,7 @@ func (w *workload) stockLevel(ctx context.Context, b *bench.Bench, vs *vuState) 
 	dID := vs.ri(vs.slDID, 1, districtsPerWarehouse)
 	threshold := vs.ri(vs.slThreshold, 10, 20)
 
-	_ = bench.Retry0(w.retryPolicy(), func() error {
+	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "stock_level"}, func(tx *bench.TxX) error {
 			nextOIDv, err := tx.QueryValue(ctx, w.q("workload_tx_stock_level", "get_district"), map[string]any{
 				"w_id": wID, "d_id": dID,

--- a/internal/workloads/tpcc/tpcc.go
+++ b/internal/workloads/tpcc/tpcc.go
@@ -272,17 +272,21 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 			sleepSeconds(float64(keyingTime[name]))
 		}
 
+		var err error
 		switch idx {
 		case 0:
-			w.newOrder(ctx, b, vs)
+			err = w.newOrder(ctx, b, vs)
 		case 1:
-			w.payment(ctx, b, vs)
+			err = w.payment(ctx, b, vs)
 		case 2:
-			w.orderStatus(ctx, b, vs)
+			err = w.orderStatus(ctx, b, vs)
 		case 3:
-			w.delivery(ctx, b, vs)
+			err = w.delivery(ctx, b, vs)
 		case 4:
-			w.stockLevel(ctx, b, vs)
+			err = w.stockLevel(ctx, b, vs)
+		}
+		if err != nil {
+			return err
 		}
 
 		if w.pacing {
@@ -318,7 +322,7 @@ func (w *workload) retryPolicy(b *bench.Bench) bench.RetryPolicy {
 
 // --- new_order ---
 
-func (w *workload) newOrder(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) newOrder(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.newOrderTotal.Add(1)
 
 	start := time.Now()
@@ -357,7 +361,7 @@ func (w *workload) newOrder(ctx context.Context, b *bench.Bench, vs *vuState) {
 		lineIID[olCnt-1] = items + 1 // nonexistent item → sentinel rollback
 	}
 
-	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		tx, err := b.Begin(ctx, bench.BeginOpts{Isolation: w.iso, Name: "new_order"})
 		if err != nil {
 			return err
@@ -568,7 +572,7 @@ func (w *workload) batchRead(
 // --- payment ---
 
 //nolint:gocognit,cyclop // TPC-C spec transaction; complexity is inherent to the spec.
-func (w *workload) payment(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) payment(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.paymentTotal.Add(1)
 
 	start := time.Now()
@@ -606,7 +610,7 @@ func (w *workload) payment(ctx context.Context, b *bench.Bench, vs *vuState) {
 
 	var wasBC bool
 
-	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		wasBC = false
 
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "payment"}, func(tx *bench.TxX) error {
@@ -715,6 +719,8 @@ func (w *workload) payment(ctx context.Context, b *bench.Bench, vs *vuState) {
 	if wasBC {
 		w.m.paymentBc.Add(1)
 	}
+
+	return err
 }
 
 func (w *workload) paymentUpdateWarehouse(
@@ -818,7 +824,7 @@ func (w *workload) customerByName(
 // --- order_status (read-only) ---
 
 //nolint:gocognit,cyclop // TPC-C spec transaction; complexity is inherent to the spec.
-func (w *workload) orderStatus(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) orderStatus(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.orderStatusTotal.Add(1)
 
 	start := time.Now()
@@ -835,7 +841,7 @@ func (w *workload) orderStatus(ctx context.Context, b *bench.Bench, vs *vuState)
 	}
 
 	bynameObserved := false
-	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	err := bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		bynameObserved = false
 
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "order_status"}, func(tx *bench.TxX) error {
@@ -904,12 +910,14 @@ func (w *workload) orderStatus(ctx context.Context, b *bench.Bench, vs *vuState)
 	if bynameObserved {
 		w.m.orderStatusByname.Add(1)
 	}
+
+	return err
 }
 
 // --- delivery ---
 
 //nolint:gocognit,cyclop // TPC-C spec transaction; complexity is inherent to the spec.
-func (w *workload) delivery(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) delivery(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.deliveryTotal.Add(1)
 
 	start := time.Now()
@@ -918,7 +926,7 @@ func (w *workload) delivery(ctx context.Context, b *bench.Bench, vs *vuState) {
 	wID := vs.homeWID
 	carrierID := vs.ri(vs.dCarrier, 1, 10)
 
-	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "delivery"}, func(tx *bench.TxX) error {
 			for dID := int64(1); dID <= districtsPerWarehouse; dID++ {
 				minRow, err := tx.QueryRow(ctx, w.q("workload_tx_delivery", "get_min_new_order"), map[string]any{
@@ -991,7 +999,7 @@ func (w *workload) delivery(ctx context.Context, b *bench.Bench, vs *vuState) {
 // --- stock_level (read-only) ---
 
 //nolint:gocognit,cyclop // TPC-C spec transaction; complexity is inherent to the spec.
-func (w *workload) stockLevel(ctx context.Context, b *bench.Bench, vs *vuState) {
+func (w *workload) stockLevel(ctx context.Context, b *bench.Bench, vs *vuState) error {
 	w.m.stockLevelTotal.Add(1)
 
 	start := time.Now()
@@ -1001,7 +1009,7 @@ func (w *workload) stockLevel(ctx context.Context, b *bench.Bench, vs *vuState) 
 	dID := vs.ri(vs.slDID, 1, districtsPerWarehouse)
 	threshold := vs.ri(vs.slThreshold, 10, 20)
 
-	_ = bench.Retry0(ctx, w.retryPolicy(b), func() error {
+	return bench.Retry0(ctx, w.retryPolicy(b), func() error {
 		return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "stock_level"}, func(tx *bench.TxX) error {
 			nextOIDv, err := tx.QueryValue(ctx, w.q("workload_tx_stock_level", "get_district"), map[string]any{
 				"w_id": wID, "d_id": dID,

--- a/pkg/bench/retry.go
+++ b/pkg/bench/retry.go
@@ -3,183 +3,203 @@ package bench
 import (
 	"context"
 	"errors"
+	"maps"
 	"math/rand/v2"
-	"strings"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
-	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stroppy-io/stroppy/pkg/driver"
 )
 
-// MySQL driver error codes returned for retryable lock contention.
+// ErrorAction is workload policy for one classified driver error.
+type ErrorAction uint8
+
 const (
-	mySQLErrLockDeadlock    = 1213 // ER_LOCK_DEADLOCK
-	mySQLErrLockWaitTimeout = 1205 // ER_LOCK_WAIT_TIMEOUT
+	ErrorActionError ErrorAction = iota
+	ErrorActionRetry
+	ErrorActionIgnore
+	ErrorActionFatal
 )
 
-// IsSerializationError reports whether err is a retryable serialization/deadlock
-// failure. The rollback sentinel injected by TPC-C ("tpcc_rollback:") is never
-// retryable. Driver errors are matched by typed errors.As on the underlying
-// pgconn/mysql error plus its SQLSTATE, replacing the TS regex port. YDB's
-// transient tx errors have no SQLSTATE and stay text-based (see TxRetryPolicy).
-func IsSerializationError(err error) bool {
-	if err == nil {
-		return false
+// ErrorActionMap maps database-independent error kinds to workload actions.
+type ErrorActionMap map[driver.ErrorKind]ErrorAction
+
+// DefaultErrorActions returns safe transaction defaults. Contention and
+// unconditional transient failures retry; everything else remains an error.
+func DefaultErrorActions(idempotent bool) ErrorActionMap {
+	actions := ErrorActionMap{
+		driver.ErrorKindSerialization: ErrorActionRetry,
+		driver.ErrorKindDeadlock:      ErrorActionRetry,
+		driver.ErrorKindLockTimeout:   ErrorActionRetry,
+		driver.ErrorKindTransient:     ErrorActionRetry,
+	}
+	if idempotent {
+		actions[driver.ErrorKindTransientIfIdempotent] = ErrorActionRetry
 	}
 
-	if strings.Contains(err.Error(), "tpcc_rollback:") {
-		return false
-	}
-
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
-		switch pgErr.Code {
-		case "40001", "40P01": // serialization_failure, deadlock_detected
-			return true
-		}
-	}
-
-	var myErr *mysql.MySQLError
-	if errors.As(err, &myErr) {
-		switch myErr.Number {
-		case mySQLErrLockDeadlock, mySQLErrLockWaitTimeout:
-			return true
-		}
-	}
-
-	return false
+	return actions
 }
 
-// Retry runs fn up to maxAttempts times, retrying while isRetryable returns true.
-// No backoff: serialization retries are immediate by design. onRetry fires once
-// per retry, before re-invoking fn, with the upcoming (2-based) attempt number.
-func Retry[T any](
-	maxAttempts int,
-	isRetryable func(error) bool,
-	fn func() (T, error),
-	onRetry ...func(int, error),
-) (T, error) {
-	var (
-		lastErr error
-		zero    T
-	)
+// With returns a copy with overrides applied. Missing kinds keep the safe
+// ErrorActionError fallback.
+func (m ErrorActionMap) With(overrides ErrorActionMap) ErrorActionMap {
+	result := make(ErrorActionMap, len(m)+len(overrides))
+	maps.Copy(result, m)
+	maps.Copy(result, overrides)
 
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		v, err := fn()
-		if err == nil {
-			return v, nil
-		}
-
-		lastErr = err
-		if !isRetryable(err) || attempt == maxAttempts {
-			return zero, err
-		}
-
-		for _, cb := range onRetry {
-			cb(attempt+1, err)
-		}
-	}
-
-	return zero, lastErr // unreachable — last iteration always returns
+	return result
 }
 
-// Retry0 is RetryWithPolicy for a void fn (the common tx-replay shape).
-func Retry0(policy RetryPolicy, fn func() error) error {
-	_, err := RetryWithPolicy(policy, func() (struct{}, error) {
+func (m ErrorActionMap) action(kind driver.ErrorKind) ErrorAction {
+	if action, ok := m[kind]; ok {
+		return action
+	}
+
+	return ErrorActionError
+}
+
+// FatalError marks an error that must stop the whole scenario.
+type FatalError struct {
+	err error
+}
+
+func (e *FatalError) Error() string { return e.err.Error() }
+func (e *FatalError) Unwrap() error { return e.err }
+
+// IsFatalError reports whether err carries a fatal workload action.
+func IsFatalError(err error) bool {
+	_, ok := errors.AsType[*FatalError](err)
+
+	return ok
+}
+
+// Retry0 is RetryWithPolicy for a void fn (the common transaction-replay shape).
+func Retry0(ctx context.Context, policy RetryPolicy, fn func() error) error {
+	_, err := RetryWithPolicy(ctx, policy, func() (struct{}, error) {
 		return struct{}{}, fn()
 	})
 
 	return err
 }
 
-// RetryDecision is the verdict a RetryPolicy.Classify returns for one error.
+// RetryDecision records the classified facts and resolved action for one error.
 type RetryDecision struct {
-	Retry        bool
+	Action       ErrorAction
+	Facts        driver.ErrorFacts
 	DelaySeconds float64
-	Reason       string
 }
 
-// RetryPolicy owns error classification and optional backoff for RetryWithPolicy.
+// RetryPolicy combines driver classification with workload-owned actions.
 type RetryPolicy struct {
 	MaxAttempts int
-	Classify    func(err error, attempt int) RetryDecision
+	Classify    func(error) driver.ErrorFacts
+	Actions     ErrorActionMap
 	OnRetry     func(attempt int, err error, decision RetryDecision)
+
+	baseDelaySeconds float64
+	maxDelaySeconds  float64
 }
 
-// RetryWithPolicy runs fn under policy. The policy owns classification and
-// optional backoff; the caller owns the transaction closure being replayed.
-func RetryWithPolicy[T any](policy RetryPolicy, fn func() (T, error)) (T, error) {
+// RetryWithPolicy runs fn under policy. Error and fatal actions preserve the
+// original error, ignore returns the zero value, and retry replays fn.
+func RetryWithPolicy[T any](
+	ctx context.Context,
+	policy RetryPolicy,
+	fn func() (T, error),
+) (T, error) {
 	var (
 		lastErr error
 		zero    T
 	)
 
-	for attempt := 1; attempt <= policy.MaxAttempts; attempt++ {
-		v, err := fn()
-		if err == nil {
-			return v, nil
-		}
-
-		lastErr = err
-
-		decision := policy.Classify(err, attempt)
-		if !decision.Retry || attempt == policy.MaxAttempts {
+	maxAttempts := max(policy.MaxAttempts, 1)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
 			return zero, err
 		}
 
-		if policy.OnRetry != nil {
-			policy.OnRetry(attempt+1, err, decision)
+		value, err := fn()
+		if err == nil {
+			return value, nil
+		}
+		lastErr = err
+
+		facts := driver.DefaultErrorFacts(err)
+		if policy.Classify != nil {
+			facts = policy.Classify(err)
 		}
 
-		if decision.DelaySeconds > 0 {
-			sleepForRetry(decision.DelaySeconds)
+		decision := RetryDecision{
+			Action: policy.Actions.action(facts.Kind),
+			Facts:  facts,
+		}
+
+		switch decision.Action {
+		case ErrorActionIgnore:
+			return zero, nil
+		case ErrorActionFatal:
+			return zero, &FatalError{err: err}
+		case ErrorActionRetry:
+			if attempt == maxAttempts {
+				return zero, err
+			}
+
+			if facts.Backoff {
+				decision.DelaySeconds = backoffSeconds(
+					attempt,
+					policy.baseDelaySeconds,
+					policy.maxDelaySeconds,
+				)
+			}
+
+			if policy.OnRetry != nil {
+				policy.OnRetry(attempt+1, err, decision)
+			}
+
+			if err := sleepForRetry(ctx, decision.DelaySeconds); err != nil {
+				return zero, err
+			}
+		default:
+			return zero, err
 		}
 	}
 
-	return zero, lastErr // unreachable
+	return zero, lastErr // unreachable: final attempt returns above
 }
 
-// TxRetryPolicyOptions configures TxRetryPolicy.
+// TxRetryPolicyOptions configures Bench.TxRetryPolicy.
 type TxRetryPolicyOptions struct {
 	MaxAttempts      int
+	Idempotent       bool
+	Actions          ErrorActionMap
 	BaseDelaySeconds float64
 	MaxDelaySeconds  float64
 	OnRetry          func(attempt int, err error, decision RetryDecision)
 }
 
-// TxRetryPolicy builds the standard transaction-retry policy: immediate retry on
-// serialization errors, exponential backoff on YDB transient errors, never on the
-// rollback sentinel. driverType selects the YDB backoff branch.
-func TxRetryPolicy(driverType DriverTypeName, opts TxRetryPolicyOptions) RetryPolicy {
+// TxRetryPolicy builds a policy from this bench's driver classifier and
+// workload overrides.
+func (b *Bench) TxRetryPolicy(opts TxRetryPolicyOptions) RetryPolicy {
+	return newTxRetryPolicy(b.drv.ClassifyError, opts)
+}
+
+func newTxRetryPolicy(
+	classify func(error) driver.ErrorFacts,
+	opts TxRetryPolicyOptions,
+) RetryPolicy {
 	if opts.BaseDelaySeconds == 0 {
 		opts.BaseDelaySeconds = 0.05
 	}
-
 	if opts.MaxDelaySeconds == 0 {
 		opts.MaxDelaySeconds = 1
 	}
 
 	return RetryPolicy{
-		MaxAttempts: opts.MaxAttempts,
-		OnRetry:     opts.OnRetry,
-		Classify: func(err error, attempt int) RetryDecision {
-			if err == nil || strings.Contains(err.Error(), "tpcc_rollback:") {
-				return RetryDecision{}
-			}
-
-			if IsSerializationError(err) {
-				return RetryDecision{Retry: true, Reason: "serialization"}
-			}
-
-			if driverType == DriverYDB && isYDBTransientTxError(err.Error()) {
-				return RetryDecision{
-					Retry: true, Reason: "ydb_transient",
-					DelaySeconds: backoffSeconds(attempt, opts.BaseDelaySeconds, opts.MaxDelaySeconds),
-				}
-			}
-
-			return RetryDecision{}
-		},
+		MaxAttempts:      opts.MaxAttempts,
+		Classify:         classify,
+		Actions:          DefaultErrorActions(opts.Idempotent).With(opts.Actions),
+		OnRetry:          opts.OnRetry,
+		baseDelaySeconds: opts.BaseDelaySeconds,
+		maxDelaySeconds:  opts.MaxDelaySeconds,
 	}
 }
 
@@ -191,39 +211,20 @@ func backoffSeconds(attempt int, base, maxSeconds float64) float64 {
 	return capped + rand.Float64()*capped*0.2 //nolint:gosec // G404: retry backoff jitter RNG, not security-sensitive
 }
 
-func sleepForRetry(seconds float64) {
+func sleepForRetry(ctx context.Context, seconds float64) error {
+	if seconds <= 0 {
+		return ctx.Err()
+	}
+
 	timer := time.NewTimer(time.Duration(seconds * float64(time.Second)))
 	defer timer.Stop()
 
 	select {
 	case <-timer.C:
-	case <-context.Background().Done():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-}
-
-// isYDBTransientTxError matches gRPC status/issue text from ydb-go-sdk, including
-// split/offline shard states that never surface as a SQLSTATE.
-func isYDBTransientTxError(msg string) bool {
-	for _, pat := range ydbTransientPatterns {
-		if strings.Contains(strings.ToLower(msg), pat) {
-			return true
-		}
-	}
-
-	return false
-}
-
-var ydbTransientPatterns = []string{
-	"operation/overloaded",
-	"operation/aborted",
-	"operation/unavailable",
-	"operation/bad_session",
-	"operation/session_busy",
-	"code = 400050",
-	"code = 400060",
-	"code = 400100",
-	"wrong_shard_state",
-	"transaction locks invalidated",
 }
 
 func max0(n int) int {

--- a/pkg/bench/retry.go
+++ b/pkg/bench/retry.go
@@ -24,29 +24,14 @@ const (
 type ErrorActionMap map[driver.ErrorKind]ErrorAction
 
 // DefaultErrorActions returns safe transaction defaults. Contention and
-// unconditional transient failures retry; everything else remains an error.
-func DefaultErrorActions(idempotent bool) ErrorActionMap {
-	actions := ErrorActionMap{
+// transient failures retry; everything else remains an error.
+func DefaultErrorActions() ErrorActionMap {
+	return ErrorActionMap{ //nolint:exhaustive // absent kinds use ErrorActionError
 		driver.ErrorKindSerialization: ErrorActionRetry,
 		driver.ErrorKindDeadlock:      ErrorActionRetry,
 		driver.ErrorKindLockTimeout:   ErrorActionRetry,
 		driver.ErrorKindTransient:     ErrorActionRetry,
 	}
-	if idempotent {
-		actions[driver.ErrorKindTransientIfIdempotent] = ErrorActionRetry
-	}
-
-	return actions
-}
-
-// With returns a copy with overrides applied. Missing kinds keep the safe
-// ErrorActionError fallback.
-func (m ErrorActionMap) With(overrides ErrorActionMap) ErrorActionMap {
-	result := make(ErrorActionMap, len(m)+len(overrides))
-	maps.Copy(result, m)
-	maps.Copy(result, overrides)
-
-	return result
 }
 
 func (m ErrorActionMap) action(kind driver.ErrorKind) ErrorAction {
@@ -72,15 +57,6 @@ func IsFatalError(err error) bool {
 	return ok
 }
 
-// Retry0 is RetryWithPolicy for a void fn (the common transaction-replay shape).
-func Retry0(ctx context.Context, policy RetryPolicy, fn func() error) error {
-	_, err := RetryWithPolicy(ctx, policy, func() (struct{}, error) {
-		return struct{}{}, fn()
-	})
-
-	return err
-}
-
 // RetryDecision records the classified facts and resolved action for one error.
 type RetryDecision struct {
 	Action       ErrorAction
@@ -95,75 +71,94 @@ type RetryPolicy struct {
 	Actions     ErrorActionMap
 	OnRetry     func(attempt int, err error, decision RetryDecision)
 
+	idempotent       bool
 	baseDelaySeconds float64
 	maxDelaySeconds  float64
 }
 
-// RetryWithPolicy runs fn under policy. Error and fatal actions preserve the
-// original error, ignore returns the zero value, and retry replays fn.
-func RetryWithPolicy[T any](
-	ctx context.Context,
-	policy RetryPolicy,
-	fn func() (T, error),
-) (T, error) {
-	var (
-		lastErr error
-		zero    T
-	)
+// Retry0 runs a void operation under policy. Error and fatal actions preserve
+// the original error, ignore returns nil, and retry replays fn.
+func Retry0(ctx context.Context, policy RetryPolicy, fn func() error) error {
+	var lastErr error
 
 	maxAttempts := max(policy.MaxAttempts, 1)
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
-			return zero, err
+			return err
 		}
 
-		value, err := fn()
+		err := fn()
 		if err == nil {
-			return value, nil
+			return nil
 		}
+
 		lastErr = err
+		decision := policy.decision(err)
 
-		facts := driver.DefaultErrorFacts(err)
-		if policy.Classify != nil {
-			facts = policy.Classify(err)
-		}
+		done, result := applyRetryDecision(ctx, policy, attempt, maxAttempts, err, decision)
 
-		decision := RetryDecision{
-			Action: policy.Actions.action(facts.Kind),
-			Facts:  facts,
-		}
-
-		switch decision.Action {
-		case ErrorActionIgnore:
-			return zero, nil
-		case ErrorActionFatal:
-			return zero, &FatalError{err: err}
-		case ErrorActionRetry:
-			if attempt == maxAttempts {
-				return zero, err
-			}
-
-			if facts.Backoff {
-				decision.DelaySeconds = backoffSeconds(
-					attempt,
-					policy.baseDelaySeconds,
-					policy.maxDelaySeconds,
-				)
-			}
-
-			if policy.OnRetry != nil {
-				policy.OnRetry(attempt+1, err, decision)
-			}
-
-			if err := sleepForRetry(ctx, decision.DelaySeconds); err != nil {
-				return zero, err
-			}
-		default:
-			return zero, err
+		if done {
+			return result
 		}
 	}
 
-	return zero, lastErr // unreachable: final attempt returns above
+	return lastErr // unreachable: final attempt returns above
+}
+
+func applyRetryDecision(
+	ctx context.Context,
+	policy RetryPolicy,
+	attempt int,
+	maxAttempts int,
+	err error,
+	decision RetryDecision,
+) (bool, error) {
+	switch decision.Action {
+	case ErrorActionIgnore:
+		return true, nil
+	case ErrorActionFatal:
+		return true, &FatalError{err: err}
+	case ErrorActionRetry:
+		if attempt == maxAttempts {
+			return true, err
+		}
+
+		if decision.Facts.Backoff {
+			decision.DelaySeconds = backoffSeconds(
+				attempt,
+				policy.baseDelaySeconds,
+				policy.maxDelaySeconds,
+			)
+		}
+
+		if policy.OnRetry != nil {
+			policy.OnRetry(attempt+1, err, decision)
+		}
+
+		if decision.DelaySeconds > 0 {
+			if err := sleepForRetry(ctx, decision.DelaySeconds); err != nil {
+				return true, err
+			}
+		}
+
+		return false, nil
+	default:
+		return true, err
+	}
+}
+
+func (p RetryPolicy) decision(err error) RetryDecision {
+	facts := driver.DefaultErrorFacts(err)
+	if p.Classify != nil {
+		facts = p.Classify(err)
+	}
+
+	action := p.Actions.action(facts.Kind)
+	if action == ErrorActionRetry && facts.RequiresIdempotency && !p.idempotent {
+		action = ErrorActionError
+	}
+
+	return RetryDecision{Action: action, Facts: facts}
 }
 
 // TxRetryPolicyOptions configures Bench.TxRetryPolicy.
@@ -189,15 +184,20 @@ func newTxRetryPolicy(
 	if opts.BaseDelaySeconds == 0 {
 		opts.BaseDelaySeconds = 0.05
 	}
+
 	if opts.MaxDelaySeconds == 0 {
 		opts.MaxDelaySeconds = 1
 	}
 
+	actions := DefaultErrorActions()
+	maps.Copy(actions, opts.Actions)
+
 	return RetryPolicy{
 		MaxAttempts:      opts.MaxAttempts,
 		Classify:         classify,
-		Actions:          DefaultErrorActions(opts.Idempotent).With(opts.Actions),
+		Actions:          actions,
 		OnRetry:          opts.OnRetry,
+		idempotent:       opts.Idempotent,
 		baseDelaySeconds: opts.BaseDelaySeconds,
 		maxDelaySeconds:  opts.MaxDelaySeconds,
 	}
@@ -212,10 +212,6 @@ func backoffSeconds(attempt int, base, maxSeconds float64) float64 {
 }
 
 func sleepForRetry(ctx context.Context, seconds float64) error {
-	if seconds <= 0 {
-		return ctx.Err()
-	}
-
 	timer := time.NewTimer(time.Duration(seconds * float64(time.Second)))
 	defer timer.Stop()
 

--- a/pkg/bench/retry_test.go
+++ b/pkg/bench/retry_test.go
@@ -1,0 +1,235 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func TestDefaultErrorActions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		kind       driver.ErrorKind
+		idempotent bool
+		want       ErrorAction
+	}{
+		{name: "serialization", kind: driver.ErrorKindSerialization, want: ErrorActionRetry},
+		{name: "deadlock", kind: driver.ErrorKindDeadlock, want: ErrorActionRetry},
+		{name: "lock timeout", kind: driver.ErrorKindLockTimeout, want: ErrorActionRetry},
+		{name: "transient", kind: driver.ErrorKindTransient, want: ErrorActionRetry},
+		{name: "conditional transient", kind: driver.ErrorKindTransientIfIdempotent, want: ErrorActionError},
+		{name: "idempotent conditional transient", kind: driver.ErrorKindTransientIfIdempotent, idempotent: true, want: ErrorActionRetry},
+		{name: "unknown", kind: driver.ErrorKindUnknown, want: ErrorActionError},
+		{name: "unsupported", kind: driver.ErrorKindUnsupported, want: ErrorActionError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := DefaultErrorActions(tt.idempotent).action(tt.kind); got != tt.want {
+				t.Fatalf("action(%q) = %v, want %v", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorActionMapWith(t *testing.T) {
+	t.Parallel()
+
+	defaults := DefaultErrorActions(false)
+	got := defaults.With(ErrorActionMap{
+		driver.ErrorKindSerialization: ErrorActionIgnore,
+		driver.ErrorKindUnknown:       ErrorActionFatal,
+	})
+
+	if defaults.action(driver.ErrorKindSerialization) != ErrorActionRetry {
+		t.Fatal("With mutated defaults")
+	}
+	if got.action(driver.ErrorKindSerialization) != ErrorActionIgnore {
+		t.Fatal("serialization override not applied")
+	}
+	if got.action(driver.ErrorKindUnknown) != ErrorActionFatal {
+		t.Fatal("unknown override not applied")
+	}
+	if got.action(driver.ErrorKindDeadlock) != ErrorActionRetry {
+		t.Fatal("default deadlock action not preserved")
+	}
+}
+
+func TestRetryWithPolicyRetriesClassifiedError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("conflict")
+	attempts := 0
+	var retried []int
+	policy := newTxRetryPolicy(
+		func(error) driver.ErrorFacts { return driver.ErrorFacts{Kind: driver.ErrorKindSerialization} },
+		TxRetryPolicyOptions{
+			MaxAttempts: 3,
+			OnRetry: func(attempt int, err error, decision RetryDecision) {
+				if !errors.Is(err, sentinel) {
+					t.Errorf("OnRetry error = %v, want sentinel", err)
+				}
+				if decision.Facts.Kind != driver.ErrorKindSerialization {
+					t.Errorf("OnRetry kind = %q", decision.Facts.Kind)
+				}
+				retried = append(retried, attempt)
+			},
+		},
+	)
+
+	err := Retry0(context.Background(), policy, func() error {
+		attempts++
+		if attempts < 3 {
+			return sentinel
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Retry0() error = %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	if len(retried) != 2 || retried[0] != 2 || retried[1] != 3 {
+		t.Fatalf("retry attempts = %v, want [2 3]", retried)
+	}
+}
+
+func TestRetryWithPolicyActions(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	tests := []struct {
+		name      string
+		action    ErrorAction
+		wantErr   error
+		wantFatal bool
+	}{
+		{name: "error", action: ErrorActionError, wantErr: sentinel},
+		{name: "ignore", action: ErrorActionIgnore},
+		{name: "fatal", action: ErrorActionFatal, wantErr: sentinel, wantFatal: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			attempts := 0
+			policy := newTxRetryPolicy(
+				func(error) driver.ErrorFacts { return driver.ErrorFacts{Kind: driver.ErrorKindUnknown} },
+				TxRetryPolicyOptions{
+					MaxAttempts: 3,
+					Actions: ErrorActionMap{
+						driver.ErrorKindUnknown: tt.action,
+					},
+				},
+			)
+
+			err := Retry0(context.Background(), policy, func() error {
+				attempts++
+
+				return sentinel
+			})
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Retry0() error = %v, want %v", err, tt.wantErr)
+			}
+			if IsFatalError(err) != tt.wantFatal {
+				t.Fatalf("IsFatalError() = %v, want %v", IsFatalError(err), tt.wantFatal)
+			}
+			if attempts != 1 {
+				t.Fatalf("attempts = %d, want 1", attempts)
+			}
+		})
+	}
+}
+
+func TestRetryWithPolicyConditionalIdempotency(t *testing.T) {
+	t.Parallel()
+
+	classify := func(error) driver.ErrorFacts {
+		return driver.ErrorFacts{Kind: driver.ErrorKindTransientIfIdempotent}
+	}
+
+	for _, idempotent := range []bool{false, true} {
+		t.Run(map[bool]string{false: "non-idempotent", true: "idempotent"}[idempotent], func(t *testing.T) {
+			t.Parallel()
+
+			attempts := 0
+			policy := newTxRetryPolicy(classify, TxRetryPolicyOptions{MaxAttempts: 2, Idempotent: idempotent})
+			err := Retry0(context.Background(), policy, func() error {
+				attempts++
+				if attempts == 1 {
+					return errors.New("transient")
+				}
+
+				return nil
+			})
+
+			if idempotent && err != nil {
+				t.Fatalf("Retry0() error = %v", err)
+			}
+			wantAttempts := 1
+			if idempotent {
+				wantAttempts = 2
+			}
+			if attempts != wantAttempts {
+				t.Fatalf("attempts = %d, want %d", attempts, wantAttempts)
+			}
+		})
+	}
+}
+
+func TestRetryWithPolicyCancellationDuringBackoff(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	policy := newTxRetryPolicy(
+		func(error) driver.ErrorFacts {
+			return driver.ErrorFacts{Kind: driver.ErrorKindTransient, Backoff: true}
+		},
+		TxRetryPolicyOptions{
+			MaxAttempts:      3,
+			BaseDelaySeconds: 10,
+			MaxDelaySeconds:  10,
+			OnRetry:          func(int, error, RetryDecision) { cancel() },
+		},
+	)
+
+	attempts := 0
+	err := Retry0(ctx, policy, func() error {
+		attempts++
+
+		return errors.New("transient")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Retry0() error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRetryWithPolicyMinimumAttempt(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	attempts := 0
+	err := Retry0(context.Background(), RetryPolicy{}, func() error {
+		attempts++
+
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Retry0() error = %v, want sentinel", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}

--- a/pkg/bench/retry_test.go
+++ b/pkg/bench/retry_test.go
@@ -12,17 +12,14 @@ func TestDefaultErrorActions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		kind       driver.ErrorKind
-		idempotent bool
-		want       ErrorAction
+		name string
+		kind driver.ErrorKind
+		want ErrorAction
 	}{
 		{name: "serialization", kind: driver.ErrorKindSerialization, want: ErrorActionRetry},
 		{name: "deadlock", kind: driver.ErrorKindDeadlock, want: ErrorActionRetry},
 		{name: "lock timeout", kind: driver.ErrorKindLockTimeout, want: ErrorActionRetry},
 		{name: "transient", kind: driver.ErrorKindTransient, want: ErrorActionRetry},
-		{name: "conditional transient", kind: driver.ErrorKindTransientIfIdempotent, want: ErrorActionError},
-		{name: "idempotent conditional transient", kind: driver.ErrorKindTransientIfIdempotent, idempotent: true, want: ErrorActionRetry},
 		{name: "unknown", kind: driver.ErrorKindUnknown, want: ErrorActionError},
 		{name: "unsupported", kind: driver.ErrorKindUnsupported, want: ErrorActionError},
 	}
@@ -31,32 +28,31 @@ func TestDefaultErrorActions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := DefaultErrorActions(tt.idempotent).action(tt.kind); got != tt.want {
+			if got := DefaultErrorActions().action(tt.kind); got != tt.want {
 				t.Fatalf("action(%q) = %v, want %v", tt.kind, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestErrorActionMapWith(t *testing.T) {
+func TestErrorActionOverrides(t *testing.T) {
 	t.Parallel()
 
-	defaults := DefaultErrorActions(false)
-	got := defaults.With(ErrorActionMap{
+	overrides := ErrorActionMap{ //nolint:exhaustive // test overrides selected kinds
 		driver.ErrorKindSerialization: ErrorActionIgnore,
 		driver.ErrorKindUnknown:       ErrorActionFatal,
-	})
-
-	if defaults.action(driver.ErrorKindSerialization) != ErrorActionRetry {
-		t.Fatal("With mutated defaults")
 	}
-	if got.action(driver.ErrorKindSerialization) != ErrorActionIgnore {
+	policy := newTxRetryPolicy(nil, TxRetryPolicyOptions{Actions: overrides})
+
+	if policy.Actions.action(driver.ErrorKindSerialization) != ErrorActionIgnore {
 		t.Fatal("serialization override not applied")
 	}
-	if got.action(driver.ErrorKindUnknown) != ErrorActionFatal {
+
+	if policy.Actions.action(driver.ErrorKindUnknown) != ErrorActionFatal {
 		t.Fatal("unknown override not applied")
 	}
-	if got.action(driver.ErrorKindDeadlock) != ErrorActionRetry {
+
+	if policy.Actions.action(driver.ErrorKindDeadlock) != ErrorActionRetry {
 		t.Fatal("default deadlock action not preserved")
 	}
 }
@@ -66,7 +62,9 @@ func TestRetryWithPolicyRetriesClassifiedError(t *testing.T) {
 
 	sentinel := errors.New("conflict")
 	attempts := 0
+
 	var retried []int
+
 	policy := newTxRetryPolicy(
 		func(error) driver.ErrorFacts { return driver.ErrorFacts{Kind: driver.ErrorKindSerialization} },
 		TxRetryPolicyOptions{
@@ -75,9 +73,11 @@ func TestRetryWithPolicyRetriesClassifiedError(t *testing.T) {
 				if !errors.Is(err, sentinel) {
 					t.Errorf("OnRetry error = %v, want sentinel", err)
 				}
+
 				if decision.Facts.Kind != driver.ErrorKindSerialization {
 					t.Errorf("OnRetry kind = %q", decision.Facts.Kind)
 				}
+
 				retried = append(retried, attempt)
 			},
 		},
@@ -94,9 +94,11 @@ func TestRetryWithPolicyRetriesClassifiedError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Retry0() error = %v", err)
 	}
+
 	if attempts != 3 {
 		t.Fatalf("attempts = %d, want 3", attempts)
 	}
+
 	if len(retried) != 2 || retried[0] != 2 || retried[1] != 3 {
 		t.Fatalf("retry attempts = %v, want [2 3]", retried)
 	}
@@ -126,7 +128,7 @@ func TestRetryWithPolicyActions(t *testing.T) {
 				func(error) driver.ErrorFacts { return driver.ErrorFacts{Kind: driver.ErrorKindUnknown} },
 				TxRetryPolicyOptions{
 					MaxAttempts: 3,
-					Actions: ErrorActionMap{
+					Actions: ErrorActionMap{ //nolint:exhaustive // test overrides one kind
 						driver.ErrorKindUnknown: tt.action,
 					},
 				},
@@ -140,9 +142,11 @@ func TestRetryWithPolicyActions(t *testing.T) {
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("Retry0() error = %v, want %v", err, tt.wantErr)
 			}
+
 			if IsFatalError(err) != tt.wantFatal {
 				t.Fatalf("IsFatalError() = %v, want %v", IsFatalError(err), tt.wantFatal)
 			}
+
 			if attempts != 1 {
 				t.Fatalf("attempts = %d, want 1", attempts)
 			}
@@ -154,7 +158,10 @@ func TestRetryWithPolicyConditionalIdempotency(t *testing.T) {
 	t.Parallel()
 
 	classify := func(error) driver.ErrorFacts {
-		return driver.ErrorFacts{Kind: driver.ErrorKindTransientIfIdempotent}
+		return driver.ErrorFacts{
+			Kind:                driver.ErrorKindTransient,
+			RequiresIdempotency: true,
+		}
 	}
 
 	for _, idempotent := range []bool{false, true} {
@@ -175,10 +182,12 @@ func TestRetryWithPolicyConditionalIdempotency(t *testing.T) {
 			if idempotent && err != nil {
 				t.Fatalf("Retry0() error = %v", err)
 			}
+
 			wantAttempts := 1
 			if idempotent {
 				wantAttempts = 2
 			}
+
 			if attempts != wantAttempts {
 				t.Fatalf("attempts = %d, want %d", attempts, wantAttempts)
 			}
@@ -203,6 +212,7 @@ func TestRetryWithPolicyCancellationDuringBackoff(t *testing.T) {
 	)
 
 	attempts := 0
+
 	err := Retry0(ctx, policy, func() error {
 		attempts++
 
@@ -211,6 +221,7 @@ func TestRetryWithPolicyCancellationDuringBackoff(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Retry0() error = %v, want context.Canceled", err)
 	}
+
 	if attempts != 1 {
 		t.Fatalf("attempts = %d, want 1", attempts)
 	}
@@ -221,6 +232,7 @@ func TestRetryWithPolicyMinimumAttempt(t *testing.T) {
 
 	sentinel := errors.New("boom")
 	attempts := 0
+
 	err := Retry0(context.Background(), RetryPolicy{}, func() error {
 		attempts++
 
@@ -229,6 +241,7 @@ func TestRetryWithPolicyMinimumAttempt(t *testing.T) {
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("Retry0() error = %v, want sentinel", err)
 	}
+
 	if attempts != 1 {
 		t.Fatalf("attempts = %d, want 1", attempts)
 	}

--- a/pkg/bench/retry_test.go
+++ b/pkg/bench/retry_test.go
@@ -157,6 +157,7 @@ func TestRetryWithPolicyActions(t *testing.T) {
 func TestRetryWithPolicyConditionalIdempotency(t *testing.T) {
 	t.Parallel()
 
+	transientErr := errors.New("transient")
 	classify := func(error) driver.ErrorFacts {
 		return driver.ErrorFacts{
 			Kind:                driver.ErrorKindTransient,
@@ -173,7 +174,7 @@ func TestRetryWithPolicyConditionalIdempotency(t *testing.T) {
 			err := Retry0(context.Background(), policy, func() error {
 				attempts++
 				if attempts == 1 {
-					return errors.New("transient")
+					return transientErr
 				}
 
 				return nil
@@ -181,6 +182,10 @@ func TestRetryWithPolicyConditionalIdempotency(t *testing.T) {
 
 			if idempotent && err != nil {
 				t.Fatalf("Retry0() error = %v", err)
+			}
+
+			if !idempotent && !errors.Is(err, transientErr) {
+				t.Fatalf("Retry0() error = %v, want transient error", err)
 			}
 
 			wantAttempts := 1

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -169,10 +169,7 @@ type scenarioSpec struct {
 func readScenario() scenarioSpec {
 	spec := scenarioSpec{name: "workload"}
 
-	spec.vus = EnvInt("VUS", 1)
-	if spec.vus < 1 {
-		spec.vus = 1
-	}
+	spec.vus = max(EnvInt("VUS", 1), 1)
 
 	if d := Env("DURATION", ""); d != "" {
 		dur, err := time.ParseDuration(d)
@@ -186,10 +183,7 @@ func readScenario() scenarioSpec {
 
 	spec.executor = "shared-iterations"
 
-	spec.iterations = int64(EnvInt("ITER", 1))
-	if spec.iterations < 1 {
-		spec.iterations = 1
-	}
+	spec.iterations = int64(max(EnvInt("ITER", 1), 1))
 
 	return spec
 }
@@ -197,50 +191,61 @@ func readScenario() scenarioSpec {
 // --- executor (shared-iterations + constant-vus) ---
 
 func runScenario(ctx context.Context, sc scenarioSpec, iterate func(*VU) error) error {
+	scenarioCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	fatalErrors := make(chan error, 1)
+	var wg sync.WaitGroup
+
+	startWorker := func(vuid int, keep func() bool) {
+		wg.Go(func() {
+			if err := runWorker(scenarioCtx, vuid, iterate, keep); IsFatalError(err) {
+				select {
+				case fatalErrors <- err:
+					cancel()
+				default:
+				}
+			}
+		})
+	}
+
 	switch sc.executor {
 	case "shared-iterations":
-		var (
-			remaining = sc.iterations
-			wg        sync.WaitGroup
-		)
+		remaining := sc.iterations
 		for i := range sc.vus {
-			wg.Add(1)
-			go func(vuid int) {
-				defer wg.Done()
-
-				runWorker(ctx, vuid, iterate, func() bool {
-					return atomic.AddInt64(&remaining, -1) >= 0
-				})
-			}(i + 1)
+			startWorker(i+1, func() bool {
+				return atomic.AddInt64(&remaining, -1) >= 0
+			})
 		}
-
-		wg.Wait()
 	case "constant-vus":
 		deadline := time.Now().Add(sc.duration)
-
-		var wg sync.WaitGroup
 		for i := range sc.vus {
-			wg.Add(1)
-			go func(vuid int) {
-				defer wg.Done()
-
-				runWorker(ctx, vuid, iterate, func() bool {
-					return time.Now().Before(deadline)
-				})
-			}(i + 1)
+			startWorker(i+1, func() bool {
+				return time.Now().Before(deadline)
+			})
 		}
-
-		wg.Wait()
 	default:
 		return fmt.Errorf("%w %q", errUnsupportedExecutor, sc.executor)
 	}
 
-	return nil
+	wg.Wait()
+
+	select {
+	case err := <-fatalErrors:
+		return err
+	default:
+	}
+
+	return ctx.Err()
 }
 
-func runWorker(ctx context.Context, vuid int, iterate func(*VU) error, keep func() bool) {
+func runWorker(ctx context.Context, vuid int, iterate func(*VU) error, keep func() bool) error {
 	vu := &VU{root: root, vuid: uint64(vuid), ctx: ctx} //nolint:gosec // G115: scale-bound, no overflow
 	for keep() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		vu.iterTest++
 		vu.iterScenario++
 
@@ -249,18 +254,21 @@ func runWorker(ctx context.Context, vuid int, iterate func(*VU) error, keep func
 		root.txMetrics.recordIteration(vu, time.Since(start))
 
 		if err != nil {
-			if errors.Is(err, errAbort) {
-				return
+			if IsFatalError(err) {
+				return err
+			}
+			if ctx.Err() != nil && errors.Is(err, ctx.Err()) {
+				return ctx.Err()
 			}
 
 			root.lg.Error("iteration failed", zap.Int("vu", vuid), zap.Error(err))
 
-			return
+			return nil
 		}
 	}
-}
 
-var errAbort = errors.New("aborted")
+	return nil
+}
 
 // --- metric handles (Counter/Trend/Rate) ---
 

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -144,7 +144,7 @@ func Run(
 			drv: drv, cfg: cfg,
 		}
 
-		return wl.Iterate(ctx, b)
+		return wl.Iterate(vu.Context(), b)
 	}); err != nil {
 		return fmt.Errorf("scenario %q: %w", sc.name, err)
 	}
@@ -195,6 +195,7 @@ func runScenario(ctx context.Context, sc scenarioSpec, iterate func(*VU) error) 
 	defer cancel()
 
 	fatalErrors := make(chan error, 1)
+
 	var wg sync.WaitGroup
 
 	startWorker := func(vuid int, keep func() bool) {
@@ -257,6 +258,7 @@ func runWorker(ctx context.Context, vuid int, iterate func(*VU) error, keep func
 			if IsFatalError(err) {
 				return err
 			}
+
 			if ctx.Err() != nil && errors.Is(err, ctx.Err()) {
 				return ctx.Err()
 			}

--- a/pkg/bench/runtime_test.go
+++ b/pkg/bench/runtime_test.go
@@ -1,0 +1,84 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestRunScenarioReturnsFatalErrorAndCancelsWorkers(t *testing.T) {
+	installRuntimeTestRoot(t)
+
+	sentinel := errors.New("fatal")
+	var calls atomic.Int64
+	err := runScenario(context.Background(), scenarioSpec{
+		executor:   "shared-iterations",
+		vus:        4,
+		iterations: 100,
+	}, func(vu *VU) error {
+		if calls.Add(1) == 1 {
+			return &FatalError{err: sentinel}
+		}
+
+		<-vu.Context().Done()
+
+		return vu.Context().Err()
+	})
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("runScenario() error = %v, want sentinel", err)
+	}
+	if !IsFatalError(err) {
+		t.Fatalf("runScenario() error = %T, want FatalError", err)
+	}
+}
+
+func TestRunScenarioKeepsOrdinaryErrorsPerWorker(t *testing.T) {
+	installRuntimeTestRoot(t)
+
+	err := runScenario(context.Background(), scenarioSpec{
+		executor:   "shared-iterations",
+		vus:        1,
+		iterations: 1,
+	}, func(*VU) error {
+		return errors.New("iteration")
+	})
+	if err != nil {
+		t.Fatalf("runScenario() error = %v, want nil", err)
+	}
+}
+
+func TestRunScenarioReturnsParentCancellation(t *testing.T) {
+	installRuntimeTestRoot(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runScenario(ctx, scenarioSpec{
+		executor:   "shared-iterations",
+		vus:        1,
+		iterations: 1,
+	}, func(*VU) error { return nil })
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runScenario() error = %v, want context.Canceled", err)
+	}
+}
+
+func installRuntimeTestRoot(t *testing.T) {
+	t.Helper()
+
+	oldRoot := root
+	testRoot, err := newRootState(zap.NewNop(), context.Background(), nil, &MetricsConfig{})
+	if err != nil {
+		t.Fatalf("newRootState() error = %v", err)
+	}
+	root = testRoot
+
+	t.Cleanup(func() {
+		testRoot.shutdownMetrics()
+		root = oldRoot
+	})
+}

--- a/pkg/bench/runtime_test.go
+++ b/pkg/bench/runtime_test.go
@@ -5,15 +5,21 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
+
+	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	_ "github.com/stroppy-io/stroppy/pkg/driver/noop"
 )
 
 func TestRunScenarioReturnsFatalErrorAndCancelsWorkers(t *testing.T) {
 	installRuntimeTestRoot(t)
 
 	sentinel := errors.New("fatal")
+
 	var calls atomic.Int64
+
 	err := runScenario(context.Background(), scenarioSpec{
 		executor:   "shared-iterations",
 		vus:        4,
@@ -31,6 +37,7 @@ func TestRunScenarioReturnsFatalErrorAndCancelsWorkers(t *testing.T) {
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("runScenario() error = %v, want sentinel", err)
 	}
+
 	if !IsFatalError(err) {
 		t.Fatalf("runScenario() error = %T, want FatalError", err)
 	}
@@ -67,18 +74,78 @@ func TestRunScenarioReturnsParentCancellation(t *testing.T) {
 	}
 }
 
+func TestRunPassesScenarioCancellationToWorkload(t *testing.T) {
+	workload := &fatalContextWorkload{secondStarted: make(chan struct{})}
+	Register(workload)
+
+	err := Run(
+		context.Background(),
+		workload.Name(),
+		map[int]*stroppy.DriverConfig{0: {DriverType: stroppy.DriverConfig_DRIVER_TYPE_NOOP}},
+		map[string]string{"VUS": "2", "ITER": "2"},
+		zap.NewNop(),
+		&MetricsConfig{},
+	)
+	if !errors.Is(err, workload.fatalErr) {
+		t.Fatalf("Run() error = %v, want fatal sentinel", err)
+	}
+
+	if !workload.canceled.Load() {
+		t.Fatal("workload did not receive scenario cancellation")
+	}
+}
+
+type fatalContextWorkload struct {
+	calls         atomic.Int64
+	canceled      atomic.Bool
+	secondStarted chan struct{}
+	fatalErr      error
+}
+
+func (*fatalContextWorkload) Name() string { return "test/fatal-context" }
+
+func (w *fatalContextWorkload) Setup(context.Context, *Bench) error {
+	w.fatalErr = errors.New("fatal iteration")
+
+	return nil
+}
+
+func (w *fatalContextWorkload) Iterate(ctx context.Context, _ *Bench) error {
+	if w.calls.Add(1) == 1 {
+		<-w.secondStarted
+
+		return &FatalError{err: w.fatalErr}
+	}
+
+	close(w.secondStarted)
+
+	select {
+	case <-ctx.Done():
+		w.canceled.Store(true)
+
+		return ctx.Err()
+	case <-time.After(100 * time.Millisecond):
+		return errors.New("scenario context was not canceled")
+	}
+}
+
+func (*fatalContextWorkload) Teardown(context.Context, *Bench) error { return nil }
+
 func installRuntimeTestRoot(t *testing.T) {
 	t.Helper()
 
 	oldRoot := root
+
 	testRoot, err := newRootState(zap.NewNop(), context.Background(), nil, &MetricsConfig{})
 	if err != nil {
 		t.Fatalf("newRootState() error = %v", err)
 	}
+
 	root = testRoot
 
 	t.Cleanup(func() {
 		testRoot.shutdownMetrics()
+
 		root = oldRoot
 	})
 }

--- a/pkg/driver/csv/errors.go
+++ b/pkg/driver/csv/errors.go
@@ -1,0 +1,15 @@
+package csv
+
+import (
+	"errors"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func (*Driver) ClassifyError(err error) driver.ErrorFacts {
+	if errors.Is(err, ErrCsvDriverNoQuery) || errors.Is(err, ErrUnsupportedInsertMethod) {
+		return driver.ErrorFacts{Kind: driver.ErrorKindUnsupported}
+	}
+
+	return driver.DefaultErrorFacts(err)
+}

--- a/pkg/driver/csv/errors_test.go
+++ b/pkg/driver/csv/errors_test.go
@@ -17,7 +17,11 @@ func TestClassifyError(t *testing.T) {
 		want driver.ErrorKind
 	}{
 		{name: "query unsupported", err: ErrCsvDriverNoQuery, want: driver.ErrorKindUnsupported},
-		{name: "wrapped insert unsupported", err: fmt.Errorf("insert: %w", ErrUnsupportedInsertMethod), want: driver.ErrorKindUnsupported},
+		{
+			name: "wrapped insert unsupported",
+			err:  fmt.Errorf("insert: %w", ErrUnsupportedInsertMethod),
+			want: driver.ErrorKindUnsupported,
+		},
 		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
 	}
 

--- a/pkg/driver/csv/errors_test.go
+++ b/pkg/driver/csv/errors_test.go
@@ -1,0 +1,33 @@
+package csv
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want driver.ErrorKind
+	}{
+		{name: "query unsupported", err: ErrCsvDriverNoQuery, want: driver.ErrorKindUnsupported},
+		{name: "wrapped insert unsupported", err: fmt.Errorf("insert: %w", ErrUnsupportedInsertMethod), want: driver.ErrorKindUnsupported},
+		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := (*Driver)(nil).ClassifyError(tt.err).Kind; got != tt.want {
+				t.Fatalf("ClassifyError().Kind = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/driver/dispatcher.go
+++ b/pkg/driver/dispatcher.go
@@ -51,6 +51,7 @@ type (
 		Insert(ctx context.Context, req *InsertRequest) (*stats.Query, error)
 		RunQuery(ctx context.Context, sql string, args map[string]any) (*QueryResult, error)
 		Begin(ctx context.Context, isolation stroppy.TxIsolationLevel) (Tx, error)
+		ClassifyError(err error) ErrorFacts
 		Teardown(ctx context.Context) error
 	}
 

--- a/pkg/driver/errors.go
+++ b/pkg/driver/errors.go
@@ -1,0 +1,40 @@
+package driver
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrorKind describes a database-independent property of a driver error.
+type ErrorKind string
+
+const (
+	ErrorKindUnknown               ErrorKind = "unknown"
+	ErrorKindSerialization         ErrorKind = "serialization"
+	ErrorKindDeadlock              ErrorKind = "deadlock"
+	ErrorKindLockTimeout           ErrorKind = "lock_timeout"
+	ErrorKindTransient             ErrorKind = "transient"
+	ErrorKindTransientIfIdempotent ErrorKind = "transient_if_idempotent"
+	ErrorKindUnsupported           ErrorKind = "unsupported"
+	ErrorKindCanceled              ErrorKind = "canceled"
+	ErrorKindTimeout               ErrorKind = "timeout"
+)
+
+// ErrorFacts are backend-neutral properties used by workload error policy.
+type ErrorFacts struct {
+	Kind    ErrorKind
+	Backoff bool
+}
+
+// DefaultErrorFacts classifies errors shared by every driver. Unknown errors
+// remain explicit so policy defaults fail closed instead of retrying them.
+func DefaultErrorFacts(err error) ErrorFacts {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return ErrorFacts{Kind: ErrorKindCanceled}
+	case errors.Is(err, context.DeadlineExceeded):
+		return ErrorFacts{Kind: ErrorKindTimeout}
+	default:
+		return ErrorFacts{Kind: ErrorKindUnknown}
+	}
+}

--- a/pkg/driver/errors.go
+++ b/pkg/driver/errors.go
@@ -9,21 +9,21 @@ import (
 type ErrorKind string
 
 const (
-	ErrorKindUnknown               ErrorKind = "unknown"
-	ErrorKindSerialization         ErrorKind = "serialization"
-	ErrorKindDeadlock              ErrorKind = "deadlock"
-	ErrorKindLockTimeout           ErrorKind = "lock_timeout"
-	ErrorKindTransient             ErrorKind = "transient"
-	ErrorKindTransientIfIdempotent ErrorKind = "transient_if_idempotent"
-	ErrorKindUnsupported           ErrorKind = "unsupported"
-	ErrorKindCanceled              ErrorKind = "canceled"
-	ErrorKindTimeout               ErrorKind = "timeout"
+	ErrorKindUnknown       ErrorKind = "unknown"
+	ErrorKindSerialization ErrorKind = "serialization"
+	ErrorKindDeadlock      ErrorKind = "deadlock"
+	ErrorKindLockTimeout   ErrorKind = "lock_timeout"
+	ErrorKindTransient     ErrorKind = "transient"
+	ErrorKindUnsupported   ErrorKind = "unsupported"
+	ErrorKindCanceled      ErrorKind = "canceled"
+	ErrorKindTimeout       ErrorKind = "timeout"
 )
 
 // ErrorFacts are backend-neutral properties used by workload error policy.
 type ErrorFacts struct {
-	Kind    ErrorKind
-	Backoff bool
+	Kind                ErrorKind
+	Backoff             bool
+	RequiresIdempotency bool
 }
 
 // DefaultErrorFacts classifies errors shared by every driver. Unknown errors

--- a/pkg/driver/errors_test.go
+++ b/pkg/driver/errors_test.go
@@ -1,0 +1,32 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestDefaultErrorFacts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want ErrorKind
+	}{
+		{name: "unknown", err: errors.New("boom"), want: ErrorKindUnknown},
+		{name: "canceled", err: fmt.Errorf("wrapped: %w", context.Canceled), want: ErrorKindCanceled},
+		{name: "timeout", err: fmt.Errorf("wrapped: %w", context.DeadlineExceeded), want: ErrorKindTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := DefaultErrorFacts(tt.err).Kind; got != tt.want {
+				t.Fatalf("DefaultErrorFacts().Kind = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/driver/mysql/errors.go
+++ b/pkg/driver/mysql/errors.go
@@ -1,0 +1,27 @@
+package mysql
+
+import (
+	"errors"
+
+	gomysql "github.com/go-sql-driver/mysql"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+const (
+	errLockDeadlock    = 1213 // ER_LOCK_DEADLOCK
+	errLockWaitTimeout = 1205 // ER_LOCK_WAIT_TIMEOUT
+)
+
+func (*Driver) ClassifyError(err error) driver.ErrorFacts {
+	if myErr, ok := errors.AsType[*gomysql.MySQLError](err); ok {
+		switch myErr.Number {
+		case errLockDeadlock:
+			return driver.ErrorFacts{Kind: driver.ErrorKindDeadlock}
+		case errLockWaitTimeout:
+			return driver.ErrorFacts{Kind: driver.ErrorKindLockTimeout}
+		}
+	}
+
+	return driver.DefaultErrorFacts(err)
+}

--- a/pkg/driver/mysql/errors_test.go
+++ b/pkg/driver/mysql/errors_test.go
@@ -19,7 +19,11 @@ func TestClassifyError(t *testing.T) {
 		want driver.ErrorKind
 	}{
 		{name: "deadlock", err: &gomysql.MySQLError{Number: errLockDeadlock}, want: driver.ErrorKindDeadlock},
-		{name: "wrapped lock timeout", err: fmt.Errorf("query: %w", &gomysql.MySQLError{Number: errLockWaitTimeout}), want: driver.ErrorKindLockTimeout},
+		{
+			name: "wrapped lock timeout",
+			err:  fmt.Errorf("query: %w", &gomysql.MySQLError{Number: errLockWaitTimeout}),
+			want: driver.ErrorKindLockTimeout,
+		},
 		{name: "other mysql", err: &gomysql.MySQLError{Number: 1062}, want: driver.ErrorKindUnknown},
 		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
 	}

--- a/pkg/driver/mysql/errors_test.go
+++ b/pkg/driver/mysql/errors_test.go
@@ -1,0 +1,36 @@
+package mysql
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	gomysql "github.com/go-sql-driver/mysql"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want driver.ErrorKind
+	}{
+		{name: "deadlock", err: &gomysql.MySQLError{Number: errLockDeadlock}, want: driver.ErrorKindDeadlock},
+		{name: "wrapped lock timeout", err: fmt.Errorf("query: %w", &gomysql.MySQLError{Number: errLockWaitTimeout}), want: driver.ErrorKindLockTimeout},
+		{name: "other mysql", err: &gomysql.MySQLError{Number: 1062}, want: driver.ErrorKindUnknown},
+		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := (*Driver)(nil).ClassifyError(tt.err).Kind; got != tt.want {
+				t.Fatalf("ClassifyError().Kind = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/driver/noop/errors.go
+++ b/pkg/driver/noop/errors.go
@@ -1,0 +1,7 @@
+package noop
+
+import "github.com/stroppy-io/stroppy/pkg/driver"
+
+func (*Driver) ClassifyError(err error) driver.ErrorFacts {
+	return driver.DefaultErrorFacts(err)
+}

--- a/pkg/driver/picodata/errors.go
+++ b/pkg/driver/picodata/errors.go
@@ -1,0 +1,17 @@
+package picodata
+
+import (
+	"errors"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func (*Driver) ClassifyError(err error) driver.ErrorFacts {
+	if errors.Is(err, ErrNativeUnsupported) ||
+		errors.Is(err, ErrTransactionsUnsupported) ||
+		errors.Is(err, ErrUnsupportedType) {
+		return driver.ErrorFacts{Kind: driver.ErrorKindUnsupported}
+	}
+
+	return driver.DefaultErrorFacts(err)
+}

--- a/pkg/driver/picodata/errors_test.go
+++ b/pkg/driver/picodata/errors_test.go
@@ -17,7 +17,11 @@ func TestClassifyError(t *testing.T) {
 		want driver.ErrorKind
 	}{
 		{name: "transactions unsupported", err: ErrTransactionsUnsupported, want: driver.ErrorKindUnsupported},
-		{name: "wrapped native unsupported", err: fmt.Errorf("insert: %w", ErrNativeUnsupported), want: driver.ErrorKindUnsupported},
+		{
+			name: "wrapped native unsupported",
+			err:  fmt.Errorf("insert: %w", ErrNativeUnsupported),
+			want: driver.ErrorKindUnsupported,
+		},
 		{name: "unsupported type", err: ErrUnsupportedType, want: driver.ErrorKindUnsupported},
 		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
 	}

--- a/pkg/driver/picodata/errors_test.go
+++ b/pkg/driver/picodata/errors_test.go
@@ -1,0 +1,34 @@
+package picodata
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want driver.ErrorKind
+	}{
+		{name: "transactions unsupported", err: ErrTransactionsUnsupported, want: driver.ErrorKindUnsupported},
+		{name: "wrapped native unsupported", err: fmt.Errorf("insert: %w", ErrNativeUnsupported), want: driver.ErrorKindUnsupported},
+		{name: "unsupported type", err: ErrUnsupportedType, want: driver.ErrorKindUnsupported},
+		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := (*Driver)(nil).ClassifyError(tt.err).Kind; got != tt.want {
+				t.Fatalf("ClassifyError().Kind = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/driver/postgres/errors.go
+++ b/pkg/driver/postgres/errors.go
@@ -15,6 +15,8 @@ func (*Driver) ClassifyError(err error) driver.ErrorFacts {
 			return driver.ErrorFacts{Kind: driver.ErrorKindSerialization}
 		case "40P01":
 			return driver.ErrorFacts{Kind: driver.ErrorKindDeadlock}
+		case "55P03":
+			return driver.ErrorFacts{Kind: driver.ErrorKindLockTimeout}
 		}
 	}
 

--- a/pkg/driver/postgres/errors.go
+++ b/pkg/driver/postgres/errors.go
@@ -1,0 +1,22 @@
+package postgres
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func (*Driver) ClassifyError(err error) driver.ErrorFacts {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+		switch pgErr.Code {
+		case "40001":
+			return driver.ErrorFacts{Kind: driver.ErrorKindSerialization}
+		case "40P01":
+			return driver.ErrorFacts{Kind: driver.ErrorKindDeadlock}
+		}
+	}
+
+	return driver.DefaultErrorFacts(err)
+}

--- a/pkg/driver/postgres/errors_test.go
+++ b/pkg/driver/postgres/errors_test.go
@@ -1,0 +1,36 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want driver.ErrorKind
+	}{
+		{name: "serialization", err: &pgconn.PgError{Code: "40001"}, want: driver.ErrorKindSerialization},
+		{name: "wrapped deadlock", err: fmt.Errorf("query: %w", &pgconn.PgError{Code: "40P01"}), want: driver.ErrorKindDeadlock},
+		{name: "other postgres", err: &pgconn.PgError{Code: "23505"}, want: driver.ErrorKindUnknown},
+		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := (*Driver)(nil).ClassifyError(tt.err).Kind; got != tt.want {
+				t.Fatalf("ClassifyError().Kind = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/driver/postgres/errors_test.go
+++ b/pkg/driver/postgres/errors_test.go
@@ -19,7 +19,12 @@ func TestClassifyError(t *testing.T) {
 		want driver.ErrorKind
 	}{
 		{name: "serialization", err: &pgconn.PgError{Code: "40001"}, want: driver.ErrorKindSerialization},
-		{name: "wrapped deadlock", err: fmt.Errorf("query: %w", &pgconn.PgError{Code: "40P01"}), want: driver.ErrorKindDeadlock},
+		{
+			name: "wrapped deadlock",
+			err:  fmt.Errorf("query: %w", &pgconn.PgError{Code: "40P01"}),
+			want: driver.ErrorKindDeadlock,
+		},
+		{name: "lock timeout", err: &pgconn.PgError{Code: "55P03"}, want: driver.ErrorKindLockTimeout},
 		{name: "other postgres", err: &pgconn.PgError{Code: "23505"}, want: driver.ErrorKindUnknown},
 		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
 	}

--- a/pkg/driver/ydb/errors.go
+++ b/pkg/driver/ydb/errors.go
@@ -23,7 +23,11 @@ func (*Driver) ClassifyError(err error) driver.ErrorFacts {
 	case mode.MustRetry(false):
 		return driver.ErrorFacts{Kind: driver.ErrorKindTransient, Backoff: mode.MustBackoff()}
 	case mode.MustRetry(true):
-		return driver.ErrorFacts{Kind: driver.ErrorKindTransientIfIdempotent, Backoff: mode.MustBackoff()}
+		return driver.ErrorFacts{
+			Kind:                driver.ErrorKindTransient,
+			Backoff:             mode.MustBackoff(),
+			RequiresIdempotency: true,
+		}
 	default:
 		return facts
 	}

--- a/pkg/driver/ydb/errors.go
+++ b/pkg/driver/ydb/errors.go
@@ -1,0 +1,30 @@
+package ydb
+
+import (
+	"errors"
+
+	ydbretry "github.com/ydb-platform/ydb-go-sdk/v3/retry"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func (*Driver) ClassifyError(err error) driver.ErrorFacts {
+	if errors.Is(err, ErrUnsupportedInsertMethod) || errors.Is(err, ErrUnsupportedType) {
+		return driver.ErrorFacts{Kind: driver.ErrorKindUnsupported}
+	}
+
+	facts := driver.DefaultErrorFacts(err)
+	if facts.Kind != driver.ErrorKindUnknown {
+		return facts
+	}
+
+	mode := ydbretry.Check(err)
+	switch {
+	case mode.MustRetry(false):
+		return driver.ErrorFacts{Kind: driver.ErrorKindTransient, Backoff: mode.MustBackoff()}
+	case mode.MustRetry(true):
+		return driver.ErrorFacts{Kind: driver.ErrorKindTransientIfIdempotent, Backoff: mode.MustBackoff()}
+	default:
+		return facts
+	}
+}

--- a/pkg/driver/ydb/errors_test.go
+++ b/pkg/driver/ydb/errors_test.go
@@ -1,0 +1,35 @@
+package ydb
+
+import (
+	"errors"
+	"testing"
+
+	ydbretry "github.com/ydb-platform/ydb-go-sdk/v3/retry"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want driver.ErrorKind
+	}{
+		{name: "retryable", err: ydbretry.RetryableError(errors.New("transient")), want: driver.ErrorKindTransient},
+		{name: "unsupported insert", err: ErrUnsupportedInsertMethod, want: driver.ErrorKindUnsupported},
+		{name: "unsupported type", err: ErrUnsupportedType, want: driver.ErrorKindUnsupported},
+		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := (*Driver)(nil).ClassifyError(tt.err).Kind; got != tt.want {
+				t.Fatalf("ClassifyError().Kind = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add mandatory per-driver `ClassifyError` implementations that translate backend errors into shared `driver.ErrorFacts`
- add default, workload-overridable fact-to-action mapping for retry, error, ignore, and fatal behavior
- gate conditional transient retries on explicit idempotency and use structured YDB retry metadata instead of message matching
- make retry backoff context-aware, propagate terminal TPC-C errors, and cancel all VUs on fatal actions
- cache retry policies once per workload instead of rebuilding them in transaction hot paths

## Default behavior

- serialization, deadlock, lock timeout, and unconditional transient facts retry
- transient facts requiring idempotency retry only when `TxRetryPolicyOptions.Idempotent` is set
- unknown, unsupported, canceled, and timeout facts remain ordinary errors
- workload `TxRetryPolicyOptions.Actions` entries override selected defaults

## Verification

- `make tests`
- `make build`
- `make linter`
- focused final correctness review

Closes #122


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent database error classification across supported drivers.
  - Added configurable retry actions, backoff handling, idempotency safeguards, and transaction-level overrides.
  - Added support for identifying unsupported, transient, timeout, deadlock, and serialization errors.

- **Bug Fixes**
  - Transaction errors are no longer silently discarded.
  - Fatal errors and cancellations now stop benchmark execution and propagate correctly.
  - Retry settings and metrics are reused consistently across workload iterations.
  - Improved context handling during retries and workload execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->