### PR TITLE
feat(bench): add typed workload parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,14 @@ conditional transient retries.
 - `-D key=value` — override driver field (url, driverType, defaultTxIsolation, errorMode, bulkSize, pool.*, postgres.*, sql.*, caCertFile, authToken, authUser, authPassword, tlsInsecureSkipVerify); multiple `-D` accumulate
 - `-d1 <preset>`, `-D1 key=value` — same for second driver index (multi-driver workloads)
 
-**Env flags:**
-- `-e KEY=VALUE` — set workload env value (uppercased); takes precedence over config file and workload defaults
+**Workload and run parameters:**
+- Registered workloads expose typed `--name VALUE` flags. Run
+  `stroppy run <workload> --help` to see the selected workload's schema.
+- Shared run flags: `--executor`, `--vus`, `--iterations`, `--duration`.
+- Workload flags include `--scale-factor`, `--load-workers`, and other
+  workload-specific declarations.
+- `-e KEY=VALUE` remains a compatibility input; keys are uppercased. Multiple
+  `-e` flags accumulate.
 
 **Step control:**
 - `--steps step1,step2` — run only listed steps
@@ -115,28 +121,44 @@ conditional transient retries.
 **Config file:**
 - Default: `stroppy-config.json` in cwd (auto-loaded if present)
 - `-f prod.json` — explicit path
-- Precedence (highest→lowest): real env > `-e` > config `env` > `-d/-D` > config `drivers` > workload defaults
+- Typed scenario parameters go under `run`; selected-workload parameters go
+  under `params`. The legacy string-valued `env` map remains compatible.
+- Typed parameter precedence (highest→lowest): typed CLI > process env > `-e` >
+  matching typed config (`run`/`params`) > config `env` > declared default.
+- Driver precedence is `-d/-D` > config `drivers`.
 
-There is **no** `--` k6-args passthrough. Concurrency is env-driven (see Scenario selection).
+```json
+{
+  "script": "tpcc/tx",
+  "run": {"executor": "constant-vus", "vus": 10, "duration": "60s"},
+  "params": {"scaleFactor": 10, "loadWorkers": 8}
+}
+```
+
+There is **no** `--` k6-args passthrough. Select the executor explicitly with
+`--executor shared-iterations` or `--executor constant-vus`.
 
 **Examples:**
 ```bash
 # TPC-C with postgres, 10 VUs for 60s
-./build/stroppy run tpcc/tx -d pg -D url=postgres://... -e VUS=10 -e DURATION=60s
+./build/stroppy run tpcc/tx -d pg -D url=postgres://... \
+  --executor constant-vus --vus 10 --duration 60s
 
 # TPC-C with picodata, local SQL file (no rebuild needed)
 ./build/stroppy run tpcc/tx ./workloads/tpcc/pico.sql -d pico -D url=http://...
 
 # TPC-B fixed-iteration power run
-./build/stroppy run tpcb/tx -d pg -D url=postgres://... -e ITER=100
+./build/stroppy run tpcb/tx -d pg -D url=postgres://... \
+  --executor shared-iterations --iterations 100
 
 # TPC-H
-./build/stroppy run tpch/tx -d pg -D url=postgres://... -e SCALE_FACTOR=0.01
+./build/stroppy run tpch/tx -d pg -D url=postgres://... --scale-factor 0.01
 
 # Noop overhead benchmark
-./build/stroppy run simple -d noop -e VUS=4 -e DURATION=10s
+./build/stroppy run simple -d noop \
+  --executor constant-vus --vus 4 --duration 10s
 
-# Probe: list embedded presets + driver insert methods
+# Probe: list workload schemas, embedded presets, and driver insert methods
 ./build/stroppy probe
 ```
 
@@ -172,15 +194,17 @@ Relational loads use `b.Step("load_data", ...)` and `b.Insert(ctx, req)` with
 a `driver.InsertRequest`. `LOAD_WORKERS` controls the per-request worker
 fan-out where wired:
 ```bash
-./build/stroppy run tpcc/tx -d pg -e LOAD_WORKERS=8 --steps drop_schema,create_schema,load_data
+./build/stroppy run tpcc/tx -d pg --load-workers 8 --steps drop_schema,create_schema,load_data
 ```
 
-**Scenario selection** (`readScenario` in `pkg/bench/runtime.go`, env-driven):
-- `DURATION` set → `constant-vus` executor (throughput run)
-- `DURATION` unset → `shared-iterations` executor (power run)
-- Tune via env `VUS` / `DURATION` / `ITER`. There are no k6 shortflags.
+**Scenario selection** (typed run parameters in `pkg/bench/runtime.go`):
+- `--executor shared-iterations --iterations N` → power run; VUs share N iterations.
+- `--executor constant-vus --vus N --duration 60s` → throughput run.
+- `--vus` applies to either executor. There are no k6 shortflags.
+- Legacy `DURATION` without an explicit executor still infers `constant-vus` and
+  emits a warning; use an explicit executor in new invocations and config.
 
-**SCALE_FACTOR semantics** differ by workload: tpcb and tpcc take an INTEGER (≥1, = branch/warehouse count); tpch and tpcds take a FRACTIONAL row-scale (0.01 ok). tpcds also carries fixed-size static dims (~1.9M rows for `customer_demographics`) that do not shrink with SF.
+**`--scale-factor` semantics** differ by workload: tpcb and tpcc take an INTEGER (≥1, = branch/warehouse count); tpch and tpcds take a FRACTIONAL row-scale (0.01 ok). tpcds also carries fixed-size static dims (~1.9M rows for `customer_demographics`) that do not shrink with SF.
 
 **Setup vs executor:** the data load lives in the workload body guarded by
 `GlobalOnce` (a once-per-process barrier), not in a separate setup phase with
@@ -191,7 +215,7 @@ Isolation by driver in the `tx` variants:
 - mysql → `read_committed`
 - picodata → `"none"` (**not** `"conn"` — `Begin()` always errors)
 - ydb → `serializable`
-- Override: `-e TX_ISOLATION=...`
+- Override: `--tx-isolation <name>` (`-e TX_ISOLATION=...` remains compatible)
 
 Full isolation type names: `read_uncommitted`, `read_committed`, `repeatable_read`, `serializable`, `db_default`, `conn`, `none`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
+- Built-in workloads expose their tuning options as typed parameters while preserving the existing environment-variable names.
 - TPC-DS typed loads format common cell types directly into reusable buffers. ([#126](https://github.com/stroppy-io/stroppy/pull/126))
 - Benchmark metrics now use standard OpenTelemetry counters, gauges, and fixed-bucket histograms. Query throughput and error rates are derived from monotonic `*_total` counters instead of k6-style sampled rates. ([#125](https://github.com/stroppy-io/stroppy/pull/125))
 - The `stroppy help <topic>` topics (drivers, config-file, steps, resolution, sql, envs, datagen, probe) now describe the Go-native binary — the previous text still documented the removed TypeScript/k6 workflow (`k6Args`, `declareDriverSetup`, `.ts` script mode, the `--` passthrough).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Fixed
 
+- Workload help and shell completion expose typed flags accurately, including explicit booleans and contextual defaults, and SQL override positionals reach registered workload bindings.
 - Typed run parameters and SQL sources keep CLI-over-environment precedence, config env names reject case-only collisions, and shared driver pool settings remain active alongside driver-specific settings.
 - Typed inserts reject malformed requests consistently, and generator ranges remain correct at integer boundaries. ([#126](https://github.com/stroppy-io/stroppy/pull/126))
 - Long high-throughput workloads keep bounded metric memory instead of retaining every latency observation until the final summary. ([#125](https://github.com/stroppy-io/stroppy/pull/125))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
+- Typed scenario and workload parameters can be set with `--name` flags or native JSON values in the config file's `run` and `params` objects, and `stroppy run <workload> --help` lists the available parameters.
 - Go workloads can declare typed string, boolean, numeric, and duration parameters with defaults, descriptions, source tracking, and discoverable schemas.
 - Database errors are classified by each driver into shared facts, and Go workloads can override the default retry, error, ignore, or fatal action for each fact without matching backend-specific codes or messages. ([#127](https://github.com/stroppy-io/stroppy/pull/127))
 - New `pkg/gen` random-generation primitives library: deterministic, seekable, allocation-free scalar and text draws composed in plain Go, intended to replace the relational datagen expression framework for workload data loading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Fixed
 
+- Typed run parameters and SQL sources keep CLI-over-environment precedence, config env names reject case-only collisions, and shared driver pool settings remain active alongside driver-specific settings.
 - Typed inserts reject malformed requests consistently, and generator ranges remain correct at integer boundaries. ([#126](https://github.com/stroppy-io/stroppy/pull/126))
 - Long high-throughput workloads keep bounded metric memory instead of retaining every latency observation until the final summary. ([#125](https://github.com/stroppy-io/stroppy/pull/125))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
+- Go workloads can declare typed string, boolean, numeric, and duration parameters with defaults, descriptions, source tracking, and discoverable schemas.
 - Database errors are classified by each driver into shared facts, and Go workloads can override the default retry, error, ignore, or fatal action for each fact without matching backend-specific codes or messages. ([#127](https://github.com/stroppy-io/stroppy/pull/127))
 - New `pkg/gen` random-generation primitives library: deterministic, seekable, allocation-free scalar and text draws composed in plain Go, intended to replace the relational datagen expression framework for workload data loading.
 - `pkg/gen` now provides typed direct-output batches: a reusable columnar [Batch] with bound [Column] handles and an [IndexedSource] that fills rows through a plain Go row callback, so workload formulas write straight into prepared storage with zero generation-time allocations after preparation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
+- `stroppy probe` now lists registered workload parameter flags, and its JSON output includes each workload's typed schema for tooling and discovery.
 - Typed scenario and workload parameters can be set with `--name` flags or native JSON values in the config file's `run` and `params` objects, and `stroppy run <workload> --help` lists the available parameters.
 - Go workloads can declare typed string, boolean, numeric, and duration parameters with defaults, descriptions, source tracking, and discoverable schemas.
 - Database errors are classified by each driver into shared facts, and Go workloads can override the default retry, error, ignore, or fatal action for each fact without matching backend-specific codes or messages. ([#127](https://github.com/stroppy-io/stroppy/pull/127))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 ### Fixed
 
 - Workload help and shell completion expose typed flags accurately, including explicit booleans and contextual defaults, and SQL override positionals reach registered workload bindings. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
-- Typed run parameters and SQL sources keep CLI-over-environment precedence, config env names reject case-only collisions, and shared driver pool settings remain active alongside driver-specific settings. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
+- Typed run parameters and SQL sources keep CLI-over-environment precedence, config env names reject case-only collisions, shared driver pool settings remain active alongside driver-specific settings, and invalid pool fields fail clearly instead of being ignored. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - Typed inserts reject malformed requests consistently, and generator ranges remain correct at integer boundaries. ([#126](https://github.com/stroppy-io/stroppy/pull/126))
 - Long high-throughput workloads keep bounded metric memory instead of retaining every latency observation until the final summary. ([#125](https://github.com/stroppy-io/stroppy/pull/125))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
-- `stroppy probe` now lists registered workload parameter flags, and its JSON output includes each workload's typed schema for tooling and discovery.
-- Typed scenario and workload parameters can be set with `--name` flags or native JSON values in the config file's `run` and `params` objects, and `stroppy run <workload> --help` lists the available parameters.
-- Go workloads can declare typed string, boolean, numeric, and duration parameters with defaults, descriptions, source tracking, and discoverable schemas.
+- `stroppy probe` now lists registered workload parameter flags, and its JSON output includes each workload's typed schema for tooling and discovery. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
+- Typed scenario and workload parameters can be set with `--name` flags or native JSON values in the config file's `run` and `params` objects, and `stroppy run <workload> --help` lists the available parameters. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
+- Go workloads can declare typed string, boolean, numeric, and duration parameters with defaults, descriptions, source tracking, and discoverable schemas. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - Database errors are classified by each driver into shared facts, and Go workloads can override the default retry, error, ignore, or fatal action for each fact without matching backend-specific codes or messages. ([#127](https://github.com/stroppy-io/stroppy/pull/127))
 - New `pkg/gen` random-generation primitives library: deterministic, seekable, allocation-free scalar and text draws composed in plain Go, intended to replace the relational datagen expression framework for workload data loading.
 - `pkg/gen` now provides typed direct-output batches: a reusable columnar [Batch] with bound [Column] handles and an [IndexedSource] that fills rows through a plain Go row callback, so workload formulas write straight into prepared storage with zero generation-time allocations after preparation.
@@ -30,15 +30,15 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
-- Built-in workloads expose their tuning options as typed parameters while preserving the existing environment-variable names.
+- Built-in workloads expose their tuning options as typed parameters while preserving the existing environment-variable names. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - TPC-DS typed loads format common cell types directly into reusable buffers. ([#126](https://github.com/stroppy-io/stroppy/pull/126))
 - Benchmark metrics now use standard OpenTelemetry counters, gauges, and fixed-bucket histograms. Query throughput and error rates are derived from monotonic `*_total` counters instead of k6-style sampled rates. ([#125](https://github.com/stroppy-io/stroppy/pull/125))
 - The `stroppy help <topic>` topics (drivers, config-file, steps, resolution, sql, envs, datagen, probe) now describe the Go-native binary — the previous text still documented the removed TypeScript/k6 workflow (`k6Args`, `declareDriverSetup`, `.ts` script mode, the `--` passthrough).
 
 ### Fixed
 
-- Workload help and shell completion expose typed flags accurately, including explicit booleans and contextual defaults, and SQL override positionals reach registered workload bindings.
-- Typed run parameters and SQL sources keep CLI-over-environment precedence, config env names reject case-only collisions, and shared driver pool settings remain active alongside driver-specific settings.
+- Workload help and shell completion expose typed flags accurately, including explicit booleans and contextual defaults, and SQL override positionals reach registered workload bindings. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
+- Typed run parameters and SQL sources keep CLI-over-environment precedence, config env names reject case-only collisions, and shared driver pool settings remain active alongside driver-specific settings. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - Typed inserts reject malformed requests consistently, and generator ranges remain correct at integer boundaries. ([#126](https://github.com/stroppy-io/stroppy/pull/126))
 - Long high-throughput workloads keep bounded metric memory instead of retaining every latency observation until the final summary. ([#125](https://github.com/stroppy-io/stroppy/pull/125))
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ stroppy run tpcc/tx           # TPC-C, raw transactions (any DB)
 stroppy run tpcc/procs        # TPC-C, stored procedures (pg/mysql)
 stroppy run tpcb/tx           # TPC-B, raw transactions (any DB)
 stroppy run tpch/tx           # TPC-H, relational load + query suite
-stroppy run tpcds -e SCALE_FACTOR=1   # TPC-DS, load 24 tables + 99 queries
+stroppy run tpcds --scale-factor 1   # TPC-DS, load 24 tables + 99 queries
 stroppy run queries.sql       # execute a SQL file
 stroppy run "select 1"        # execute inline SQL
 ```
@@ -66,7 +66,7 @@ TPC-B and TPC-C each ship two variants:
 
 TPC-H loads all eight tables and runs the 22 query suite. TPC-DS generates and
 loads all 24 tables (faithful `dsdgen` port) and runs the 99 query suite; scale
-either via `SCALE_FACTOR`.
+either via `--scale-factor`.
 
 Use `-d` to select a driver preset and `-D` to override driver options:
 
@@ -78,24 +78,36 @@ stroppy run tpcc/tx -d pg -d1 mysql        # two drivers
 stroppy run simple -d noop                  # framework/runner overhead only
 ```
 
-Pass environment variables to the workload with `-e` (keys are auto-uppercased).
-Concurrency is configured via env, not CLI flags:
+Registered workloads expose typed direct flags. Select the executor explicitly;
+use `stroppy run <workload> --help` to inspect that workload's parameters:
 
 ```bash
-stroppy run tpcc/tx -e VUS=10 -e DURATION=60s     # throughput run
-stroppy run tpcc/tx -e ITER=100                   # fixed-iteration power run
-stroppy run tpcc/tx -e pool_size=200
-stroppy run tpcc/tx -d pg -e load_workers=8       # parallelize load_data
+stroppy run tpcc/tx --executor constant-vus --vus 10 --duration 60s
+stroppy run tpcc/tx --executor shared-iterations --iterations 100
+stroppy run tpcc/tx --scale-factor 10 --load-workers 8
+stroppy run tpcc/tx -e pool_size=200   # legacy env compatibility
 ```
 
-Collect repeated settings in `stroppy-config.json` or an explicit `-f` file:
+Collect repeated settings in `stroppy-config.json` or an explicit `-f` file.
+Typed scenario parameters belong under `run`, workload parameters under `params`,
+and the string-valued `env` map remains available for compatibility:
+
+```json
+{
+  "script": "tpcc/tx",
+  "run": {"executor": "constant-vus", "vus": 10, "duration": "60s"},
+  "params": {"scaleFactor": 10, "loadWorkers": 8}
+}
+```
 
 ```bash
 stroppy run -f prod.json
 ```
 
-Precedence is: real environment > `-e` > config `env` > `-d/-D` >
-config `drivers` > workload defaults.
+Typed parameter precedence is: CLI flag > process environment > `-e` > matching
+`run`/`params` config > config `env` > declared default. Driver precedence is
+`-d/-D` > config `drivers`. Legacy `DURATION` inference remains compatible but
+warns; use an explicit executor.
 
 Use `stroppy help` to explore available topics:
 
@@ -106,8 +118,8 @@ stroppy help config-file
 
 ### Probe
 
-Probe lists the embedded workload presets and the insert methods each driver
-supports:
+Probe lists registered workload parameter schemas, embedded presets, and the insert
+methods each driver supports:
 
 ```bash
 stroppy probe

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ TPC-B and TPC-C each ship two variants:
 
 TPC-H loads all eight tables and runs the 22 query suite. TPC-DS generates and
 loads all 24 tables (faithful `dsdgen` port) and runs the 99 query suite; scale
-either via `--scale-factor`.
+either workload via `--scale-factor`.
 
 Use `-d` to select a driver preset and `-D` to override driver options:
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ and the string-valued `env` map remains available for compatibility:
 
 ```json
 {
+  "version": "1",
   "script": "tpcc/tx",
   "run": {"executor": "constant-vus", "vus": 10, "duration": "60s"},
   "params": {"scaleFactor": 10, "loadWorkers": 8}

--- a/cmd/stroppy/commands/help/topic_config_file.go
+++ b/cmd/stroppy/commands/help/topic_config_file.go
@@ -97,7 +97,9 @@ PRECEDENCE (highest to lowest)
 
   There is no "--" k6-args passthrough and no k6Args field in effect.
   Use typed executor/vus/iterations/duration parameters; legacy
-  VUS/DURATION/ITER environment values remain compatible.
+  VUS/DURATION/ITER environment values remain compatible. Legacy DURATION
+  without an explicit executor infers constant-vus and emits a warning; prefer
+  an explicit "run.executor" value.
 
 DEBUG LOGGING
 

--- a/cmd/stroppy/commands/help/topic_config_file.go
+++ b/cmd/stroppy/commands/help/topic_config_file.go
@@ -23,10 +23,15 @@ func init() {
 
 Example stroppy-config.json:
   {
+    "version": "1",
     "script": "tpcc/tx",
     "global": {
-      "logger": { "logLevel": "LOG_LEVEL_INFO" },
+      "version": "1",
+      "runId": "",
+      "seed": 0,
+      "logger": { "logLevel": "LOG_LEVEL_INFO", "logMode": "LOG_MODE_PRODUCTION" },
       "exporter": {
+        "name": "otlp",
         "otlpExport": { "otlpGrpcEndpoint": "otel-collector:4317", "otlpEndpointInsecure": true }
       }
     },

--- a/cmd/stroppy/commands/help/topic_config_file.go
+++ b/cmd/stroppy/commands/help/topic_config_file.go
@@ -16,9 +16,10 @@ func init() {
     stroppy run -f prod.json tpcc/tx       # config file + override workload
     stroppy run -f prod.json ./local.sql   # config file + override SQL file
 
-  The config file is decoded with protojson semantics against the frozen
-  RunConfig Go type (see pkg/common/proto/stroppy/run.pb.go). Unknown fields
-  are rejected.
+  Frozen RunConfig fields use strict protojson decoding. The "run" and "params"
+  objects retain native JSON values for typed scenario and workload parameters;
+  their names are validated after the selected workload declares its schema.
+  Unknown top-level fields and unknown names within either scope are rejected.
 
 Example stroppy-config.json:
   {
@@ -37,6 +38,12 @@ Example stroppy-config.json:
         "pool": { "maxConns": 200, "minConns": 200 }
       }
     },
+    "run": {
+      "executor": "constant-vus",
+      "vus": 10,
+      "duration": "30s"
+    },
+    "params": {},
     "env": {
       "WAREHOUSES": "10",
       "POOL_SIZE": "200"
@@ -50,7 +57,9 @@ Example stroppy-config.json:
     sql      string            Explicit SQL file override (2nd positional)
     global   object            Logger and OTEL exporter config (no CLI equivalent)
     drivers  map[string]obj    Per-index driver configs (keys "0", "1", ...)
-    env      map[string]string Workload env overrides (keys uppercased on load)
+    run      object            Typed scenario params: executor, vus, iterations, duration
+    params   object            Typed parameters declared by the selected workload
+    env      map[string]string Legacy workload env overrides (keys uppercased on load)
     steps    []string          Step allowlist (same as CLI --steps)
     noSteps  []string          Step blocklist (same as CLI --no-steps)
 
@@ -69,15 +78,16 @@ Example stroppy-config.json:
 
 PRECEDENCE (highest to lowest)
 
-  The same parameter can come from multiple sources. The first source that
-  provides a non-empty value wins:
+  Typed parameters use strict presence and type validation:
 
-    1. Real environment variables (OS / container env)
-    2. -e KEY=VALUE flags (CLI env overrides)
-    3. Config file "env" map
-    4. -d/-D driver flags (CLI driver presets and overrides)
-    5. Config file "drivers" map
-    6. Workload defaults
+    1. Typed --name CLI flag
+    2. Real environment variable
+    3. -e KEY=VALUE legacy env override
+    4. Matching config object ("run" or "params")
+    5. Config file "env" map
+    6. Declared default
+
+  Driver precedence is CLI -d/-D over the config file "drivers" map.
 
   Special cases:
 
@@ -85,9 +95,9 @@ PRECEDENCE (highest to lowest)
     steps / noSteps:             CLI --steps > config file "steps" field
     logger / OTEL exporter:      config file "global" only (no CLI equivalent)
 
-  There is no "--" k6-args passthrough and no k6Args field in effect:
-  concurrency is env-driven via VUS / DURATION / ITER (see scenario selection
-  in AGENTS.md or 'stroppy run --help').
+  There is no "--" k6-args passthrough and no k6Args field in effect.
+  Use typed executor/vus/iterations/duration parameters; legacy
+  VUS/DURATION/ITER environment values remain compatible.
 
 DEBUG LOGGING
 

--- a/cmd/stroppy/commands/help/topic_datagen.go
+++ b/cmd/stroppy/commands/help/topic_datagen.go
@@ -41,10 +41,10 @@ DETERMINISM AND PARALLEL LOAD
   reproduce rows across workers, batch sizes, and partition boundaries, so a
   driver can split a table into worker ranges with no warm-up.
 
-  Workloads that support parallel load read LOAD_WORKERS and pass it as the
+  Workloads that support parallel load declare --load-workers and pass it as the
   request worker count:
 
-    stroppy run tpcc/tx -d pg -e LOAD_WORKERS=8 \
+    stroppy run tpcc/tx -d pg --load-workers 8 \
       --steps drop_schema,create_schema,load_data
 
 CSV OUTPUT

--- a/cmd/stroppy/commands/help/topic_envs.go
+++ b/cmd/stroppy/commands/help/topic_envs.go
@@ -3,123 +3,97 @@ package help
 func init() {
 	Register(Topic{
 		Name:  "envs",
-		Short: "Environment variables, scenario selection, and -e overrides",
-		Long: `ENVS
+		Short: "Typed parameters, environment compatibility, and precedence",
+		Long: `ENVS AND TYPED PARAMETERS
 
-  Stroppy workloads read their configuration through environment variables.
-  The Go engine exposes them via the Env/EnvInt helpers in pkg/bench; real
-  process env always takes precedence over -e and config-file values.
+  Registered workloads declare typed run and workload parameters. Set them with
+  direct flags and inspect the selected schema dynamically:
 
-  There is no k6, no __ENV global, and no ENV() TypeScript helper — those
-  belonged to the removed script runtime.
+    stroppy run tpcc/tx --help
+    stroppy run tpcc/tx --scale-factor 10 --load-workers 8
 
-SETTING VALUES
+  Scenario parameters are shared by every workload:
 
-  Export variables in your shell before running:
+    --executor     shared-iterations or constant-vus
+    --vus          Number of virtual users
+    --iterations   Total shared iterations
+    --duration     Run length as a Go duration, e.g. 60s or 10m
 
-    export WAREHOUSES=50
-    stroppy run tpcc/tx
-
-  Or set them inline for a single run:
-
-    WAREHOUSES=50 stroppy run tpcc/tx
-
-  Or use stroppy's -e/--env flag. Keys are uppercased, so the following
-  are equivalent:
-
-    stroppy run tpcc/tx -e warehouses=20 -e pool_size=50
-    stroppy run tpcc/tx -e WAREHOUSES=20 -e POOL_SIZE=50
-
-  Multiple -e flags accumulate.
-
-SCENARIO SELECTION
-
-  The bench engine chooses an executor from env (see readScenario in
-  pkg/bench/runtime.go):
-
-    DURATION set   -> constant-vus executor (throughput run)
-                      VUs spin for the given duration.
-    DURATION unset -> shared-iterations executor (power run)
-                      VUs share a fixed iteration count.
-
-  Tune with:
-    VUS       int           Number of virtual users (default 1)
-    DURATION  Go duration   Throughput run length, e.g. "60s", "10m"
-    ITER      int           Total iterations for power runs (default 1)
-
-  Examples:
+  Select the executor explicitly. Examples:
 
     # TPC-C throughput: 10 VUs for 60 seconds
-    stroppy run tpcc/tx -d pg -e VUS=10 -e DURATION=60s
+    stroppy run tpcc/tx -d pg --executor constant-vus --vus 10 --duration 60s
 
     # TPC-B fixed-iteration power run
-    stroppy run tpcb/tx -d pg -e ITER=100
+    stroppy run tpcb/tx -d pg --executor shared-iterations --iterations 100
 
-  There are no k6 shortflags and no "--" passthrough. Configure concurrency
-  exclusively via VUS / DURATION / ITER.
+SOURCES AND PRECEDENCE
 
-PER-WORKLOAD VARIABLES
+  Every declared parameter has a direct flag, projected environment name, typed
+  config key, and default. Some also accept legacy environment aliases. Source
+  precedence, highest to lowest:
 
-  Each workload documents its own env vars; common ones:
+    1. Typed --name CLI flag
+    2. Process environment
+    3. -e KEY=VALUE compatibility override
+    4. Matching typed config object ("run" or "params")
+    5. Config file "env" map
+    6. Declared default
 
-    SCALE_FACTOR  tpcb/tpcc: integer branch/warehouse count (>=1)
-                  tpch/tpcds: fractional row scale (e.g. 0.01)
-    WAREHOUSES    Alias used by tpcc
-    LOAD_WORKERS  Per-table InsertSpec fan-out where wired
-    TX_ISOLATION  Override per-driver isolation default
-    POOL_SIZE     Postgres-only shorthand: sets pgx MinConns=MaxConns
-    SQL_FILE      SQL file path for execute_sql workload
+  Process environment examples:
 
-  Driver-specific isolation defaults (tx variants):
-    postgres -> read_committed
-    mysql    -> read_committed
-    picodata -> "none"  (Begin() always errors; do NOT use "conn")
-    ydb      -> serializable
+    SCALE_FACTOR=10 stroppy run tpcc/tx
+    export LOAD_WORKERS=8
 
-  Full isolation names: read_uncommitted, read_committed, repeatable_read,
-  serializable, db_default, conn, none.
+  The repeatable -e/--env flag remains available for compatibility. Keys are
+  uppercased:
 
-PROBE
+    stroppy run tpcc/tx -e warehouses=10 -e load_workers=8
 
-  'stroppy probe' lists embedded workload presets and the SQL dialects/docs
-  each ships with. It does not enumerate per-workload env vars — read the
-  workload source (internal/workloads/<name>/) or its .sql file for the
-  authoritative list.
+  Legacy DURATION without an explicit executor still infers constant-vus and
+  emits a warning. Prefer --executor constant-vus, or "run.executor" in config,
+  so the run shape is unambiguous. There are no k6 shortflags or "--" passthrough.
 
-  stroppy probe
-  stroppy probe -o json
+DISCOVERY
 
-CONFIG FILE ALTERNATIVE
+  'stroppy probe' lists registered workloads and their typed parameter flags.
+  JSON output includes each parameter's name, scope, type, description, default,
+  environment names, legacy aliases, and config key:
 
-  Instead of repeating -e flags, collect env overrides in a config file
-  under the "env" key:
+    stroppy probe
+    stroppy probe -o json
+
+  Use 'stroppy run <workload> --help' for the detailed selected-workload view.
+
+CONFIG FILE
+
+  Typed scenario values belong under "run" and workload-specific values under
+  "params". The legacy string-valued "env" map remains supported:
 
     {
+      "run": {
+        "executor": "constant-vus",
+        "vus": 10,
+        "duration": "60s"
+      },
+      "params": {
+        "scaleFactor": 10,
+        "loadWorkers": 8
+      },
       "env": {
-        "WAREHOUSES": "10",
         "POOL_SIZE": "200"
       }
     }
 
-  Precedence: real env > -e flags > config file env > workload defaults.
-  See 'stroppy help config-file' for the full format and precedence rules.
-
-DEBUG: TRACING ENV RESOLUTION
-
-  At LOG_LEVEL=debug the engine logs env precedence decisions:
-
-    LOG_LEVEL=debug stroppy run tpcc/tx -e load_workers=8
-
-  The env_override logger emits a debug line whenever the real environment
-  takes precedence over a -e flag or config-file entry, identifying the
-  key that was skipped.
+  The selected workload's runtime schema validates typed names and values. See
+  'stroppy help config-file' for the full file format.
 
 SEE ALSO
 
-  stroppy run --help
-  stroppy help drivers
+  stroppy run <workload> --help
+  stroppy help probe
   stroppy help config-file
-  stroppy help steps
+  stroppy help drivers
 `,
 	})
 }

--- a/cmd/stroppy/commands/help/topic_probe.go
+++ b/cmd/stroppy/commands/help/topic_probe.go
@@ -3,19 +3,18 @@ package help
 func init() {
 	Register(Topic{
 		Name:  "probe",
-		Short: "List embedded workload presets and driver capabilities",
+		Short: "List workload schemas, embedded presets, and driver capabilities",
 		Long: `PROBE
 
-  stroppy probe lists the embedded workload presets bundled into the binary
-  and the insert methods each driver supports. It takes no arguments and
-  connects to no database — it only reads the compile-time-embedded catalog.
+  stroppy probe reports discovery data compiled into the binary. It does not
+  set up a workload, dispatch a driver, or connect to a database.
 
   Use probe to:
-    - See which workloads are built into the binary
-    - Check which SQL dialect files each workload ships (pg.sql, mysql.sql,
-      pico.sql, ydb.sql) and which docs accompany them
-    - See the insert methods each driver supports (plain_query, plain_bulk,
-      native, columnar)
+    - List registered workloads and their typed parameter flags
+    - Inspect parameter schemas as JSON, including names, scopes, types,
+      descriptions, defaults, environment names, legacy aliases, and config keys
+    - Check embedded SQL dialect and documentation files
+    - See each driver's supported insert methods
 
 USAGE
 
@@ -24,32 +23,20 @@ USAGE
 
 OUTPUT
 
-  PRESETS section: one entry per embedded workload, showing the preset name
-  and its sql/docs variants. Example shape:
+  PRESETS lists embedded workload files. WORKLOADS groups each registered
+  workload's flags into shared run parameters and workload parameters. DRIVERS
+  lists supported insert methods by driver type.
 
-    PRESETS (embedded workloads)
+  Use the dynamic selected-workload help for full parameter details:
 
-      tpcc
-        sql:   pg.sql, mysql.sql, pico.sql, ydb.sql
+    stroppy run tpcc/tx --help
 
-      tpcb
-        sql:   pg.sql, mysql.sql, pico.sql, ydb.sql
+  JSON output preserves the existing "presets" and "drivers" arrays and adds a
+  sorted "workloads" array. Each workload contains "name" and "params"; each
+  parameter contains:
 
-    ...
-
-  DRIVERS section: one row per driver type with its supported insert methods:
-
-    DRIVERS (supported insert methods)
-
-      postgres  plain_query, plain_bulk, native
-      mysql     plain_query, plain_bulk
-      picodata  plain_query, plain_bulk
-      ydb       plain_query, plain_bulk, native
-      noop      plain_query, plain_bulk, native
-      csv       native
-
-  The JSON form emits an object with "presets" and "drivers" arrays — useful
-  for tooling and CI inspection.
+    name, flag, scope, type, description, default, env,
+    legacy_aliases, config
 
 FLAGS
 
@@ -57,19 +44,12 @@ FLAGS
 
   Probe takes no positional arguments.
 
-EXAMPLES
-
-  # Human-readable catalog
-  stroppy probe
-
-  # Machine-readable JSON
-  stroppy probe -o json
-
 SEE ALSO
 
+  stroppy run <workload> --help
+  stroppy help envs
+  stroppy help config-file
   stroppy help drivers
-  stroppy run --help
-  stroppy help resolution
 `,
 	})
 }

--- a/cmd/stroppy/commands/help/topic_resolution.go
+++ b/cmd/stroppy/commands/help/topic_resolution.go
@@ -35,6 +35,20 @@ INPUT MODES
 
   Unknown names (not registered, not .sql, not inline SQL) are rejected.
 
+PARAMETER DISCOVERY AND RESOLUTION
+
+  Once a registered workload is selected, stroppy builds its typed schema and
+  recognizes direct --name flags for its parameters. The help view is dynamic:
+
+    stroppy run tpcc/tx --help
+    stroppy run tpcc/tx --scale-factor 10 --load-workers 8
+
+  Shared run parameters are --executor, --vus, --iterations, and --duration.
+  Select shared-iterations or constant-vus explicitly. Typed values resolve in
+  this order: CLI flag > process env > -e > matching "run"/"params" config >
+  config "env" > declared default. Legacy DURATION can still infer constant-vus,
+  but emits a warning; prefer an explicit executor.
+
 SQL RESOLUTION ORDER
 
   For a SQL file (passed explicitly or selected by the workload), stroppy

--- a/cmd/stroppy/commands/probe/probe.go
+++ b/cmd/stroppy/commands/probe/probe.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/stroppy-io/stroppy/pkg/bench"
 	"github.com/stroppy-io/stroppy/pkg/driver"
 	"github.com/stroppy-io/stroppy/workloads"
 )
@@ -30,7 +31,8 @@ var (
 			Use:   "probe",
 			Short: "List embedded workload presets and supported drivers",
 			Long: `Probe lists the embedded workload presets (their SQL dialects and docs)
-and the insert methods each driver supports.
+and the insert methods each driver supports. Registered workload parameter schemas
+are read without setting up a workload or connecting to a database.
 
   -o json   machine-readable output
 `,
@@ -47,7 +49,7 @@ and the insert methods each driver supports.
 					)
 				}
 
-				return printCatalog(formatFlagValue)
+				return printCatalog(cmd.OutOrStdout(), formatFlagValue)
 			},
 		}
 
@@ -69,29 +71,94 @@ func contains(haystack []string, needle string) bool {
 	return false
 }
 
-// printCatalog renders the embedded preset catalog and the driver
+// printCatalog renders the embedded preset catalog, workload schemas, and driver
 // insert-method matrix in the requested format.
-func printCatalog(format string) error {
+func printCatalog(output io.Writer, format string) error {
 	catalog, err := workloads.Catalog()
 	if err != nil {
 		return fmt.Errorf("failed to build workloads catalog: %w", err)
 	}
 
+	descriptions, err := bench.DescribeAll()
+	if err != nil {
+		return fmt.Errorf("failed to describe workloads: %w", err)
+	}
+
 	drivers := driverCatalog()
+	workloadSchemas := describeWorkloads(descriptions)
 
 	switch format {
 	case jsonFormat:
-		bytes, err := json.Marshal(map[string]any{"presets": catalog, "drivers": drivers})
+		bytes, err := json.Marshal(catalogOutput{
+			Presets:   catalog,
+			Drivers:   drivers,
+			Workloads: workloadSchemas,
+		})
 		if err != nil {
 			return fmt.Errorf("can't marshal catalog: %w", err)
 		}
 
-		fmt.Fprintf(os.Stdout, "%s\n", string(bytes))
+		fmt.Fprintf(output, "%s\n", string(bytes))
 	case humanFormat:
-		fmt.Fprint(os.Stdout, formatCatalog(catalog, drivers))
+		fmt.Fprint(output, formatCatalog(catalog, drivers, workloadSchemas))
 	}
 
 	return nil
+}
+
+type catalogOutput struct {
+	Presets   []workloads.PresetInfo `json:"presets"`
+	Drivers   []driverEntry          `json:"drivers"`
+	Workloads []workloadEntry        `json:"workloads"`
+}
+
+type workloadEntry struct {
+	Name   string       `json:"name"`
+	Params []paramEntry `json:"params"`
+}
+
+type paramEntry struct {
+	Name          string           `json:"name"`
+	Flag          string           `json:"flag"`
+	Scope         bench.ParamScope `json:"scope"`
+	Type          bench.ParamType  `json:"type"`
+	Description   string           `json:"description"`
+	Default       any              `json:"default"`
+	Env           string           `json:"env"`
+	LegacyAliases []string         `json:"legacy_aliases"`
+	Config        string           `json:"config"`
+}
+
+func describeWorkloads(descriptions []bench.Description) []workloadEntry {
+	entries := make([]workloadEntry, 0, len(descriptions))
+
+	for _, description := range descriptions {
+		params := make([]paramEntry, 0, len(description.Params))
+		for idx := range description.Params {
+			param := &description.Params[idx]
+
+			defaultValue := param.Default
+			if param.Type == bench.ParamTypeDuration {
+				defaultValue = fmt.Sprint(param.Default)
+			}
+
+			params = append(params, paramEntry{
+				Name:          param.Name,
+				Flag:          param.Flag,
+				Scope:         param.Scope,
+				Type:          param.Type,
+				Description:   param.Description,
+				Default:       defaultValue,
+				Env:           param.Env,
+				LegacyAliases: append([]string{}, param.LegacyEnvAliases...),
+				Config:        param.Config,
+			})
+		}
+
+		entries = append(entries, workloadEntry{Name: description.Name, Params: params})
+	}
+
+	return entries
 }
 
 // driverEntry is one row of the driver capability matrix in catalog output.
@@ -124,9 +191,13 @@ func driverCatalog() []driverEntry {
 	return entries
 }
 
-// formatCatalog builds the human-readable preset listing and driver
-// insert-method matrix.
-func formatCatalog(catalog []workloads.PresetInfo, drivers []driverEntry) string {
+// formatCatalog builds the human-readable preset listing, workload schemas,
+// and driver insert-method matrix.
+func formatCatalog(
+	catalog []workloads.PresetInfo,
+	drivers []driverEntry,
+	workloadSchemas []workloadEntry,
+) string {
 	var builder strings.Builder
 
 	builder.WriteString("\nPRESETS (embedded workloads)\n\n")
@@ -145,6 +216,28 @@ func formatCatalog(catalog []workloads.PresetInfo, drivers []driverEntry) string
 		builder.WriteString("\n")
 	}
 
+	builder.WriteString("WORKLOADS (typed parameters)\n\n")
+
+	for _, workload := range workloadSchemas {
+		builder.WriteString("  " + workload.Name + "\n")
+
+		for _, group := range []struct {
+			label string
+			scope bench.ParamScope
+		}{
+			{"run", bench.ParamScopeRun},
+			{"workload", bench.ParamScopeWorkload},
+		} {
+			flags := paramFlags(workload.Params, group.scope)
+			if len(flags) > 0 {
+				fmt.Fprintf(&builder, "    %-9s %s\n", group.label+":", strings.Join(flags, ", "))
+			}
+		}
+
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString("  Use 'stroppy run <workload> --help' for types, defaults, and sources.\n\n")
 	builder.WriteString("DRIVERS (supported insert methods)\n\n")
 
 	typeWidth := 0
@@ -160,4 +253,16 @@ func formatCatalog(catalog []workloads.PresetInfo, drivers []driverEntry) string
 	builder.WriteString("\n")
 
 	return builder.String()
+}
+
+func paramFlags(params []paramEntry, scope bench.ParamScope) []string {
+	flags := make([]string, 0, len(params))
+	for idx := range params {
+		param := &params[idx]
+		if param.Scope == scope {
+			flags = append(flags, param.Flag)
+		}
+	}
+
+	return flags
 }

--- a/cmd/stroppy/commands/probe/probe.go
+++ b/cmd/stroppy/commands/probe/probe.go
@@ -118,15 +118,16 @@ type workloadEntry struct {
 }
 
 type paramEntry struct {
-	Name          string           `json:"name"`
-	Flag          string           `json:"flag"`
-	Scope         bench.ParamScope `json:"scope"`
-	Type          bench.ParamType  `json:"type"`
-	Description   string           `json:"description"`
-	Default       any              `json:"default"`
-	Env           string           `json:"env"`
-	LegacyAliases []string         `json:"legacy_aliases"`
-	Config        string           `json:"config"`
+	Name               string           `json:"name"`
+	Flag               string           `json:"flag"`
+	Scope              bench.ParamScope `json:"scope"`
+	Type               bench.ParamType  `json:"type"`
+	Description        string           `json:"description"`
+	Default            any              `json:"default"`
+	DefaultDescription string           `json:"default_description,omitempty"`
+	Env                string           `json:"env"`
+	LegacyAliases      []string         `json:"legacy_aliases"`
+	Config             string           `json:"config"`
 }
 
 func describeWorkloads(descriptions []bench.Description) []workloadEntry {
@@ -143,15 +144,16 @@ func describeWorkloads(descriptions []bench.Description) []workloadEntry {
 			}
 
 			params = append(params, paramEntry{
-				Name:          param.Name,
-				Flag:          param.Flag,
-				Scope:         param.Scope,
-				Type:          param.Type,
-				Description:   param.Description,
-				Default:       defaultValue,
-				Env:           param.Env,
-				LegacyAliases: append([]string{}, param.LegacyEnvAliases...),
-				Config:        param.Config,
+				Name:               param.Name,
+				Flag:               param.Flag,
+				Scope:              param.Scope,
+				Type:               param.Type,
+				Description:        param.Description,
+				Default:            defaultValue,
+				DefaultDescription: param.DefaultDescription,
+				Env:                param.Env,
+				LegacyAliases:      append([]string{}, param.LegacyEnvAliases...),
+				Config:             param.Config,
 			})
 		}
 

--- a/cmd/stroppy/commands/probe/probe_test.go
+++ b/cmd/stroppy/commands/probe/probe_test.go
@@ -118,6 +118,12 @@ func assertRepresentativeParams(t *testing.T, workloads []workloadEntry) {
 	if duration.Type != bench.ParamTypeDuration || duration.Default != "0s" {
 		t.Fatalf("duration schema = %#v", duration)
 	}
+
+	loadItems := findParam(t, tpcc.Params, "load-items")
+	if loadItems.Default != nil ||
+		loadItems.DefaultDescription != "true when warehouse-start is 1; false otherwise" {
+		t.Fatalf("load-items schema = %#v", loadItems)
+	}
 }
 
 func findWorkload(t *testing.T, workloads []workloadEntry, name string) workloadEntry {

--- a/cmd/stroppy/commands/probe/probe_test.go
+++ b/cmd/stroppy/commands/probe/probe_test.go
@@ -1,0 +1,149 @@
+package probe
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	_ "github.com/stroppy-io/stroppy/internal/workloads"
+	"github.com/stroppy-io/stroppy/pkg/bench"
+)
+
+func TestJSONCatalogIncludesWorkloadSchemas(t *testing.T) {
+	first := renderJSONCatalog(t)
+	second := renderJSONCatalog(t)
+
+	if !bytes.Equal(first, second) {
+		t.Fatal("JSON output is not stable")
+	}
+
+	catalog := decodeCatalog(t, first)
+	assertSortedWorkloads(t, catalog.Workloads)
+	assertRepresentativeParams(t, catalog.Workloads)
+}
+
+func TestHumanCatalogIncludesGroupedWorkloads(t *testing.T) {
+	var output bytes.Buffer
+	if err := printCatalog(&output, humanFormat); err != nil {
+		t.Fatalf("printCatalog() error = %v", err)
+	}
+
+	text := output.String()
+	for _, want := range []string{
+		"PRESETS (embedded workloads)",
+		"WORKLOADS (typed parameters)",
+		"  tpcc/tx\n",
+		"    run:      --duration, --executor, --iterations, --vus",
+		"    workload: --load-items",
+		"stroppy run <workload> --help",
+		"DRIVERS (supported insert methods)",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("human output does not contain %q\n%s", want, text)
+		}
+	}
+}
+
+func renderJSONCatalog(t *testing.T) []byte {
+	t.Helper()
+
+	var output bytes.Buffer
+	if err := printCatalog(&output, jsonFormat); err != nil {
+		t.Fatalf("printCatalog() error = %v", err)
+	}
+
+	return output.Bytes()
+}
+
+func decodeCatalog(t *testing.T, data []byte) catalogOutput {
+	t.Helper()
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("decode top-level JSON: %v", err)
+	}
+
+	for _, key := range []string{"presets", "drivers", "workloads"} {
+		if _, ok := top[key]; !ok {
+			t.Errorf("top-level key %q is missing", key)
+		}
+	}
+
+	var catalog catalogOutput
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("decode catalog JSON: %v", err)
+	}
+
+	return catalog
+}
+
+func assertSortedWorkloads(t *testing.T, workloads []workloadEntry) {
+	t.Helper()
+
+	names := make([]string, 0, len(workloads))
+	for _, workload := range workloads {
+		names = append(names, workload.Name)
+	}
+
+	if !slices.IsSorted(names) {
+		t.Fatalf("workloads are not sorted: %v", names)
+	}
+}
+
+func assertRepresentativeParams(t *testing.T, workloads []workloadEntry) {
+	t.Helper()
+
+	tpcc := findWorkload(t, workloads, "tpcc/tx")
+	scaleFactor := findParam(t, tpcc.Params, "scale-factor")
+
+	if scaleFactor.Flag != "--scale-factor" ||
+		scaleFactor.Scope != bench.ParamScopeWorkload ||
+		scaleFactor.Type != bench.ParamTypeInt ||
+		scaleFactor.Description != "Number of warehouses." ||
+		scaleFactor.Default != float64(1) ||
+		scaleFactor.Env != "SCALE_FACTOR" ||
+		!slices.Equal(scaleFactor.LegacyAliases, []string{"WAREHOUSES"}) ||
+		scaleFactor.Config != "scaleFactor" {
+		t.Fatalf("tpcc scale-factor schema = %#v", scaleFactor)
+	}
+
+	executor := findParam(t, tpcc.Params, "executor")
+	if executor.Scope != bench.ParamScopeRun || executor.Flag != "--executor" || executor.Config != "executor" {
+		t.Fatalf("executor schema = %#v", executor)
+	}
+
+	duration := findParam(t, tpcc.Params, "duration")
+	if duration.Type != bench.ParamTypeDuration || duration.Default != "0s" {
+		t.Fatalf("duration schema = %#v", duration)
+	}
+}
+
+func findWorkload(t *testing.T, workloads []workloadEntry, name string) workloadEntry {
+	t.Helper()
+
+	for _, workload := range workloads {
+		if workload.Name == name {
+			return workload
+		}
+	}
+
+	t.Fatalf("workload %q not found", name)
+
+	return workloadEntry{}
+}
+
+func findParam(t *testing.T, params []paramEntry, name string) paramEntry {
+	t.Helper()
+
+	for idx := range params {
+		if params[idx].Name == name {
+			return params[idx]
+		}
+	}
+
+	t.Fatalf("parameter %q not found", name)
+
+	return paramEntry{}
+}

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
 	"github.com/stroppy-io/stroppy/internal/version"
@@ -35,6 +37,7 @@ var (
 	errUnknownRunFlag     = errors.New("unknown run flag")
 	errPositionalAfterOpt = errors.New("unexpected positional argument after options")
 	errKeyValuePositional = errors.New("unexpected key=value positional argument")
+	errDriverExtraType    = errors.New("invalid driver extra field type")
 	errTooManyPositionals = errors.New(
 		"too many positional arguments; expected script and optional sql_file before --",
 	)
@@ -58,8 +61,13 @@ SQL files are searched in: current directory -> ~/.stroppy/ -> built-in workload
 The workload and optional sql_file positionals must be adjacent.
 
 Environment flags:
-  -e, --env KEY=VALUE     Set env var for the workload (lowercase auto-uppercased)
-                          Real env takes precedence over -e values.
+  -e, --env KEY=VALUE     Set a legacy env value for the workload.
+                          Real env and typed flags take precedence.
+
+Typed parameter flags:
+  --name VALUE            Set a run or selected-workload parameter.
+  --name=VALUE            Equals form. Boolean values must be explicit.
+  Use 'stroppy run <workload> --help' to list available typed parameters.
 
 Driver flags:
   -d, --driver NAME       Use a driver preset (pg, mysql, pico, ydb, noop)
@@ -69,7 +77,9 @@ Driver flags:
 
 Config file flags:
   -f, --file PATH         Load config from file (default: ./stroppy-config.json if exists)
-                          Config file values are lower precedence than -e/-d/-D flags.
+                          "run" holds scenario params; "params" holds workload params.
+                          Config env values are lower precedence than -e and typed values.
+                          Config drivers are lower precedence than -d/-D.
                           See 'stroppy help config-file' for details.
 `,
 	DisableFlagParsing: true,
@@ -79,6 +89,7 @@ Config file flags:
   stroppy run tpcb/tx                           # TPC-B tx workload
   stroppy run tpch/tx                           # TPC-H load + query suite
   stroppy run tpcds                             # TPC-DS load + query suite
+  stroppy run simple --executor constant-vus --duration 10s --vus 4
   stroppy run queries.sql                       # execute a SQL file
   stroppy run "select 1"                        # execute inline SQL
   stroppy run tpcc/tx --steps create_schema,load_data  # only run specified steps
@@ -91,10 +102,6 @@ Config file flags:
     --steps drop_schema,create_schema,load_data  # dump generated rows to CSV
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
-			return cmd.Help()
-		}
-
 		parsed, err := parseRunArgs(args)
 		if err != nil {
 			return invalidConfig(err)
@@ -112,6 +119,24 @@ Config file flags:
 		steps := runner.EffectiveSteps(parsed.steps, fileConfig)
 		noSteps := runner.EffectiveNoSteps(parsed.noSteps, fileConfig)
 
+		if parsed.help {
+			if scriptArg == "" {
+				return cmd.Help()
+			}
+
+			describeName := scriptArg
+			if name, _, _, ok := executeSQLGoRoute(scriptArg, sqlArg); ok {
+				describeName = name
+			}
+
+			description, err := bench.Describe(describeName)
+			if err != nil {
+				return invalidConfig(fmt.Errorf("%w: %q", errUnknownWorkload, scriptArg))
+			}
+
+			return printWorkloadHelp(cmd, description)
+		}
+
 		if scriptArg == "" {
 			return invalidConfig(errNoScript)
 		}
@@ -124,17 +149,17 @@ Config file flags:
 		if fileConfig != nil {
 			lg := logger.Global().Named("run")
 
-			if parsed.scriptArg != "" && fileConfig.GetScript() != "" {
+			if parsed.scriptArg != "" && fileConfig.RunConfig.GetScript() != "" {
 				lg.Debug("CLI script overrides config file",
 					zap.String("cli", parsed.scriptArg),
-					zap.String("file", fileConfig.GetScript()),
+					zap.String("file", fileConfig.RunConfig.GetScript()),
 				)
 			}
 
-			if len(parsed.steps) > 0 && len(fileConfig.GetSteps()) > 0 {
+			if len(parsed.steps) > 0 && len(fileConfig.RunConfig.GetSteps()) > 0 {
 				lg.Debug("CLI --steps overrides config file steps",
 					zap.Strings("cli", parsed.steps),
-					zap.Strings("file", fileConfig.GetSteps()),
+					zap.Strings("file", fileConfig.RunConfig.GetSteps()),
 				)
 			}
 		}
@@ -145,7 +170,25 @@ Config file flags:
 			return invalidConfig(err)
 		}
 
+		paramInputs := bench.ParamInputs{
+			CLI:       parsed.typedParams,
+			LegacyEnv: envOverrides,
+		}
+		rootEnv := cloneStringMap(envOverrides)
+
 		driverConfigs := runner.DriverCLIConfigs{}
+
+		if fileConfig != nil {
+			paramInputs.RunConfig = fileConfig.Run
+			paramInputs.WorkloadConfig = fileConfig.Params
+			paramInputs.LegacyConfigEnv = fileConfig.RunConfig.GetEnv()
+			rootEnv = mergeLegacyEnv(fileConfig.RunConfig.GetEnv(), envOverrides)
+
+			driverConfigs, err = runner.DriverCLIConfigsFromFile(fileConfig.RunConfig.GetDrivers())
+			if err != nil {
+				return invalidConfig(err)
+			}
+		}
 
 		for idx, presetName := range parsed.driverPresets {
 			if err := applyDriverPreset(driverConfigs, idx, presetName); err != nil {
@@ -168,21 +211,55 @@ Config file flags:
 		if name, body, file, ok := executeSQLGoRoute(scriptArg, sqlArg); ok {
 			if body != "" {
 				envOverrides["STROPPY_SQL_BODY"] = body
+				rootEnv["STROPPY_SQL_BODY"] = body
 			} else if file != "" {
 				envOverrides["SQL_FILE"] = file
+				rootEnv["SQL_FILE"] = file
 			}
 
-			return runGoWorkload(name, steps, noSteps, envOverrides, driverConfigs, metricsConfig(fileConfig))
+			return runGoWorkload(
+				name, steps, noSteps, rootEnv, paramInputs, driverConfigs, metricsConfig(loadedRunConfig(fileConfig)),
+			)
 		}
 
 		// Go-native workload: if a Go workload is registered under the bare
 		// script name, dispatch to bench.Run.
 		if _, ok := bench.Lookup(scriptArg); ok {
-			return runGoWorkload(scriptArg, steps, noSteps, envOverrides, driverConfigs, metricsConfig(fileConfig))
+			return runGoWorkload(
+				scriptArg,
+				steps,
+				noSteps,
+				rootEnv,
+				paramInputs,
+				driverConfigs,
+				metricsConfig(loadedRunConfig(fileConfig)),
+			)
 		}
 
 		return invalidConfig(fmt.Errorf("%w: %q", errUnknownWorkload, scriptArg))
 	},
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	cloned := make(map[string]string, len(values))
+	maps.Copy(cloned, values)
+
+	return cloned
+}
+
+func mergeLegacyEnv(configEnv, cliEnv map[string]string) map[string]string {
+	merged := cloneStringMap(configEnv)
+	maps.Copy(merged, cliEnv)
+
+	return merged
+}
+
+func loadedRunConfig(config *runner.LoadedConfig) *stroppy.RunConfig {
+	if config == nil {
+		return nil
+	}
+
+	return config.RunConfig
 }
 
 func metricsConfig(config *stroppy.RunConfig) *bench.MetricsConfig {
@@ -208,6 +285,54 @@ func metricsConfig(config *stroppy.RunConfig) *bench.MetricsConfig {
 	metrics.Prefix = export.GetOtlpMetricsPrefix()
 
 	return metrics
+}
+
+func printWorkloadHelp(cmd *cobra.Command, description bench.Description) error {
+	var output strings.Builder
+
+	fmt.Fprintf(&output, "Usage:\n  stroppy run %s [sql_file] [flags]\n\n", description.Name)
+	output.WriteString("Static flags:\n")
+	output.WriteString("  -f, --file PATH          Load a config file\n")
+	output.WriteString("  -d, --driver NAME        Use a driver preset\n")
+	output.WriteString("  -D, --driver-opt K=V     Override a driver field\n")
+	output.WriteString("  -e, --env KEY=VALUE      Set a legacy workload environment value\n")
+	output.WriteString("      --steps NAMES        Run only named steps\n")
+	output.WriteString("      --no-steps NAMES     Skip named steps\n")
+	output.WriteString("  -h, --help               Show this help\n")
+
+	writeParamHelpSection(&output, "Run parameters", description.Params, bench.ParamScopeRun)
+	writeParamHelpSection(&output, "Workload parameters", description.Params, bench.ParamScopeWorkload)
+
+	_, err := fmt.Fprint(cmd.OutOrStdout(), output.String())
+
+	return err
+}
+
+func writeParamHelpSection(
+	output *strings.Builder,
+	title string,
+	params []bench.ParamSchema,
+	scope bench.ParamScope,
+) {
+	output.WriteString("\n" + title + ":\n")
+
+	for idx := range params {
+		param := &params[idx]
+		if param.Scope != scope {
+			continue
+		}
+
+		fmt.Fprintf(
+			output,
+			"  %-22s %-8s default=%v\n      %s (env %s, config %s)\n",
+			param.Flag,
+			param.Type,
+			param.Default,
+			param.Description,
+			param.Env,
+			param.Config,
+		)
+	}
 }
 
 func invalidConfig(err error) error {
@@ -244,14 +369,15 @@ func executeSQLGoRoute(scriptArg, sqlArg string) (name, body, file string, ok bo
 func runGoWorkload(
 	name string,
 	steps, noSteps []string,
-	envOverrides map[string]string,
+	env map[string]string,
+	paramInputs bench.ParamInputs,
 	driverConfigs runner.DriverCLIConfigs,
 	metrics *bench.MetricsConfig,
 ) error {
 	drivers := map[int]*stroppy.DriverConfig{}
 
 	for idx, cfg := range driverConfigs {
-		dc, err := buildDriverConfig(idx, cfg, envOverrides)
+		dc, err := buildDriverConfig(idx, cfg, env)
 		if err != nil {
 			return err
 		}
@@ -285,8 +411,8 @@ func runGoWorkload(
 		ctx,
 		name,
 		drivers,
-		envOverrides,
-		bench.ParamInputs{LegacyEnv: envOverrides},
+		env,
+		paramInputs,
 		logger.Global(),
 		metrics,
 	); err != nil {
@@ -314,15 +440,18 @@ func buildDriverConfig(
 		dc.DriverType = t
 	}
 
-	// defaultInsertMethod is TS-only; Go workloads set Method on each InsertSpec.
-	if len(cfg.Extra) > 0 {
-		if extraJSON, err := json.Marshal(cfg.Extra); err == nil {
-			_ = json.Unmarshal(extraJSON, dc) //nolint:musttag // frozen proto type, out of scope to tag
-		}
+	// defaultInsertMethod is owned by each Go workload's InsertRequest.
+	if err := applyDriverExtras(idx, dc, cfg.Extra); err != nil {
+		return nil, invalidConfig(err)
 	}
 
 	if dc.GetDriverType() == stroppy.DriverConfig_DRIVER_TYPE_POSTGRES {
-		if ps, ok := envOverrides["POOL_SIZE"]; ok {
+		ps, ok := os.LookupEnv("POOL_SIZE")
+		if !ok {
+			ps, ok = envOverrides["POOL_SIZE"]
+		}
+
+		if ok {
 			if n, err := strconv.Atoi(ps); err == nil && n > 0 {
 				nc := int32(n) //nolint:gosec // G109: parsed config value, bounded by user input, not untrusted
 				dc.DriverSpecific = &stroppy.DriverConfig_Postgres{Postgres: &stroppy.DriverConfig_PostgresConfig{
@@ -335,6 +464,110 @@ func buildDriverConfig(
 	return dc, nil
 }
 
+func applyDriverExtras(idx int, config *stroppy.DriverConfig, extras map[string]any) error {
+	if len(extras) == 0 {
+		return nil
+	}
+
+	values := maps.Clone(extras)
+
+	if errorModeValue, ok := popDriverExtra(values, "errorMode", "error_mode"); ok {
+		errorMode, isString := errorModeValue.(string)
+		if !isString {
+			return fmt.Errorf("driver %d errorMode: %w", idx, errDriverExtraType)
+		}
+
+		parsed, err := bench.ParseErrorMode(errorMode)
+		if err != nil {
+			return fmt.Errorf("driver %d errorMode: %w", idx, err)
+		}
+
+		config.ErrorMode = parsed
+	}
+
+	_, _ = popDriverExtra(values, "defaultTxIsolation", "default_tx_isolation")
+	pool, hasPool := popDriverExtra(values, "pool")
+
+	if config.GetDriverType() == stroppy.DriverConfig_DRIVER_TYPE_POSTGRES {
+		_, _ = popDriverExtra(values, "sql")
+	} else {
+		_, _ = popDriverExtra(values, "postgres")
+	}
+
+	extraConfig := &stroppy.DriverConfig{}
+
+	data, err := json.Marshal(values)
+	if err != nil {
+		return fmt.Errorf("driver %d extra config: %w", idx, err)
+	}
+
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(data, extraConfig); err != nil {
+		return fmt.Errorf("driver %d extra config: %w", idx, err)
+	}
+
+	if extraConfig.GetDriverSpecific() == nil && hasPool {
+		if err := applyPoolDriverSpecific(config.GetDriverType(), pool, extraConfig); err != nil {
+			return fmt.Errorf("driver %d pool config: %w", idx, err)
+		}
+	}
+
+	config.BulkSize = extraConfig.BulkSize
+	config.DriverSpecific = extraConfig.GetDriverSpecific()
+	config.CaCertFile = extraConfig.CaCertFile
+	config.AuthToken = extraConfig.AuthToken
+	config.AuthUser = extraConfig.AuthUser
+	config.AuthPassword = extraConfig.AuthPassword
+	config.TlsInsecureSkipVerify = extraConfig.TlsInsecureSkipVerify
+	config.InsertProgress = extraConfig.GetInsertProgress()
+
+	return nil
+}
+
+func popDriverExtra(values map[string]any, names ...string) (any, bool) {
+	for _, name := range names {
+		if value, ok := values[name]; ok {
+			delete(values, name)
+
+			return value, true
+		}
+	}
+
+	return nil, false
+}
+
+func applyPoolDriverSpecific(
+	driverType stroppy.DriverConfig_DriverType,
+	pool any,
+	config *stroppy.DriverConfig,
+) error {
+	data, err := json.Marshal(pool)
+	if err != nil {
+		return err
+	}
+
+	unmarshal := protojson.UnmarshalOptions{DiscardUnknown: true}
+
+	if driverType == stroppy.DriverConfig_DRIVER_TYPE_POSTGRES {
+		postgres := &stroppy.DriverConfig_PostgresConfig{}
+		if err := unmarshal.Unmarshal(data, postgres); err != nil {
+			return err
+		}
+
+		config.DriverSpecific = &stroppy.DriverConfig_Postgres{Postgres: postgres}
+
+		return nil
+	}
+
+	sqlConfig := &stroppy.DriverConfig_SqlConfig{}
+	if err := unmarshal.Unmarshal(data, sqlConfig); err != nil {
+		return err
+	}
+
+	config.DriverSpecific = &stroppy.DriverConfig_Sql{Sql: sqlConfig}
+
+	return nil
+}
+
 // runArgs holds the result of parseRunArgs.
 type runArgs struct {
 	scriptArg     string
@@ -343,7 +576,9 @@ type runArgs struct {
 	steps         []string
 	noSteps       []string
 	afterDash     []string
-	envArgs       []string            // -e KEY=VALUE raw pairs
+	envArgs       []string          // -e KEY=VALUE raw pairs
+	typedParams   map[string]string // provisional --name=value workload/run params
+	help          bool
 	driverPresets map[int]string      // driver index → preset name
 	driverOpts    map[int][][2]string // driver index → list of [key, value] pairs
 }
@@ -375,10 +610,12 @@ func parseRunArgs(args []string) (runArgs, error) {
 	}
 
 	parsers := []flagParser{
+		parseHelpFlag,
 		parseStepsFlag,
 		parseFileFlag,
 		parseEnvFlag,
 		parseDriverFlags,
+		parseTypedParamFlag,
 	}
 
 	if err := parseRunArgsBeforeDash(positional, parsers, &parsed); err != nil {
@@ -460,6 +697,66 @@ func dispatchFlag(parsers []flagParser, positional []string, i int, parsed *runA
 	}
 
 	return 0, nil
+}
+
+func parseHelpFlag(args []string, i int, parsed *runArgs) (int, error) {
+	if args[i] != "--help" && args[i] != "-h" {
+		return 0, nil
+	}
+
+	parsed.help = true
+
+	return 1, nil
+}
+
+func parseTypedParamFlag(args []string, i int, parsed *runArgs) (int, error) {
+	arg := args[i]
+	if !strings.HasPrefix(arg, "--") {
+		return 0, nil
+	}
+
+	nameValue := strings.TrimPrefix(arg, "--")
+
+	name, value, hasEquals := strings.Cut(nameValue, "=")
+	if name == "" {
+		return 0, fmt.Errorf("%w %q", errUnknownRunFlag, arg)
+	}
+
+	consumed := 1
+
+	if !hasEquals {
+		var err error
+
+		value, err = nextTypedFlagValue(args, i)
+		if err != nil {
+			return 0, err
+		}
+
+		consumed = consumedPairFlag
+	}
+
+	if parsed.typedParams == nil {
+		parsed.typedParams = make(map[string]string)
+	}
+
+	parsed.typedParams[name] = value
+
+	return consumed, nil
+}
+
+func nextTypedFlagValue(args []string, i int) (string, error) {
+	flag := args[i]
+	if i+1 >= len(args) {
+		return "", fmt.Errorf("%s: %w", flag, errFlagRequiresValue)
+	}
+
+	next := args[i+1]
+	if strings.HasPrefix(next, "--") || next == "-h" ||
+		(strings.HasPrefix(next, "-") && (len(next) < 2 || next[1] < '0' || next[1] > '9')) {
+		return "", fmt.Errorf("%s: %w", flag, errFlagRequiresValue)
+	}
+
+	return next, nil
 }
 
 // parseStepsFlag handles --steps and --no-steps in both space and equals forms.

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
 	"github.com/stroppy-io/stroppy/internal/version"
@@ -27,6 +28,8 @@ const (
 	flagSteps        = "--steps"
 	flagNoSteps      = "--no-steps"
 	flagDriverOpt    = "--driver-opt"
+	sqlBodyEnv       = "STROPPY_SQL_BODY"
+	sqlFileEnv       = "SQL_FILE"
 )
 
 var (
@@ -107,6 +110,10 @@ Config file flags:
 			return invalidConfig(err)
 		}
 
+		if parsed.help && parsed.scriptArg != "" {
+			return printSelectedWorkloadHelp(cmd, parsed.scriptArg, parsed.sqlArg)
+		}
+
 		// Load config file if -f is specified or stroppy-config.json exists.
 		fileConfig, _, err := runner.LoadRunConfig(parsed.fileArg)
 		if err != nil {
@@ -124,17 +131,7 @@ Config file flags:
 				return cmd.Help()
 			}
 
-			describeName := scriptArg
-			if name, _, _, ok := executeSQLGoRoute(scriptArg, sqlArg); ok {
-				describeName = name
-			}
-
-			description, err := bench.Describe(describeName)
-			if err != nil {
-				return invalidConfig(fmt.Errorf("%w: %q", errUnknownWorkload, scriptArg))
-			}
-
-			return printWorkloadHelp(cmd, description)
+			return printSelectedWorkloadHelp(cmd, scriptArg, sqlArg)
 		}
 
 		if scriptArg == "" {
@@ -209,17 +206,22 @@ Config file flags:
 		// (STROPPY_SQL_BODY for inline, SQL_FILE for a path) — replacing the TS wrapper.
 		// Checked before the registered-name lookup so the preset's sql arg is honored.
 		if name, body, file, ok := executeSQLGoRoute(scriptArg, sqlArg); ok {
-			if body != "" {
-				envOverrides["STROPPY_SQL_BODY"] = body
-				rootEnv["STROPPY_SQL_BODY"] = body
-			} else if file != "" {
-				envOverrides["SQL_FILE"] = file
-				rootEnv["SQL_FILE"] = file
+			sqlSource := resolveSQLSource(
+				&parsed,
+				body,
+				file,
+				envOverrides,
+				paramInputs.LegacyConfigEnv,
+			)
+			applySQLSource(rootEnv, sqlSource)
+
+			run := func() error {
+				return runGoWorkload(
+					name, steps, noSteps, rootEnv, paramInputs, driverConfigs, metricsConfig(loadedRunConfig(fileConfig)),
+				)
 			}
 
-			return runGoWorkload(
-				name, steps, noSteps, rootEnv, paramInputs, driverConfigs, metricsConfig(loadedRunConfig(fileConfig)),
-			)
+			return withProcessSQLSource(sqlSource, run)
 		}
 
 		// Go-native workload: if a Go workload is registered under the bare
@@ -285,6 +287,20 @@ func metricsConfig(config *stroppy.RunConfig) *bench.MetricsConfig {
 	metrics.Prefix = export.GetOtlpMetricsPrefix()
 
 	return metrics
+}
+
+func printSelectedWorkloadHelp(cmd *cobra.Command, scriptArg, sqlArg string) error {
+	describeName := scriptArg
+	if name, _, _, ok := executeSQLGoRoute(scriptArg, sqlArg); ok {
+		describeName = name
+	}
+
+	description, err := bench.Describe(describeName)
+	if err != nil {
+		return invalidConfig(fmt.Errorf("%w: %q", errUnknownWorkload, scriptArg))
+	}
+
+	return printWorkloadHelp(cmd, description)
 }
 
 func printWorkloadHelp(cmd *cobra.Command, description bench.Description) error {
@@ -360,6 +376,121 @@ func executeSQLGoRoute(scriptArg, sqlArg string) (name, body, file string, ok bo
 	}
 
 	return "", "", "", false
+}
+
+type sqlSource struct {
+	envKey      string
+	value       string
+	explicitCLI bool
+}
+
+func resolveSQLSource(
+	parsed *runArgs,
+	routeBody, routeFile string,
+	cliEnv, configEnv map[string]string,
+) sqlSource {
+	if file, ok := parsed.typedParams["sql-file"]; ok {
+		return sqlSource{envKey: sqlFileEnv, value: file, explicitCLI: true}
+	}
+
+	routeSource := sqlSourceFor(routeBody, routeFile)
+	if routeSource.envKey != "" && explicitCLISQLSource(parsed) {
+		routeSource.explicitCLI = true
+
+		return routeSource
+	}
+
+	if source := sqlSourceFromProcess(); source.envKey != "" {
+		return source
+	}
+
+	if source := sqlSourceFromMap(cliEnv); source.envKey != "" {
+		return source
+	}
+
+	if routeSource.envKey != "" {
+		return routeSource
+	}
+
+	return sqlSourceFromMap(configEnv)
+}
+
+func explicitCLISQLSource(parsed *runArgs) bool {
+	return parsed.sqlArg != "" ||
+		strings.Contains(parsed.scriptArg, " ") ||
+		strings.HasSuffix(parsed.scriptArg, ".sql")
+}
+
+func sqlSourceFor(body, file string) sqlSource {
+	if body != "" {
+		return sqlSource{envKey: sqlBodyEnv, value: body}
+	}
+
+	if file != "" {
+		return sqlSource{envKey: sqlFileEnv, value: file}
+	}
+
+	return sqlSource{}
+}
+
+func sqlSourceFromProcess() sqlSource {
+	if body, ok := os.LookupEnv(sqlBodyEnv); ok && body != "" {
+		return sqlSource{envKey: sqlBodyEnv, value: body}
+	}
+
+	if file, ok := os.LookupEnv(sqlFileEnv); ok && file != "" {
+		return sqlSource{envKey: sqlFileEnv, value: file}
+	}
+
+	return sqlSource{}
+}
+
+func sqlSourceFromMap(values map[string]string) sqlSource {
+	return sqlSourceFor(values[sqlBodyEnv], values[sqlFileEnv])
+}
+
+func applySQLSource(env map[string]string, source sqlSource) {
+	delete(env, sqlBodyEnv)
+	delete(env, sqlFileEnv)
+
+	if source.envKey != "" {
+		env[source.envKey] = source.value
+	}
+}
+
+func withProcessSQLSource(source sqlSource, run func() error) error {
+	if !source.explicitCLI {
+		return run()
+	}
+
+	body, bodySet := os.LookupEnv(sqlBodyEnv)
+	file, fileSet := os.LookupEnv(sqlFileEnv)
+
+	applyProcessSQLSource(source)
+
+	defer restoreProcessEnv(sqlBodyEnv, body, bodySet)
+	defer restoreProcessEnv(sqlFileEnv, file, fileSet)
+
+	return run()
+}
+
+func applyProcessSQLSource(source sqlSource) {
+	_ = os.Unsetenv(sqlBodyEnv)
+	_ = os.Unsetenv(sqlFileEnv)
+
+	if source.envKey != "" {
+		_ = os.Setenv(source.envKey, source.value)
+	}
+}
+
+func restoreProcessEnv(name, value string, set bool) {
+	if set {
+		_ = os.Setenv(name, value)
+
+		return
+	}
+
+	_ = os.Unsetenv(name)
 }
 
 // runGoWorkload dispatches to the Go-native bench engine. Driver CLI configs are
@@ -505,8 +636,8 @@ func applyDriverExtras(idx int, config *stroppy.DriverConfig, extras map[string]
 		return fmt.Errorf("driver %d extra config: %w", idx, err)
 	}
 
-	if extraConfig.GetDriverSpecific() == nil && hasPool {
-		if err := applyPoolDriverSpecific(config.GetDriverType(), pool, extraConfig); err != nil {
+	if hasPool {
+		if err := mergePoolDriverSpecific(config.GetDriverType(), pool, extraConfig); err != nil {
 			return fmt.Errorf("driver %d pool config: %w", idx, err)
 		}
 	}
@@ -535,7 +666,7 @@ func popDriverExtra(values map[string]any, names ...string) (any, bool) {
 	return nil, false
 }
 
-func applyPoolDriverSpecific(
+func mergePoolDriverSpecific(
 	driverType stroppy.DriverConfig_DriverType,
 	pool any,
 	config *stroppy.DriverConfig,
@@ -553,6 +684,10 @@ func applyPoolDriverSpecific(
 			return err
 		}
 
+		if specific := config.GetPostgres(); specific != nil {
+			proto.Merge(postgres, specific)
+		}
+
 		config.DriverSpecific = &stroppy.DriverConfig_Postgres{Postgres: postgres}
 
 		return nil
@@ -561,6 +696,10 @@ func applyPoolDriverSpecific(
 	sqlConfig := &stroppy.DriverConfig_SqlConfig{}
 	if err := unmarshal.Unmarshal(data, sqlConfig); err != nil {
 		return err
+	}
+
+	if specific := config.GetSql(); specific != nil {
+		proto.Merge(sqlConfig, specific)
 	}
 
 	config.DriverSpecific = &stroppy.DriverConfig_Sql{Sql: sqlConfig}

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -281,7 +281,15 @@ func runGoWorkload(
 	}
 
 	ctx := context.Background()
-	if err := bench.Run(ctx, name, drivers, envOverrides, logger.Global(), metrics); err != nil {
+	if err := bench.Run(
+		ctx,
+		name,
+		drivers,
+		envOverrides,
+		bench.ParamInputs{LegacyEnv: envOverrides},
+		logger.Global(),
+		metrics,
+	); err != nil {
 		return fmt.Errorf("failed to run go workload: %w", err)
 	}
 

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"os"
 	"slices"
 	"strconv"
@@ -41,6 +42,7 @@ var (
 	errPositionalAfterOpt = errors.New("unexpected positional argument after options")
 	errKeyValuePositional = errors.New("unexpected key=value positional argument")
 	errDriverExtraType    = errors.New("invalid driver extra field type")
+	errSQLFilePositional  = errors.New("workload does not accept sql_file positional")
 	errTooManyPositionals = errors.New(
 		"too many positional arguments; expected script and optional sql_file before --",
 	)
@@ -229,7 +231,10 @@ Config file flags:
 		// Go-native workload: if a Go workload is registered under the bare
 		// script name, dispatch to bench.Run.
 		if _, ok := bench.Lookup(scriptArg); ok {
-			workloadParamInputs := withEffectiveSQLFile(paramInputs, sqlArg)
+			workloadParamInputs, err := withEffectiveSQLFile(scriptArg, paramInputs, sqlArg)
+			if err != nil {
+				return invalidConfig(err)
+			}
 
 			return runGoWorkload(
 				scriptArg,
@@ -246,9 +251,21 @@ Config file flags:
 	},
 }
 
-func withEffectiveSQLFile(inputs bench.ParamInputs, sqlFile string) bench.ParamInputs {
+func withEffectiveSQLFile(name string, inputs bench.ParamInputs, sqlFile string) (bench.ParamInputs, error) {
 	if sqlFile == "" {
-		return inputs
+		return inputs, nil
+	}
+
+	description, err := bench.Describe(name)
+	if err != nil {
+		return inputs, err
+	}
+
+	acceptsSQLFile := slices.ContainsFunc(description.Params, func(param bench.ParamSchema) bool {
+		return param.Scope == bench.ParamScopeWorkload && param.Name == "sql-file"
+	})
+	if !acceptsSQLFile {
+		return inputs, fmt.Errorf("%w for workload %q", errSQLFilePositional, name)
 	}
 
 	inputs.CLI = cloneStringMap(inputs.CLI)
@@ -256,7 +273,7 @@ func withEffectiveSQLFile(inputs bench.ParamInputs, sqlFile string) bench.ParamI
 		inputs.CLI["sql-file"] = sqlFile
 	}
 
-	return inputs
+	return inputs, nil
 }
 
 func cloneStringMap(values map[string]string) map[string]string {
@@ -687,11 +704,11 @@ func applyLegacyPostgresPoolSize(config *stroppy.DriverConfig, env map[string]st
 	}
 
 	value, err := strconv.Atoi(poolSize)
-	if err != nil || value <= 0 {
+	if err != nil || value <= 0 || value > math.MaxInt32 {
 		return
 	}
 
-	connections := int32(value) //nolint:gosec // G109: parsed config value, bounded by user input
+	connections := int32(value) //nolint:gosec // G109: range-checked above
 
 	postgres := config.GetPostgres()
 	if postgres == nil {
@@ -724,13 +741,24 @@ func applyDriverExtras(idx int, config *stroppy.DriverConfig, extras map[string]
 		config.ErrorMode = parsed
 	}
 
-	_, _ = popDriverExtra(values, "defaultTxIsolation", "default_tx_isolation")
+	if _, ok := popDriverExtra(values, "defaultTxIsolation", "default_tx_isolation"); ok {
+		warnIgnoredDriverExtra(idx, "defaultTxIsolation", "use workload parameter --tx-isolation")
+	}
+
 	pool, hasPool := popDriverExtra(values, "pool")
 
 	if config.GetDriverType() == stroppy.DriverConfig_DRIVER_TYPE_POSTGRES {
-		_, _ = popDriverExtra(values, "sql")
-	} else {
-		_, _ = popDriverExtra(values, "postgres")
+		if _, ok := popDriverExtra(values, "sql"); ok {
+			warnIgnoredDriverExtra(idx, "sql", "PostgreSQL uses postgres pool settings")
+		}
+	} else if _, ok := popDriverExtra(values, "postgres"); ok {
+		warnIgnoredDriverExtra(idx, "postgres", "only PostgreSQL uses postgres pool settings")
+	}
+
+	if hasPool && !driverSupportsPool(config.GetDriverType()) {
+		warnIgnoredDriverExtra(idx, "pool", "selected driver has no connection pool")
+
+		hasPool = false
 	}
 
 	extraConfig := &stroppy.DriverConfig{}
@@ -774,6 +802,27 @@ func popDriverExtra(values map[string]any, names ...string) (any, bool) {
 	return nil, false
 }
 
+func warnIgnoredDriverExtra(idx int, field, reason string) {
+	logger.Global().Named("run").Warn(
+		"ignoring driver option",
+		zap.Int("driver", idx),
+		zap.String("field", field),
+		zap.String("reason", reason),
+	)
+}
+
+func driverSupportsPool(driverType stroppy.DriverConfig_DriverType) bool {
+	switch driverType {
+	case stroppy.DriverConfig_DRIVER_TYPE_POSTGRES,
+		stroppy.DriverConfig_DRIVER_TYPE_MYSQL,
+		stroppy.DriverConfig_DRIVER_TYPE_PICODATA,
+		stroppy.DriverConfig_DRIVER_TYPE_YDB:
+		return true
+	default:
+		return false
+	}
+}
+
 func mergePoolDriverSpecific(
 	driverType stroppy.DriverConfig_DriverType,
 	pool any,
@@ -784,7 +833,7 @@ func mergePoolDriverSpecific(
 		return err
 	}
 
-	unmarshal := protojson.UnmarshalOptions{DiscardUnknown: true}
+	unmarshal := protojson.UnmarshalOptions{DiscardUnknown: false}
 
 	if driverType == stroppy.DriverConfig_DRIVER_TYPE_POSTGRES {
 		postgres := &stroppy.DriverConfig_PostgresConfig{}

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -87,6 +87,7 @@ Config file flags:
 `,
 	DisableFlagParsing: true,
 	SilenceErrors:      false,
+	ValidArgsFunction:  completeRunArgs,
 	Example: `
   stroppy run tpcc/tx                           # built-in TPC-C tx workload
   stroppy run tpcb/tx                           # TPC-B tx workload
@@ -211,6 +212,7 @@ Config file flags:
 				body,
 				file,
 				envOverrides,
+				paramInputs.WorkloadConfig,
 				paramInputs.LegacyConfigEnv,
 			)
 			applySQLSource(rootEnv, sqlSource)
@@ -227,12 +229,14 @@ Config file flags:
 		// Go-native workload: if a Go workload is registered under the bare
 		// script name, dispatch to bench.Run.
 		if _, ok := bench.Lookup(scriptArg); ok {
+			workloadParamInputs := withEffectiveSQLFile(paramInputs, sqlArg)
+
 			return runGoWorkload(
 				scriptArg,
 				steps,
 				noSteps,
 				rootEnv,
-				paramInputs,
+				workloadParamInputs,
 				driverConfigs,
 				metricsConfig(loadedRunConfig(fileConfig)),
 			)
@@ -240,6 +244,19 @@ Config file flags:
 
 		return invalidConfig(fmt.Errorf("%w: %q", errUnknownWorkload, scriptArg))
 	},
+}
+
+func withEffectiveSQLFile(inputs bench.ParamInputs, sqlFile string) bench.ParamInputs {
+	if sqlFile == "" {
+		return inputs
+	}
+
+	inputs.CLI = cloneStringMap(inputs.CLI)
+	if _, explicit := inputs.CLI["sql-file"]; !explicit {
+		inputs.CLI["sql-file"] = sqlFile
+	}
+
+	return inputs
 }
 
 func cloneStringMap(values map[string]string) map[string]string {
@@ -289,6 +306,49 @@ func metricsConfig(config *stroppy.RunConfig) *bench.MetricsConfig {
 	return metrics
 }
 
+func completeRunArgs(
+	_ *cobra.Command,
+	args []string,
+	toComplete string,
+) ([]string, cobra.ShellCompDirective) {
+	if !strings.HasPrefix(toComplete, "--") {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	parsed, err := parseRunArgs(args)
+	if err != nil || parsed.scriptArg == "" {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	describeName := parsed.scriptArg
+	if name, _, _, ok := executeSQLGoRoute(parsed.scriptArg, parsed.sqlArg); ok {
+		describeName = name
+	}
+
+	description, err := bench.Describe(describeName)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	completions := make([]string, 0, len(description.Params))
+	for idx := range description.Params {
+		param := &description.Params[idx]
+
+		candidates := []string{param.Flag}
+		if param.Type == bench.ParamTypeBool {
+			candidates = []string{param.Flag + "=true", param.Flag + "=false"}
+		}
+
+		for _, candidate := range candidates {
+			if strings.HasPrefix(candidate, toComplete) {
+				completions = append(completions, candidate+"\t"+param.Description)
+			}
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
 func printSelectedWorkloadHelp(cmd *cobra.Command, scriptArg, sqlArg string) error {
 	describeName := scriptArg
 	if name, _, _, ok := executeSQLGoRoute(scriptArg, sqlArg); ok {
@@ -315,6 +375,7 @@ func printWorkloadHelp(cmd *cobra.Command, description bench.Description) error 
 	output.WriteString("      --steps NAMES        Run only named steps\n")
 	output.WriteString("      --no-steps NAMES     Skip named steps\n")
 	output.WriteString("  -h, --help               Show this help\n")
+	output.WriteString("\nBoolean parameters require an explicit value: --flag=true or --flag=false.\n")
 
 	writeParamHelpSection(&output, "Run parameters", description.Params, bench.ParamScopeRun)
 	writeParamHelpSection(&output, "Workload parameters", description.Params, bench.ParamScopeWorkload)
@@ -338,12 +399,22 @@ func writeParamHelpSection(
 			continue
 		}
 
+		flag := param.Flag
+		if param.Type == bench.ParamTypeBool {
+			flag += "=true|false"
+		}
+
+		defaultValue := param.Default
+		if param.DefaultDescription != "" {
+			defaultValue = param.DefaultDescription
+		}
+
 		fmt.Fprintf(
 			output,
 			"  %-22s %-8s default=%v\n      %s (env %s, config %s)\n",
-			param.Flag,
+			flag,
 			param.Type,
-			param.Default,
+			defaultValue,
 			param.Description,
 			param.Env,
 			param.Config,
@@ -387,7 +458,9 @@ type sqlSource struct {
 func resolveSQLSource(
 	parsed *runArgs,
 	routeBody, routeFile string,
-	cliEnv, configEnv map[string]string,
+	cliEnv map[string]string,
+	workloadConfig map[string]json.RawMessage,
+	configEnv map[string]string,
 ) sqlSource {
 	if file, ok := parsed.typedParams["sql-file"]; ok {
 		return sqlSource{envKey: sqlFileEnv, value: file, explicitCLI: true}
@@ -405,6 +478,10 @@ func resolveSQLSource(
 	}
 
 	if source := sqlSourceFromMap(cliEnv); source.envKey != "" {
+		return source
+	}
+
+	if source := sqlSourceFromWorkloadConfig(workloadConfig); source.envKey != "" {
 		return source
 	}
 
@@ -447,6 +524,20 @@ func sqlSourceFromProcess() sqlSource {
 
 func sqlSourceFromMap(values map[string]string) sqlSource {
 	return sqlSourceFor(values[sqlBodyEnv], values[sqlFileEnv])
+}
+
+func sqlSourceFromWorkloadConfig(values map[string]json.RawMessage) sqlSource {
+	raw, ok := values["sqlFile"]
+	if !ok {
+		return sqlSource{}
+	}
+
+	var file string
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return sqlSource{}
+	}
+
+	return sqlSource{envKey: sqlFileEnv, value: file}
 }
 
 func applySQLSource(env map[string]string, source sqlSource) {
@@ -576,23 +667,40 @@ func buildDriverConfig(
 		return nil, invalidConfig(err)
 	}
 
-	if dc.GetDriverType() == stroppy.DriverConfig_DRIVER_TYPE_POSTGRES {
-		ps, ok := os.LookupEnv("POOL_SIZE")
-		if !ok {
-			ps, ok = envOverrides["POOL_SIZE"]
-		}
-
-		if ok {
-			if n, err := strconv.Atoi(ps); err == nil && n > 0 {
-				nc := int32(n) //nolint:gosec // G109: parsed config value, bounded by user input, not untrusted
-				dc.DriverSpecific = &stroppy.DriverConfig_Postgres{Postgres: &stroppy.DriverConfig_PostgresConfig{
-					MaxConns: &nc, MinConns: &nc,
-				}}
-			}
-		}
-	}
+	applyLegacyPostgresPoolSize(dc, envOverrides)
 
 	return dc, nil
+}
+
+func applyLegacyPostgresPoolSize(config *stroppy.DriverConfig, env map[string]string) {
+	if config.GetDriverType() != stroppy.DriverConfig_DRIVER_TYPE_POSTGRES {
+		return
+	}
+
+	poolSize, ok := os.LookupEnv("POOL_SIZE")
+	if !ok {
+		poolSize, ok = env["POOL_SIZE"]
+	}
+
+	if !ok {
+		return
+	}
+
+	value, err := strconv.Atoi(poolSize)
+	if err != nil || value <= 0 {
+		return
+	}
+
+	connections := int32(value) //nolint:gosec // G109: parsed config value, bounded by user input
+
+	postgres := config.GetPostgres()
+	if postgres == nil {
+		postgres = &stroppy.DriverConfig_PostgresConfig{}
+	}
+
+	postgres.MaxConns = &connections
+	postgres.MinConns = &connections
+	config.DriverSpecific = &stroppy.DriverConfig_Postgres{Postgres: postgres}
 }
 
 func applyDriverExtras(idx int, config *stroppy.DriverConfig, extras map[string]any) error {
@@ -1343,5 +1451,41 @@ func applyDriverOpt(configs runner.DriverCLIConfigs, idx int, key, value string)
 		configs[idx] = cfg
 	}
 
-	return cfg.ApplyOverride(key, value)
+	if err := cfg.ApplyOverride(key, value); err != nil {
+		return err
+	}
+
+	if specificKey := poolSpecificDriverOverride(cfg.DriverType, key); specificKey != "" {
+		return cfg.ApplyOverride(specificKey, value)
+	}
+
+	return nil
+}
+
+func poolSpecificDriverOverride(driverType, key string) string {
+	field, ok := strings.CutPrefix(key, "pool.")
+	if !ok {
+		return ""
+	}
+
+	switch driverType {
+	case "postgres":
+		switch field {
+		case "maxConns", "minConns", "minIdleConns",
+			"maxConnLifetime", "maxConnIdleTime", "traceLogLevel",
+			"defaultQueryExecMode", "descriptionCacheCapacity", "statementCacheCapacity":
+			return "postgres." + field
+		default:
+			return ""
+		}
+	case "mysql", "picodata", "ydb":
+		switch field {
+		case "maxOpenConns", "maxIdleConns", "connMaxLifetime", "connMaxIdleTime":
+			return "sql." + field
+		default:
+			return ""
+		}
+	default:
+		return ""
+	}
 }

--- a/cmd/stroppy/commands/run/run_test.go
+++ b/cmd/stroppy/commands/run/run_test.go
@@ -1,14 +1,20 @@
 package run
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"maps"
 	"os"
 	"testing"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
+	"github.com/stroppy-io/stroppy/pkg/bench"
+	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
 )
 
+//nolint:cyclop // one table covers the complete run argument grammar
 func TestParseRunArgs(t *testing.T) {
 	t.Parallel()
 
@@ -21,6 +27,8 @@ func TestParseRunArgs(t *testing.T) {
 		wantSteps     []string
 		wantNoSteps   []string
 		wantAfterDash []string
+		wantTyped     map[string]string
+		wantHelp      bool
 		wantPresets   map[int]string
 		wantOpts      map[int][][2]string
 		wantErr       error
@@ -57,9 +65,28 @@ func TestParseRunArgs(t *testing.T) {
 			wantErrStr: "too many positional arguments",
 		},
 		{
-			name:       "unknown flag before separator returns error",
+			name:       "typed flag pair form",
 			args:       []string{"tpcc", "--vus", "10"},
-			wantErrStr: "pass k6 flags after --",
+			wantScript: "tpcc",
+			wantTyped:  map[string]string{"vus": "10"},
+		},
+		{
+			name:       "typed bool equals form",
+			args:       []string{"--enabled=false", "tpcc"},
+			wantScript: "tpcc",
+			wantTyped:  map[string]string{"enabled": "false"},
+		},
+		{
+			name:       "typed negative pair value",
+			args:       []string{"tpcc", "--offset", "-10"},
+			wantScript: "tpcc",
+			wantTyped:  map[string]string{"offset": "-10"},
+		},
+		{
+			name:       "help after workload",
+			args:       []string{"tpcc", "--help"},
+			wantScript: "tpcc",
+			wantHelp:   true,
 		},
 		{
 			name:        "inline SQL query with spaces and equals is single positional",
@@ -480,6 +507,14 @@ func TestParseRunArgs(t *testing.T) {
 				t.Errorf("afterDash: got %v, want %v", got.afterDash, tt.wantAfterDash)
 			}
 
+			if !maps.Equal(got.typedParams, tt.wantTyped) {
+				t.Errorf("typedParams: got %v, want %v", got.typedParams, tt.wantTyped)
+			}
+
+			if got.help != tt.wantHelp {
+				t.Errorf("help: got %v, want %v", got.help, tt.wantHelp)
+			}
+
 			if !presetMapsEqual(got.driverPresets, tt.wantPresets) {
 				t.Errorf("driverPresets: got %v, want %v", got.driverPresets, tt.wantPresets)
 			}
@@ -490,6 +525,132 @@ func TestParseRunArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
+	merged := mergeLegacyEnv(
+		map[string]string{"CONFIG_ONLY": "file", "SHARED": "file"},
+		map[string]string{"CLI_ONLY": "cli", "SHARED": "cli"},
+	)
+	if !maps.Equal(merged, map[string]string{
+		"CONFIG_ONLY": "file",
+		"CLI_ONLY":    "cli",
+		"SHARED":      "cli",
+	}) {
+		t.Fatalf("merged env = %v", merged)
+	}
+
+	driverType := "postgres"
+	fileURL := "postgres://file"
+	errorMode := "throw"
+	bulkSize := int32(20)
+	maxConns := int32(7)
+
+	configs, err := runner.DriverCLIConfigsFromFile(map[uint32]*stroppy.DriverRunConfig{
+		0: {
+			DriverType: &driverType,
+			Url:        &fileURL,
+			ErrorMode:  &errorMode,
+			BulkSize:   &bulkSize,
+			Pool:       &stroppy.DriverRunConfig_PoolConfig{MaxConns: &maxConns},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DriverCLIConfigsFromFile() error = %v", err)
+	}
+
+	if err := applyDriverOpt(configs, 0, "url", "postgres://cli"); err != nil {
+		t.Fatalf("applyDriverOpt() error = %v", err)
+	}
+
+	if configs[0].DriverType != "postgres" || configs[0].URL != "postgres://cli" {
+		t.Fatalf("merged driver config = %#v", configs[0])
+	}
+
+	runtimeConfig, err := buildDriverConfig(0, configs[0], nil)
+	if err != nil {
+		t.Fatalf("buildDriverConfig() error = %v", err)
+	}
+
+	if runtimeConfig.GetUrl() != "postgres://cli" ||
+		runtimeConfig.GetBulkSize() != 20 ||
+		runtimeConfig.GetErrorMode() != stroppy.DriverConfig_ERROR_MODE_THROW ||
+		runtimeConfig.GetPostgres().GetMaxConns() != 7 {
+		t.Fatalf("runtime driver config = %#v, extra = %#v", runtimeConfig, configs[0].Extra)
+	}
+}
+
+func TestBuildDriverConfigReturnsJSONConversionErrors(t *testing.T) {
+	_, err := buildDriverConfig(0, &runner.DriverCLIConfig{
+		Extra: map[string]any{"invalid": func() {}},
+	}, nil)
+	if err == nil || !contains(err.Error(), "extra config") {
+		t.Fatalf("buildDriverConfig() error = %v", err)
+	}
+}
+
+func TestDynamicWorkloadHelpAndBadTypedParam(t *testing.T) {
+	bench.Register(func() bench.Workload { return &runParamTestWorkload{} })
+
+	previousOutput := Cmd.OutOrStdout()
+	defer Cmd.SetOut(previousOutput)
+
+	var output bytes.Buffer
+	Cmd.SetOut(&output)
+
+	if err := Cmd.RunE(Cmd, []string{"test/run-typed-params", "--help"}); err != nil {
+		t.Fatalf("RunE(help) error = %v", err)
+	}
+
+	help := output.String()
+	for _, expected := range []string{"Run parameters:", "Workload parameters:", "--executor", "--enabled", "--count"} {
+		if !contains(help, expected) {
+			t.Fatalf("help output missing %q:\n%s", expected, help)
+		}
+	}
+
+	err := Cmd.RunE(Cmd, []string{"test/run-typed-params", "--count=bad", "-d", "noop"})
+	if err == nil || !contains(err.Error(), `parameter "count"`) {
+		t.Fatalf("RunE(bad param) error = %v", err)
+	}
+
+	if contains(err.Error(), "driver dispatch") {
+		t.Fatalf("bad parameter reached driver dispatch: %v", err)
+	}
+
+	configPath := t.TempDir() + "/scoped.json"
+	if err := os.WriteFile(configPath, []byte(`{
+		"script":"test/run-typed-params",
+		"run":{"count":2},
+		"params":{"vus":3}
+	}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	err = Cmd.RunE(Cmd, []string{"-f", configPath, "-d", "noop"})
+	if err == nil || !contains(err.Error(), "unknown run config parameter") ||
+		!contains(err.Error(), "unknown workload config parameter") {
+		t.Fatalf("RunE(crossed config scopes) error = %v", err)
+	}
+
+	if contains(err.Error(), "driver dispatch") {
+		t.Fatalf("crossed config scopes reached driver dispatch: %v", err)
+	}
+}
+
+type runParamTestWorkload struct{}
+
+func (*runParamTestWorkload) Name() string { return "test/run-typed-params" }
+
+func (*runParamTestWorkload) Define(def *bench.Def) error {
+	def.Param.Bool("enabled", false, "Enable test behavior.")
+	def.Param.Int("count", 1, "Number of test operations.")
+
+	return nil
+}
+
+func (*runParamTestWorkload) Setup(context.Context, *bench.Bench) error    { return nil }
+func (*runParamTestWorkload) Iterate(context.Context, *bench.Bench) error  { return nil }
+func (*runParamTestWorkload) Teardown(context.Context, *bench.Bench) error { return nil }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 

--- a/cmd/stroppy/commands/run/run_test.go
+++ b/cmd/stroppy/commands/run/run_test.go
@@ -7,7 +7,10 @@ import (
 	"errors"
 	"maps"
 	"os"
+	"sync"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
 	"github.com/stroppy-io/stroppy/pkg/bench"
@@ -546,6 +549,7 @@ func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
 	errorMode := "throw"
 	bulkSize := int32(20)
 	maxConns := int32(7)
+	specificMaxConns := int32(5)
 	statementCache := int32(13)
 
 	configs, err := runner.DriverCLIConfigsFromFile(map[uint32]*stroppy.DriverRunConfig{
@@ -555,7 +559,10 @@ func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
 			ErrorMode:  &errorMode,
 			BulkSize:   &bulkSize,
 			Pool:       &stroppy.DriverRunConfig_PoolConfig{MaxConns: &maxConns},
-			Postgres:   &stroppy.DriverConfig_PostgresConfig{StatementCacheCapacity: &statementCache},
+			Postgres: &stroppy.DriverConfig_PostgresConfig{
+				MaxConns:               &specificMaxConns,
+				StatementCacheCapacity: &statementCache,
+			},
 		},
 	})
 	if err != nil {
@@ -563,7 +570,11 @@ func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
 	}
 
 	if err := applyDriverOpt(configs, 0, "url", "postgres://cli"); err != nil {
-		t.Fatalf("applyDriverOpt() error = %v", err)
+		t.Fatalf("applyDriverOpt(url) error = %v", err)
+	}
+
+	if err := applyDriverOpt(configs, 0, "pool.maxConns", "10"); err != nil {
+		t.Fatalf("applyDriverOpt(pool.maxConns) error = %v", err)
 	}
 
 	if configs[0].DriverType != "postgres" || configs[0].URL != "postgres://cli" {
@@ -578,24 +589,32 @@ func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
 	if runtimeConfig.GetUrl() != "postgres://cli" ||
 		runtimeConfig.GetBulkSize() != 20 ||
 		runtimeConfig.GetErrorMode() != stroppy.DriverConfig_ERROR_MODE_THROW ||
-		runtimeConfig.GetPostgres().GetMaxConns() != 7 ||
+		runtimeConfig.GetPostgres().GetMaxConns() != 10 ||
 		runtimeConfig.GetPostgres().GetStatementCacheCapacity() != 13 {
 		t.Fatalf("runtime driver config = %#v, extra = %#v", runtimeConfig, configs[0].Extra)
 	}
 
 	mysql := "mysql"
 	maxOpenConns := int32(9)
+	specificMaxOpenConns := int32(5)
 	maxIdleConns := int32(4)
 
 	configs, err = runner.DriverCLIConfigsFromFile(map[uint32]*stroppy.DriverRunConfig{
 		0: {
 			DriverType: &mysql,
 			Pool:       &stroppy.DriverRunConfig_PoolConfig{MaxOpenConns: &maxOpenConns},
-			Sql:        &stroppy.DriverConfig_SqlConfig{MaxIdleConns: &maxIdleConns},
+			Sql: &stroppy.DriverConfig_SqlConfig{
+				MaxOpenConns: &specificMaxOpenConns,
+				MaxIdleConns: &maxIdleConns,
+			},
 		},
 	})
 	if err != nil {
 		t.Fatalf("DriverCLIConfigsFromFile(mysql) error = %v", err)
+	}
+
+	if err := applyDriverOpt(configs, 0, "pool.maxOpenConns", "12"); err != nil {
+		t.Fatalf("applyDriverOpt(pool.maxOpenConns) error = %v", err)
 	}
 
 	runtimeConfig, err = buildDriverConfig(0, configs[0], nil)
@@ -603,8 +622,31 @@ func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
 		t.Fatalf("buildDriverConfig(mysql) error = %v", err)
 	}
 
-	if runtimeConfig.GetSql().GetMaxOpenConns() != 9 || runtimeConfig.GetSql().GetMaxIdleConns() != 4 {
+	if runtimeConfig.GetSql().GetMaxOpenConns() != 12 || runtimeConfig.GetSql().GetMaxIdleConns() != 4 {
 		t.Fatalf("runtime mysql driver config = %#v", runtimeConfig)
+	}
+}
+
+func TestPoolSizePreservesPostgresSpecificConfig(t *testing.T) {
+	t.Setenv("POOL_SIZE", "11")
+
+	config, err := buildDriverConfig(0, &runner.DriverCLIConfig{
+		DriverType: "postgres",
+		Extra: map[string]any{
+			"postgres": map[string]any{
+				"statementCacheCapacity": 13,
+				"maxConnLifetime":        "1h",
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildDriverConfig() error = %v", err)
+	}
+
+	postgres := config.GetPostgres()
+	if postgres.GetMaxConns() != 11 || postgres.GetMinConns() != 11 ||
+		postgres.GetStatementCacheCapacity() != 13 || postgres.GetMaxConnLifetime() != "1h" {
+		t.Fatalf("postgres config = %#v", postgres)
 	}
 }
 
@@ -616,6 +658,7 @@ func TestResolveSQLSourcePrecedence(t *testing.T) {
 			&runArgs{scriptArg: "execute_sql", sqlArg: "cli.sql"},
 			"",
 			"cli.sql",
+			nil,
 			nil,
 			map[string]string{sqlBodyEnv: "select 'config'"},
 		)
@@ -640,6 +683,7 @@ func TestResolveSQLSourcePrecedence(t *testing.T) {
 			"select 'config route'",
 			"",
 			nil,
+			nil,
 			map[string]string{sqlBodyEnv: "select 'config env'"},
 		)
 		if source.envKey != sqlFileEnv || source.value != "typed.sql" || !source.explicitCLI {
@@ -655,6 +699,7 @@ func TestResolveSQLSourcePrecedence(t *testing.T) {
 			&runArgs{scriptArg: "select 1"},
 			"--= query\nselect 1;\n",
 			"",
+			nil,
 			nil,
 			nil,
 		)
@@ -681,6 +726,29 @@ func TestResolveSQLSourcePrecedence(t *testing.T) {
 		}
 	})
 
+	t.Run("typed workload config beats config env body", func(t *testing.T) {
+		unsetRunTestEnv(t, sqlBodyEnv, sqlFileEnv)
+
+		source := resolveSQLSource(
+			&runArgs{},
+			"",
+			"",
+			nil,
+			map[string]json.RawMessage{"sqlFile": json.RawMessage(`"typed-config.sql"`)},
+			map[string]string{sqlBodyEnv: "select 'config env'"},
+		)
+		if source.envKey != sqlFileEnv || source.value != "typed-config.sql" {
+			t.Fatalf("source = %#v", source)
+		}
+
+		env := map[string]string{sqlBodyEnv: "select 'config env'"}
+		applySQLSource(env, source)
+
+		if !maps.Equal(env, map[string]string{sqlFileEnv: "typed-config.sql"}) {
+			t.Fatalf("resolved env = %v", env)
+		}
+	})
+
 	t.Run("process beats legacy and config sources", func(t *testing.T) {
 		unsetRunTestEnv(t, sqlBodyEnv, sqlFileEnv)
 		t.Setenv(sqlFileEnv, "process.sql")
@@ -690,6 +758,7 @@ func TestResolveSQLSourcePrecedence(t *testing.T) {
 			"select 'config route'",
 			"",
 			map[string]string{sqlBodyEnv: "select '-e'"},
+			nil,
 			map[string]string{sqlBodyEnv: "select 'config env'"},
 		)
 		if source.envKey != sqlFileEnv || source.value != "process.sql" {
@@ -708,7 +777,7 @@ func TestBuildDriverConfigReturnsJSONConversionErrors(t *testing.T) {
 }
 
 func TestDynamicWorkloadHelpAndBadTypedParam(t *testing.T) {
-	bench.Register(func() bench.Workload { return &runParamTestWorkload{} })
+	registerRunParamTestWorkload()
 
 	previousOutput := Cmd.OutOrStdout()
 	defer Cmd.SetOut(previousOutput)
@@ -728,7 +797,15 @@ func TestDynamicWorkloadHelpAndBadTypedParam(t *testing.T) {
 	}
 
 	help := output.String()
-	for _, expected := range []string{"Run parameters:", "Workload parameters:", "--executor", "--enabled", "--count"} {
+	for _, expected := range []string{
+		"Run parameters:",
+		"Workload parameters:",
+		"--executor",
+		"--enabled=true|false",
+		"Boolean parameters require an explicit value",
+		"--count",
+		"default=selected at runtime",
+	} {
 		if !contains(help, expected) {
 			t.Fatalf("help output missing %q:\n%s", expected, help)
 		}
@@ -763,13 +840,122 @@ func TestDynamicWorkloadHelpAndBadTypedParam(t *testing.T) {
 	}
 }
 
+func TestWorkloadTypedFlagCompletion(t *testing.T) {
+	registerRunParamTestWorkload()
+
+	completions, directive := Cmd.ValidArgsFunction(
+		Cmd,
+		[]string{"test/run-typed-params"},
+		"--en",
+	)
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v", directive)
+	}
+
+	for _, expected := range []string{
+		"--enabled=true\tEnable test behavior.",
+		"--enabled=false\tEnable test behavior.",
+	} {
+		if !containsCompletion(completions, expected) {
+			t.Fatalf("completions %v missing %q", completions, expected)
+		}
+	}
+
+	completions, directive = Cmd.ValidArgsFunction(
+		Cmd,
+		[]string{"test/run-typed-params"},
+		"--sql",
+	)
+	if directive != cobra.ShellCompDirectiveNoFileComp ||
+		!containsCompletion(completions, "--sql-file\tSQL dialect override file.") {
+		t.Fatalf("sql-file completions = %v, directive = %v", completions, directive)
+	}
+
+	completions, directive = Cmd.ValidArgsFunction(Cmd, nil, "--en")
+	if len(completions) != 0 || directive != cobra.ShellCompDirectiveDefault {
+		t.Fatalf("generic completions = %v, directive = %v", completions, directive)
+	}
+}
+
+func TestRegisteredWorkloadReceivesEffectiveSQLFile(t *testing.T) {
+	registerRunParamTestWorkload()
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "second positional",
+			args: []string{
+				"test/run-typed-params", "compat.sql", "--count=bad", "-d", "noop",
+			},
+			want: "compat.sql",
+		},
+		{
+			name: "direct typed flag wins",
+			args: []string{
+				"test/run-typed-params", "compat.sql", "--sql-file=direct.sql", "--count=bad", "-d", "noop",
+			},
+			want: "direct.sql",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lastRunParamSQLFile = ""
+
+			err := Cmd.RunE(Cmd, test.args)
+			if err == nil || !contains(err.Error(), `parameter "count"`) {
+				t.Fatalf("RunE() error = %v", err)
+			}
+
+			if lastRunParamSQLFile != test.want {
+				t.Fatalf("sql-file binding = %q, want %q", lastRunParamSQLFile, test.want)
+			}
+		})
+	}
+
+	configPath := t.TempDir() + "/sql.json"
+	if err := os.WriteFile(configPath, []byte(`{
+		"script":"test/run-typed-params",
+		"sql":"config.sql"
+	}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	lastRunParamSQLFile = ""
+
+	err := Cmd.RunE(Cmd, []string{"-f", configPath, "--count=bad", "-d", "noop"})
+	if err == nil || !contains(err.Error(), `parameter "count"`) {
+		t.Fatalf("RunE(config) error = %v", err)
+	}
+
+	if lastRunParamSQLFile != "config.sql" {
+		t.Fatalf("config sql-file binding = %q", lastRunParamSQLFile)
+	}
+}
+
 type runParamTestWorkload struct{}
+
+var (
+	lastRunParamSQLFile          string
+	registerRunParamWorkloadOnce sync.Once
+)
+
+func registerRunParamTestWorkload() {
+	registerRunParamWorkloadOnce.Do(func() {
+		bench.Register(func() bench.Workload { return &runParamTestWorkload{} })
+	})
+}
 
 func (*runParamTestWorkload) Name() string { return "test/run-typed-params" }
 
 func (*runParamTestWorkload) Define(def *bench.Def) error {
 	def.Param.Bool("enabled", false, "Enable test behavior.")
-	def.Param.Int("count", 1, "Number of test operations.")
+	def.Param.Int("count", 1, "Number of test operations.", bench.DerivedDefault("selected at runtime"))
+	sqlFile := def.Param.String("sql-file", "", "SQL dialect override file.")
+	lastRunParamSQLFile = sqlFile.Value()
 
 	return nil
 }
@@ -779,6 +965,16 @@ func (*runParamTestWorkload) Iterate(context.Context, *bench.Bench) error  { ret
 func (*runParamTestWorkload) Teardown(context.Context, *bench.Bench) error { return nil }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
+
+func containsCompletion(completions []string, expected string) bool {
+	for _, completion := range completions {
+		if completion == expected {
+			return true
+		}
+	}
+
+	return false
+}
 
 func contains(s, substr string) bool {
 	return len(substr) == 0 || (len(s) >= len(substr) && containsStr(s, substr))

--- a/cmd/stroppy/commands/run/run_test.go
+++ b/cmd/stroppy/commands/run/run_test.go
@@ -527,6 +527,8 @@ func TestParseRunArgs(t *testing.T) {
 }
 
 func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
+	unsetRunTestEnv(t, "POOL_SIZE")
+
 	merged := mergeLegacyEnv(
 		map[string]string{"CONFIG_ONLY": "file", "SHARED": "file"},
 		map[string]string{"CLI_ONLY": "cli", "SHARED": "cli"},
@@ -544,6 +546,7 @@ func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
 	errorMode := "throw"
 	bulkSize := int32(20)
 	maxConns := int32(7)
+	statementCache := int32(13)
 
 	configs, err := runner.DriverCLIConfigsFromFile(map[uint32]*stroppy.DriverRunConfig{
 		0: {
@@ -552,6 +555,7 @@ func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
 			ErrorMode:  &errorMode,
 			BulkSize:   &bulkSize,
 			Pool:       &stroppy.DriverRunConfig_PoolConfig{MaxConns: &maxConns},
+			Postgres:   &stroppy.DriverConfig_PostgresConfig{StatementCacheCapacity: &statementCache},
 		},
 	})
 	if err != nil {
@@ -574,9 +578,124 @@ func TestLegacyEnvAndConfigDriversMergeBelowCLI(t *testing.T) {
 	if runtimeConfig.GetUrl() != "postgres://cli" ||
 		runtimeConfig.GetBulkSize() != 20 ||
 		runtimeConfig.GetErrorMode() != stroppy.DriverConfig_ERROR_MODE_THROW ||
-		runtimeConfig.GetPostgres().GetMaxConns() != 7 {
+		runtimeConfig.GetPostgres().GetMaxConns() != 7 ||
+		runtimeConfig.GetPostgres().GetStatementCacheCapacity() != 13 {
 		t.Fatalf("runtime driver config = %#v, extra = %#v", runtimeConfig, configs[0].Extra)
 	}
+
+	mysql := "mysql"
+	maxOpenConns := int32(9)
+	maxIdleConns := int32(4)
+
+	configs, err = runner.DriverCLIConfigsFromFile(map[uint32]*stroppy.DriverRunConfig{
+		0: {
+			DriverType: &mysql,
+			Pool:       &stroppy.DriverRunConfig_PoolConfig{MaxOpenConns: &maxOpenConns},
+			Sql:        &stroppy.DriverConfig_SqlConfig{MaxIdleConns: &maxIdleConns},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DriverCLIConfigsFromFile(mysql) error = %v", err)
+	}
+
+	runtimeConfig, err = buildDriverConfig(0, configs[0], nil)
+	if err != nil {
+		t.Fatalf("buildDriverConfig(mysql) error = %v", err)
+	}
+
+	if runtimeConfig.GetSql().GetMaxOpenConns() != 9 || runtimeConfig.GetSql().GetMaxIdleConns() != 4 {
+		t.Fatalf("runtime mysql driver config = %#v", runtimeConfig)
+	}
+}
+
+func TestResolveSQLSourcePrecedence(t *testing.T) {
+	t.Run("CLI SQL positional beats config inline body", func(t *testing.T) {
+		unsetRunTestEnv(t, sqlBodyEnv, sqlFileEnv)
+
+		source := resolveSQLSource(
+			&runArgs{scriptArg: "execute_sql", sqlArg: "cli.sql"},
+			"",
+			"cli.sql",
+			nil,
+			map[string]string{sqlBodyEnv: "select 'config'"},
+		)
+		if source.envKey != sqlFileEnv || source.value != "cli.sql" || !source.explicitCLI {
+			t.Fatalf("source = %#v", source)
+		}
+
+		env := map[string]string{sqlBodyEnv: "select 'config'"}
+		applySQLSource(env, source)
+
+		if !maps.Equal(env, map[string]string{sqlFileEnv: "cli.sql"}) {
+			t.Fatalf("resolved env = %v", env)
+		}
+	})
+
+	t.Run("typed CLI sql-file beats process and config body", func(t *testing.T) {
+		unsetRunTestEnv(t, sqlBodyEnv, sqlFileEnv)
+		t.Setenv(sqlBodyEnv, "select 'process'")
+
+		source := resolveSQLSource(
+			&runArgs{typedParams: map[string]string{"sql-file": "typed.sql"}},
+			"select 'config route'",
+			"",
+			nil,
+			map[string]string{sqlBodyEnv: "select 'config env'"},
+		)
+		if source.envKey != sqlFileEnv || source.value != "typed.sql" || !source.explicitCLI {
+			t.Fatalf("source = %#v", source)
+		}
+	})
+
+	t.Run("CLI inline SQL masks process file", func(t *testing.T) {
+		unsetRunTestEnv(t, sqlBodyEnv, sqlFileEnv)
+		t.Setenv(sqlFileEnv, "process.sql")
+
+		source := resolveSQLSource(
+			&runArgs{scriptArg: "select 1"},
+			"--= query\nselect 1;\n",
+			"",
+			nil,
+			nil,
+		)
+		if !source.explicitCLI || source.envKey != sqlBodyEnv {
+			t.Fatalf("source = %#v", source)
+		}
+
+		if err := withProcessSQLSource(source, func() error {
+			if body := os.Getenv(sqlBodyEnv); body != source.value {
+				t.Fatalf("process body = %q", body)
+			}
+
+			if _, ok := os.LookupEnv(sqlFileEnv); ok {
+				t.Fatal("process SQL_FILE was not masked")
+			}
+
+			return nil
+		}); err != nil {
+			t.Fatalf("withProcessSQLSource() error = %v", err)
+		}
+
+		if file := os.Getenv(sqlFileEnv); file != "process.sql" {
+			t.Fatalf("process SQL_FILE was not restored: %q", file)
+		}
+	})
+
+	t.Run("process beats legacy and config sources", func(t *testing.T) {
+		unsetRunTestEnv(t, sqlBodyEnv, sqlFileEnv)
+		t.Setenv(sqlFileEnv, "process.sql")
+
+		source := resolveSQLSource(
+			&runArgs{},
+			"select 'config route'",
+			"",
+			map[string]string{sqlBodyEnv: "select '-e'"},
+			map[string]string{sqlBodyEnv: "select 'config env'"},
+		)
+		if source.envKey != sqlFileEnv || source.value != "process.sql" {
+			t.Fatalf("source = %#v", source)
+		}
+	})
 }
 
 func TestBuildDriverConfigReturnsJSONConversionErrors(t *testing.T) {
@@ -597,7 +716,14 @@ func TestDynamicWorkloadHelpAndBadTypedParam(t *testing.T) {
 	var output bytes.Buffer
 	Cmd.SetOut(&output)
 
-	if err := Cmd.RunE(Cmd, []string{"test/run-typed-params", "--help"}); err != nil {
+	malformedConfig := t.TempDir() + "/stroppy-config.json"
+	if err := os.WriteFile(malformedConfig, []byte(`{malformed`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := Cmd.RunE(Cmd, []string{
+		"-f", malformedConfig, "test/run-typed-params", "--help",
+	}); err != nil {
 		t.Fatalf("RunE(help) error = %v", err)
 	}
 
@@ -877,6 +1003,25 @@ func TestToEnvVarsSetsWhenNotInEnv(t *testing.T) {
 
 	if len(envs) == 0 {
 		t.Fatal("expected STROPPY_DRIVER_0 to be set")
+	}
+}
+
+func unsetRunTestEnv(t *testing.T, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		value, set := os.LookupEnv(name)
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("Unsetenv(%q) error = %v", name, err)
+		}
+
+		t.Cleanup(func() {
+			if set {
+				_ = os.Setenv(name, value)
+			} else {
+				_ = os.Unsetenv(name)
+			}
+		})
 	}
 }
 

--- a/cmd/stroppy/commands/run/run_test.go
+++ b/cmd/stroppy/commands/run/run_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
+	_ "github.com/stroppy-io/stroppy/internal/workloads/simple"
 	"github.com/stroppy-io/stroppy/pkg/bench"
 	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
 )
@@ -650,6 +651,19 @@ func TestPoolSizePreservesPostgresSpecificConfig(t *testing.T) {
 	}
 }
 
+func TestLegacyPostgresPoolSizeRejectsInt32Overflow(t *testing.T) {
+	t.Setenv("POOL_SIZE", "2147483648")
+
+	config, err := buildDriverConfig(0, &runner.DriverCLIConfig{DriverType: "postgres"}, nil)
+	if err != nil {
+		t.Fatalf("buildDriverConfig() error = %v", err)
+	}
+
+	if config.GetPostgres() != nil {
+		t.Fatalf("postgres config = %#v", config.GetPostgres())
+	}
+}
+
 func TestResolveSQLSourcePrecedence(t *testing.T) {
 	t.Run("CLI SQL positional beats config inline body", func(t *testing.T) {
 		unsetRunTestEnv(t, sqlBodyEnv, sqlFileEnv)
@@ -936,6 +950,13 @@ func TestRegisteredWorkloadReceivesEffectiveSQLFile(t *testing.T) {
 	}
 }
 
+func TestSimpleRejectsSQLFilePositional(t *testing.T) {
+	err := Cmd.RunE(Cmd, []string{"simple", "unused.sql", "-d", "noop"})
+	if err == nil || !contains(err.Error(), "workload does not accept sql_file positional") {
+		t.Fatalf("RunE() error = %v", err)
+	}
+}
+
 type runParamTestWorkload struct{}
 
 var (
@@ -1114,7 +1135,9 @@ func TestApplyDriverOptDottedPoolMergesJSONPreset(t *testing.T) {
 func TestApplyDriverOptDottedPoolUnknownField(t *testing.T) {
 	t.Parallel()
 
-	configs := runner.DriverCLIConfigs{}
+	configs := runner.DriverCLIConfigs{
+		0: &runner.DriverCLIConfig{DriverType: "postgres"},
+	}
 
 	if err := applyDriverOpt(configs, 0, "pool.maximum", "20"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1125,6 +1148,10 @@ func TestApplyDriverOptDottedPoolUnknownField(t *testing.T) {
 
 	if pool["maximum"] != float64(20) {
 		t.Errorf("pool.maximum: got %v, want 20", pool["maximum"])
+	}
+
+	if _, err := buildDriverConfig(0, configs[0], nil); err == nil || !contains(err.Error(), "unknown field") {
+		t.Fatalf("buildDriverConfig() error = %v", err)
 	}
 }
 

--- a/docs/jsonschema/run.schema.json
+++ b/docs/jsonschema/run.schema.json
@@ -1935,26 +1935,6 @@
               }
             }
           ]
-        },
-        {
-          "oneOf": [
-            {
-              "required": [
-                "k6Config"
-              ]
-            },
-            {
-              "not": {
-                "anyOf": [
-                  {
-                    "required": [
-                      "k6Config"
-                    ]
-                  }
-                ]
-              }
-            }
-          ]
         }
       ],
       "properties": {
@@ -2001,27 +1981,10 @@
         },
         "noSteps": {
           "$ref": "#/$defs/.stroppy.RunConfig.no_steps"
-        },
-        "k6Args": {
-          "$ref": "#/$defs/.stroppy.RunConfig.k6_args"
-        },
-        "k6Config": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "#/$defs/.stroppy.RunConfig.k6_config"
-            }
-          ]
         }
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "version",
-        "global"
-      ],
       "description": "Top-level stroppy config. Typed parameter precedence: CLI flag > process environment > -e override > matching run/params value > env map > declared default. The selected workload schema validates names and concrete values in params at runtime."
     },
     ".stroppy.RunConfig.drivers": {

--- a/docs/jsonschema/run.schema.json
+++ b/docs/jsonschema/run.schema.json
@@ -1990,6 +1990,12 @@
         "env": {
           "$ref": "#/$defs/.stroppy.RunConfig.env"
         },
+        "run": {
+          "$ref": "#/$defs/.stroppy.RunConfig.run"
+        },
+        "params": {
+          "$ref": "#/$defs/.stroppy.RunConfig.params"
+        },
         "steps": {
           "$ref": "#/$defs/.stroppy.RunConfig.steps"
         },
@@ -2010,12 +2016,13 @@
           ]
         }
       },
+      "additionalProperties": false,
       "type": "object",
       "required": [
         "version",
         "global"
       ],
-      "description": "*\n RunConfig is the top-level stroppy config file schema.\n\n Default file: ./stroppy-config.json (auto-discovered by stroppy run and stroppy probe).\n Override with -f/--file flag.\n\n Precedence (highest to lowest):\n   real env \u003e -e flags \u003e this file \u003e -d/-D presets \u003e script defaults\n\n Example (stroppy-config.json):\n   {\n     \"version\": \"1\",\n     \"script\": \"tpcc\",\n     \"global\": {\n       \"logger\": { \"logLevel\": \"LOG_LEVEL_INFO\" }\n     },\n     \"drivers\": {\n       \"0\": { \"driverType\": \"postgres\", \"url\": \"postgres://user:pass@db:5432/bench\",\n               \"defaultInsertMethod\": \"native\", \"pool\": { \"maxConns\": 200 } }\n     },\n     \"env\": { \"WAREHOUSES\": \"10\" },\n     \"k6Args\": [\"--vus\", \"10\", \"--duration\", \"30m\"]\n   }"
+      "description": "Top-level stroppy config. Typed parameter precedence: CLI flag > process environment > -e override > matching run/params value > env map > declared default. The selected workload schema validates names and concrete values in params at runtime."
     },
     ".stroppy.RunConfig.drivers": {
       "additionalProperties": {
@@ -2029,7 +2036,47 @@
         "type": "string"
       },
       "type": "object",
-      "description": "*\n Environment variable overrides for the k6 script.\n Equivalent to -e KEY=VALUE. All keys are uppercased on load.\n Precedence: real env \u003e -e flags \u003e this map \u003e script ENV() defaults."
+      "description": "Legacy string-valued parameter overrides. Keys are uppercased on load."
+    },
+    ".stroppy.RunConfig.run": {
+      "additionalProperties": false,
+      "properties": {
+        "executor": {
+          "type": "string",
+          "enum": [
+            "shared-iterations",
+            "constant-vus"
+          ]
+        },
+        "vus": {
+          "type": "integer"
+        },
+        "iterations": {
+          "type": "integer"
+        },
+        "duration": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "description": "Typed shared run parameters. Select shared-iterations or constant-vus explicitly."
+    },
+    ".stroppy.RunConfig.params": {
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "type": "object",
+      "description": "Typed parameters declared by the selected workload. Names and concrete types are validated against that workload's runtime schema."
     },
     ".stroppy.RunConfig.global": {
       "$ref": "#/$defs/.stroppy.GlobalConfig",

--- a/docs/jsonschema/run.schema.json
+++ b/docs/jsonschema/run.schema.json
@@ -2045,18 +2045,6 @@
       "$ref": "#/$defs/.stroppy.GlobalConfig",
       "description": "*\n Global stroppy settings: logger level/mode, OTEL exporter, seed, run_id, metadata.\n These activate the previously-dead GlobalConfig plumbing."
     },
-    ".stroppy.RunConfig.k6_args": {
-      "items": {
-        "type": "string",
-        "description": "*\n Additional raw args passed directly to \"k6 run\".\n Placed before CLI -- args, so CLI args can override (last-wins for most k6 flags).\n Example: [\"--vus\", \"10\", \"--duration\", \"30m\"]"
-      },
-      "type": "array",
-      "description": "*\n Additional raw args passed directly to \"k6 run\".\n Placed before CLI -- args, so CLI args can override (last-wins for most k6 flags).\n Example: [\"--vus\", \"10\", \"--duration\", \"30m\"]"
-    },
-    ".stroppy.RunConfig.k6_config": {
-      "type": "string",
-      "description": "*\n Optional path to a k6 native config JSON file.\n If set, \"--config \u003cpath\u003e\" is prepended to k6 run args.\n Useful for setting scenarios, thresholds, or other options not available via CLI flags."
-    },
     ".stroppy.RunConfig.no_steps": {
       "items": {
         "type": "string",

--- a/docs/parallelism.md
+++ b/docs/parallelism.md
@@ -1,7 +1,7 @@
 # parallelism
 
 How stroppy's typed data-generation load parallelism works, why it is
-deterministic across workers, and how to tune `LOAD_WORKERS` for a
+deterministic across workers, and how to tune `--load-workers` for a
 workload.
 
 `pkg/gen` replaces the relational expression framework: generation is
@@ -14,14 +14,15 @@ mutable runtime, and nothing to race.
 
 ## 1. Model
 
-**One dial.** A workload reads `LOAD_WORKERS` and passes it as the
-`Workers` field of `driver.InsertRequest`:
+**One dial.** A workload declares `--load-workers` (`params.loadWorkers` in
+config) and passes the resolved value as the `Workers` field of
+`driver.InsertRequest`:
 
 ```go
 req := &driver.InsertRequest{
     Table:   "orders",
     Method:  driver.InsertNative,
-    Workers: loadWorkers,            // -e LOAD_WORKERS=N
+    Workers: loadWorkers,            // --load-workers=N
     Source:  source,
 }
 b.Insert(ctx, req)
@@ -47,7 +48,7 @@ single worker, and batches are worker-private after `Prepare`.
 
 ## 2. End-to-end trace
 
-How `LOAD_WORKERS=4` becomes four goroutines writing concurrently.
+How `--load-workers=4` becomes four goroutines writing concurrently.
 
 1. **Workload.** Builds a source and a request, calls `b.Insert` inside
    a `load_data` step (guarded by `GlobalOnce`).
@@ -105,7 +106,7 @@ stats.
 
 ---
 
-## 5. Setting `LOAD_WORKERS`
+## 5. Setting `--load-workers`
 
 Guideline for workload authors.
 

--- a/internal/runner/config_file.go
+++ b/internal/runner/config_file.go
@@ -23,6 +23,7 @@ const DefaultConfigFile = "stroppy-config.json"
 var (
 	errConfigObjectExpected = errors.New("JSON object expected")
 	errDuplicateConfigField = errors.New("duplicate JSON field")
+	errConfigEnvCollision   = errors.New("config env keys collide case-insensitively")
 	errTrailingConfigData   = errors.New("trailing JSON data")
 )
 
@@ -78,14 +79,8 @@ func LoadRunConfig(path string) (*LoadedConfig, bool, error) {
 		return nil, false, fmt.Errorf("parsing config file %q: %w", path, err)
 	}
 
-	// Uppercase all env keys for consistency with -e flag behavior.
-	if len(cfg.GetEnv()) > 0 {
-		normalized := make(map[string]string, len(cfg.GetEnv()))
-		for k, v := range cfg.GetEnv() {
-			normalized[strings.ToUpper(k)] = v
-		}
-
-		cfg.Env = normalized
+	if err := normalizeRunConfigEnv(cfg); err != nil {
+		return nil, false, fmt.Errorf("parsing config file %q: %w", path, err)
 	}
 
 	lg := logger.Global().Named("config_file")
@@ -114,6 +109,36 @@ func LoadRunConfig(path string) (*LoadedConfig, bool, error) {
 	}
 
 	return &LoadedConfig{RunConfig: cfg, Run: runParams, Params: workloadParams}, true, nil
+}
+
+func normalizeRunConfigEnv(config *stroppy.RunConfig) error {
+	if len(config.GetEnv()) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(config.GetEnv()))
+	for key := range config.GetEnv() {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	normalized := make(map[string]string, len(config.GetEnv()))
+	original := make(map[string]string, len(config.GetEnv()))
+
+	for _, key := range keys {
+		upper := strings.ToUpper(key)
+		if previous, exists := original[upper]; exists && previous != key {
+			return fmt.Errorf("%w: %q and %q", errConfigEnvCollision, previous, key)
+		}
+
+		normalized[upper] = config.GetEnv()[key]
+		original[upper] = key
+	}
+
+	config.Env = normalized
+
+	return nil
 }
 
 func takeParamScope(fields map[string]json.RawMessage, name string) (map[string]json.RawMessage, error) {

--- a/internal/runner/config_file.go
+++ b/internal/runner/config_file.go
@@ -1,7 +1,11 @@
 package runner
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -16,13 +20,26 @@ import (
 // DefaultConfigFile is the file auto-discovered in the current directory.
 const DefaultConfigFile = "stroppy-config.json"
 
+var (
+	errConfigObjectExpected = errors.New("JSON object expected")
+	errDuplicateConfigField = errors.New("duplicate JSON field")
+	errTrailingConfigData   = errors.New("trailing JSON data")
+)
+
+// LoadedConfig keeps the frozen run config separate from typed parameter scopes.
+type LoadedConfig struct {
+	RunConfig *stroppy.RunConfig
+	Run       map[string]json.RawMessage
+	Params    map[string]json.RawMessage
+}
+
 // LoadRunConfig loads a RunConfig from a JSON file.
 //
 //   - If path is non-empty: load from that path; return error if not found.
 //   - If path is empty: try DefaultConfigFile in cwd; return (nil, false, nil) if absent.
 //
 // Returns (config, loaded, error).
-func LoadRunConfig(path string) (*stroppy.RunConfig, bool, error) {
+func LoadRunConfig(path string) (*LoadedConfig, bool, error) {
 	if path == "" {
 		if _, err := os.Stat(DefaultConfigFile); os.IsNotExist(err) {
 			return nil, false, nil
@@ -36,8 +53,28 @@ func LoadRunConfig(path string) (*stroppy.RunConfig, bool, error) {
 		return nil, false, fmt.Errorf("reading config file %q: %w", path, err)
 	}
 
+	fields, err := decodeRawObject(data)
+	if err != nil {
+		return nil, false, fmt.Errorf("parsing config file %q: %w", path, err)
+	}
+
+	runParams, err := takeParamScope(fields, "run")
+	if err != nil {
+		return nil, false, fmt.Errorf("parsing config file %q: %w", path, err)
+	}
+
+	workloadParams, err := takeParamScope(fields, "params")
+	if err != nil {
+		return nil, false, fmt.Errorf("parsing config file %q: %w", path, err)
+	}
+
+	protoData, err := json.Marshal(fields)
+	if err != nil {
+		return nil, false, fmt.Errorf("parsing config file %q: %w", path, err)
+	}
+
 	cfg := &stroppy.RunConfig{}
-	if err := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(data, cfg); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(protoData, cfg); err != nil {
 		return nil, false, fmt.Errorf("parsing config file %q: %w", path, err)
 	}
 
@@ -76,7 +113,82 @@ func LoadRunConfig(path string) (*stroppy.RunConfig, bool, error) {
 		)
 	}
 
-	return cfg, true, nil
+	return &LoadedConfig{RunConfig: cfg, Run: runParams, Params: workloadParams}, true, nil
+}
+
+func takeParamScope(fields map[string]json.RawMessage, name string) (map[string]json.RawMessage, error) {
+	raw, ok := fields[name]
+	if !ok {
+		return map[string]json.RawMessage{}, nil
+	}
+
+	delete(fields, name)
+
+	scope, err := decodeRawObject(raw)
+	if err != nil {
+		return nil, fmt.Errorf("config field %q: %w", name, err)
+	}
+
+	return scope, nil
+}
+
+func decodeRawObject(data []byte) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '{' {
+		return nil, errConfigObjectExpected
+	}
+
+	fields := make(map[string]json.RawMessage)
+
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		key, ok := keyToken.(string)
+		if !ok {
+			return nil, errConfigObjectExpected
+		}
+
+		if _, duplicate := fields[key]; duplicate {
+			return nil, fmt.Errorf("%w %q", errDuplicateConfigField, key)
+		}
+
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, err
+		}
+
+		fields[key] = raw
+	}
+
+	if _, err := decoder.Token(); err != nil {
+		return nil, err
+	}
+
+	if err := ensureJSONEnd(decoder); err != nil {
+		return nil, err
+	}
+
+	return fields, nil
+}
+
+func ensureJSONEnd(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); errors.Is(err, io.EOF) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	return errTrailingConfigData
 }
 
 // BuildProbeEnvFromRunConfig returns the config-derived environment that probe

--- a/internal/runner/config_file_test.go
+++ b/internal/runner/config_file_test.go
@@ -165,6 +165,15 @@ func TestLoadRunConfig_RejectsInvalidParameterScopes(t *testing.T) {
 	}
 }
 
+func TestLoadRunConfigRejectsCaseInsensitiveEnvCollisions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"env":{"vus":"1","VUS":"2"}}`), 0o600))
+
+	_, _, err := runner.LoadRunConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `config env keys collide case-insensitively: "VUS" and "vus"`)
+}
+
 func TestBuildProbeEnvFromRunConfigIncludesFileDriver(t *testing.T) {
 	cfg := &stroppy.RunConfig{
 		Env: map[string]string{"WAREHOUSES": "10"},

--- a/internal/runner/config_file_test.go
+++ b/internal/runner/config_file_test.go
@@ -25,8 +25,8 @@ func TestLoadRunConfig_ExplicitPath(t *testing.T) {
 		cfg, loaded, err := runner.LoadRunConfig(f.Name())
 		require.NoError(t, err)
 		assert.True(t, loaded)
-		assert.Equal(t, "tpcc", cfg.GetScript())
-		assert.Equal(t, "30m", cfg.Env["DURATION"]) // key uppercased
+		assert.Equal(t, "tpcc", cfg.RunConfig.GetScript())
+		assert.Equal(t, "30m", cfg.RunConfig.Env["DURATION"]) // key uppercased
 	})
 
 	t.Run("file not found", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestLoadRunConfig_AutoDiscovery(t *testing.T) {
 		cfg, loaded, err := runner.LoadRunConfig("")
 		require.NoError(t, err)
 		assert.True(t, loaded)
-		assert.Equal(t, "bar", cfg.Env["FOO"])
+		assert.Equal(t, "bar", cfg.RunConfig.Env["FOO"])
 	})
 }
 
@@ -115,7 +115,7 @@ func TestLoadRunConfig_DriverConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, loaded)
 
-	drv := cfg.Drivers[0]
+	drv := cfg.RunConfig.Drivers[0]
 	require.NotNil(t, drv)
 	assert.Equal(t, "postgres", drv.GetDriverType())
 	assert.Equal(t, "postgres://user:pass@localhost:5432/bench", drv.GetUrl())
@@ -124,6 +124,45 @@ func TestLoadRunConfig_DriverConfig(t *testing.T) {
 	assert.Equal(t, int32(5), drv.Pool.GetMinIdleConns())
 	assert.Equal(t, int32(128), drv.Postgres.GetStatementCacheCapacity())
 	assert.Equal(t, int32(12), drv.Sql.GetMaxOpenConns())
+}
+
+func TestLoadRunConfig_TypedParameterScopes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+		"version": "1",
+		"run": {"executor":"constant-vus","vus":3,"duration":"2s","future":true},
+		"params": {"scaleFactor":1.5,"enabled":false,"label":"sample"}
+	}`), 0o600))
+
+	cfg, loaded, err := runner.LoadRunConfig(path)
+	require.NoError(t, err)
+	assert.True(t, loaded)
+	assert.JSONEq(t, `"constant-vus"`, string(cfg.Run["executor"]))
+	assert.JSONEq(t, `3`, string(cfg.Run["vus"]))
+	assert.JSONEq(t, `true`, string(cfg.Run["future"]))
+	assert.JSONEq(t, `1.5`, string(cfg.Params["scaleFactor"]))
+	assert.JSONEq(t, `false`, string(cfg.Params["enabled"]))
+	assert.JSONEq(t, `"sample"`, string(cfg.Params["label"]))
+}
+
+func TestLoadRunConfig_RejectsInvalidParameterScopes(t *testing.T) {
+	tests := map[string]string{
+		"null run":            `{"run":null}`,
+		"array params":        `{"params":[]}`,
+		"duplicate run":       `{"run":{},"run":{}}`,
+		"duplicate run field": `{"run":{"vus":1,"vus":2}}`,
+		"unknown top level":   `{"unknown":{}}`,
+	}
+
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.json")
+			require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+			_, _, err := runner.LoadRunConfig(path)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestBuildProbeEnvFromRunConfigIncludesFileDriver(t *testing.T) {

--- a/internal/runner/config_file_test.go
+++ b/internal/runner/config_file_test.go
@@ -152,6 +152,7 @@ func TestLoadRunConfig_RejectsInvalidParameterScopes(t *testing.T) {
 		"duplicate run":       `{"run":{},"run":{}}`,
 		"duplicate run field": `{"run":{"vus":1,"vus":2}}`,
 		"unknown top level":   `{"unknown":{}}`,
+		"trailing data":       `{"version":"1"} {"version":"2"}`,
 	}
 
 	for name, content := range tests {

--- a/internal/runner/driver_preset.go
+++ b/internal/runner/driver_preset.go
@@ -318,6 +318,27 @@ func NewDriverCLIConfigFromJSON(raw string) (DriverCLIConfig, error) {
 // DriverCLIConfigs holds parsed driver configurations indexed by driver number.
 type DriverCLIConfigs map[int]*DriverCLIConfig
 
+// DriverCLIConfigsFromFile converts frozen config-file drivers into mutable CLI configs.
+func DriverCLIConfigsFromFile(fileDrivers map[uint32]*stroppy.DriverRunConfig) (DriverCLIConfigs, error) {
+	configs := make(DriverCLIConfigs, len(fileDrivers))
+
+	for idx, fileConfig := range fileDrivers {
+		data, err := (protojson.MarshalOptions{EmitUnpopulated: false}).Marshal(fileConfig)
+		if err != nil {
+			return nil, fmt.Errorf("serialize config file driver %d: %w", idx, err)
+		}
+
+		config, err := NewDriverCLIConfigFromJSON(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("convert config file driver %d: %w", idx, err)
+		}
+
+		configs[int(idx)] = &config
+	}
+
+	return configs, nil
+}
+
 // ToEnvVars serializes all driver configs to STROPPY_DRIVER_N=<json> pairs.
 // If a STROPPY_DRIVER_N env var is already set in the process environment,
 // the CLI-composed value is skipped — user-set env takes precedence.

--- a/internal/runner/run_config_merge.go
+++ b/internal/runner/run_config_merge.go
@@ -1,18 +1,14 @@
 package runner
 
-import (
-	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
-)
-
 // EffectiveScript returns the script to use.
 // CLI positional arg takes precedence over config file.
-func EffectiveScript(cliScript string, cfg *stroppy.RunConfig) string {
+func EffectiveScript(cliScript string, cfg *LoadedConfig) string {
 	if cliScript != "" {
 		return cliScript
 	}
 
-	if cfg != nil && cfg.Script != nil {
-		return cfg.GetScript()
+	if cfg != nil && cfg.RunConfig != nil && cfg.RunConfig.Script != nil {
+		return cfg.RunConfig.GetScript()
 	}
 
 	return ""
@@ -20,13 +16,13 @@ func EffectiveScript(cliScript string, cfg *stroppy.RunConfig) string {
 
 // EffectiveSQL returns the SQL arg to use.
 // CLI positional arg takes precedence over config file.
-func EffectiveSQL(cliSQL string, cfg *stroppy.RunConfig) string {
+func EffectiveSQL(cliSQL string, cfg *LoadedConfig) string {
 	if cliSQL != "" {
 		return cliSQL
 	}
 
-	if cfg != nil && cfg.Sql != nil {
-		return cfg.GetSql()
+	if cfg != nil && cfg.RunConfig != nil && cfg.RunConfig.Sql != nil {
+		return cfg.RunConfig.GetSql()
 	}
 
 	return ""
@@ -34,13 +30,13 @@ func EffectiveSQL(cliSQL string, cfg *stroppy.RunConfig) string {
 
 // EffectiveSteps returns the step allowlist.
 // CLI --steps fully overrides config file steps.
-func EffectiveSteps(cliSteps []string, cfg *stroppy.RunConfig) []string {
+func EffectiveSteps(cliSteps []string, cfg *LoadedConfig) []string {
 	if len(cliSteps) > 0 {
 		return cliSteps
 	}
 
-	if cfg != nil {
-		return cfg.GetSteps()
+	if cfg != nil && cfg.RunConfig != nil {
+		return cfg.RunConfig.GetSteps()
 	}
 
 	return nil
@@ -48,13 +44,13 @@ func EffectiveSteps(cliSteps []string, cfg *stroppy.RunConfig) []string {
 
 // EffectiveNoSteps returns the step blocklist.
 // CLI --no-steps fully overrides config file no_steps.
-func EffectiveNoSteps(cliNoSteps []string, cfg *stroppy.RunConfig) []string {
+func EffectiveNoSteps(cliNoSteps []string, cfg *LoadedConfig) []string {
 	if len(cliNoSteps) > 0 {
 		return cliNoSteps
 	}
 
-	if cfg != nil {
-		return cfg.GetNoSteps()
+	if cfg != nil && cfg.RunConfig != nil {
+		return cfg.RunConfig.GetNoSteps()
 	}
 
 	return nil

--- a/internal/runner/run_config_merge_test.go
+++ b/internal/runner/run_config_merge_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestEffectiveScript(t *testing.T) {
-	cfg := &stroppy.RunConfig{Script: proto.String("tpcc")}
+	cfg := &runner.LoadedConfig{RunConfig: &stroppy.RunConfig{Script: proto.String("tpcc")}}
 
 	assert.Equal(t, "custom.ts", runner.EffectiveScript("custom.ts", cfg))
 	assert.Equal(t, "tpcc", runner.EffectiveScript("", cfg))
@@ -19,7 +19,7 @@ func TestEffectiveScript(t *testing.T) {
 }
 
 func TestEffectiveSteps(t *testing.T) {
-	cfg := &stroppy.RunConfig{Steps: []string{"create_schema", "load"}}
+	cfg := &runner.LoadedConfig{RunConfig: &stroppy.RunConfig{Steps: []string{"create_schema", "load"}}}
 
 	assert.Equal(t, []string{"only_this"}, runner.EffectiveSteps([]string{"only_this"}, cfg))
 	assert.Equal(t, []string{"create_schema", "load"}, runner.EffectiveSteps(nil, cfg))

--- a/internal/workloads/execute_sql/execute_sql.go
+++ b/internal/workloads/execute_sql/execute_sql.go
@@ -20,25 +20,30 @@ var (
 )
 
 type workload struct {
-	sql    *bench.SQL
-	names  []string
-	preset string
+	sql     *bench.SQL
+	names   []string
+	preset  string
+	sqlFile string
 }
 
 func init() { bench.Register(func() bench.Workload { return &workload{} }) }
 
 func (*workload) Name() string { return "execute_sql" }
 
-func (*workload) Define(*bench.Def) error { return nil }
+func (w *workload) Define(d *bench.Def) error {
+	w.sqlFile = d.Param.String("sql-file", "", "SQL file to execute.").Value()
+
+	return nil
+}
 
 func (w *workload) Setup(_ context.Context, b *bench.Bench) error {
 	w.preset = "execute_sql"
 	if body := bench.Env("STROPPY_SQL_BODY", ""); body != "" {
 		w.sql = bench.ParseSQL(body)
-	} else if file := bench.Env("SQL_FILE", ""); file != "" {
-		s, err := bench.LoadSQL(w.preset, file)
+	} else if w.sqlFile != "" {
+		s, err := bench.LoadSQL(w.preset, w.sqlFile)
 		if err != nil {
-			return fmt.Errorf("execute_sql: load %s: %w", file, err)
+			return fmt.Errorf("execute_sql: load %s: %w", w.sqlFile, err)
 		}
 
 		w.sql = s

--- a/internal/workloads/execute_sql/execute_sql.go
+++ b/internal/workloads/execute_sql/execute_sql.go
@@ -25,9 +25,11 @@ type workload struct {
 	preset string
 }
 
-func init() { bench.Register(&workload{}) }
+func init() { bench.Register(func() bench.Workload { return &workload{} }) }
 
 func (*workload) Name() string { return "execute_sql" }
+
+func (*workload) Define(*bench.Def) error { return nil }
 
 func (w *workload) Setup(_ context.Context, b *bench.Bench) error {
 	w.preset = "execute_sql"

--- a/internal/workloads/params_test.go
+++ b/internal/workloads/params_test.go
@@ -1,0 +1,175 @@
+package workloads
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stroppy-io/stroppy/pkg/bench"
+)
+
+func TestBuiltInWorkloadParameterSchemas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want []bench.ParamSchema
+	}{
+		{"execute_sql", []bench.ParamSchema{
+			param("sql-file", bench.ParamTypeString, "", "SQL_FILE", "sqlFile"),
+		}},
+		{"simple", []bench.ParamSchema{}},
+		{"tpcb/tx", []bench.ParamSchema{
+			param("load-workers", bench.ParamTypeInt, 1, "LOAD_WORKERS", "loadWorkers"),
+			param("retry-attempts", bench.ParamTypeInt, 3, "RETRY_ATTEMPTS", "retryAttempts"),
+			param("scale-factor", bench.ParamTypeInt, 1, "SCALE_FACTOR", "scaleFactor"),
+			param("sql-file", bench.ParamTypeString, "", "SQL_FILE", "sqlFile"),
+			param("tx-isolation", bench.ParamTypeString, "", "TX_ISOLATION", "txIsolation"),
+		}},
+		{"tpcc/procs", tpccParamSchema()},
+		{"tpcc/tx", tpccParamSchema()},
+		{"tpcds", []bench.ParamSchema{
+			param("load-workers", bench.ParamTypeInt, 0, "LOAD_WORKERS", "loadWorkers"),
+			param("pg-unlogged", bench.ParamTypeBool, false, "PG_UNLOGGED", "pgUnlogged"),
+			param("query-seed", bench.ParamTypeInt, 19620718, "QUERY_SEED", "querySeed"),
+			param("query-stream", bench.ParamTypeInt, 0, "QUERY_STREAM", "queryStream"),
+			param("scale-factor", bench.ParamTypeFloat64, float64(1), "SCALE_FACTOR", "scaleFactor"),
+			param("schema-file", bench.ParamTypeString, "", "SCHEMA_FILE", "schemaFile"),
+			param("sql-file", bench.ParamTypeString, "", "SQL_FILE", "sqlFile"),
+			param("streams", bench.ParamTypeInt, 1, "STREAMS", "streams"),
+			param("validate-force", bench.ParamTypeBool, false, "VALIDATE_FORCE", "validateForce"),
+			param("ydb-store-mode", bench.ParamTypeString, "column", "YDB_STORE_MODE", "ydbStoreMode"),
+		}},
+		{"tpch/tx", []bench.ParamSchema{
+			param("load-workers", bench.ParamTypeInt, 0, "LOAD_WORKERS", "loadWorkers"),
+			param("pg-unlogged", bench.ParamTypeBool, false, "PG_UNLOGGED", "pgUnlogged"),
+			param("scale-factor", bench.ParamTypeFloat64, float64(1), "SCALE_FACTOR", "scaleFactor"),
+			param("sql-file", bench.ParamTypeString, "", "SQL_FILE", "sqlFile"),
+			param("ydb-store-mode", bench.ParamTypeString, "column", "YDB_STORE_MODE", "ydbStoreMode"),
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			description, err := bench.Describe(tt.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := workloadParams(description.Params)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parameter schema mismatch\n got: %#v\nwant: %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuiltInWorkloadsDoNotReadPublicEnvDirectly(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if entry.IsDir() || strings.HasSuffix(path, "_test.go") || filepath.Ext(path) != ".go" {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || len(call.Args) == 0 || !isEnvRead(selector.Sel.Name) {
+				return true
+			}
+
+			pkg, ok := selector.X.(*ast.Ident)
+			if !ok || pkg.Name != "bench" {
+				return true
+			}
+
+			literal, ok := call.Args[0].(*ast.BasicLit)
+			if !ok {
+				return true
+			}
+
+			name, err := strconv.Unquote(literal.Value)
+			if err == nil && name != "STROPPY_SQL_BODY" {
+				t.Errorf("%s reads public workload knob %s through bench.%s", path, name, selector.Sel.Name)
+			}
+
+			return true
+		})
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func isEnvRead(name string) bool {
+	return name == "Env" || name == "EnvInt" || name == "EnvFloat"
+}
+
+func tpccParamSchema() []bench.ParamSchema {
+	return []bench.ParamSchema{
+		param("load-items", bench.ParamTypeBool, true, "LOAD_ITEMS", "loadItems"),
+		param("load-workers", bench.ParamTypeInt, 1, "LOAD_WORKERS", "loadWorkers"),
+		param("pacing", bench.ParamTypeBool, false, "PACING", "pacing"),
+		param("pg-unlogged", bench.ParamTypeBool, false, "PG_UNLOGGED", "pgUnlogged"),
+		param("retry-attempts", bench.ParamTypeInt, 3, "RETRY_ATTEMPTS", "retryAttempts"),
+		param("scale-factor", bench.ParamTypeInt, 1, "SCALE_FACTOR", "scaleFactor", "WAREHOUSES"),
+		param("sql-file", bench.ParamTypeString, "", "SQL_FILE", "sqlFile"),
+		param("tx-isolation", bench.ParamTypeString, "", "TX_ISOLATION", "txIsolation"),
+		param("warehouse-start", bench.ParamTypeInt, 1, "WAREHOUSE_START", "warehouseStart"),
+	}
+}
+
+func param(
+	name string,
+	typ bench.ParamType,
+	defaultValue any,
+	env, config string,
+	aliases ...string,
+) bench.ParamSchema {
+	return bench.ParamSchema{
+		Name: name, Type: typ, Default: defaultValue, Env: env,
+		LegacyEnvAliases: aliases, Config: config,
+	}
+}
+
+func workloadParams(params []bench.ParamSchema) []bench.ParamSchema {
+	standard := map[string]bool{"duration": true, "executor": true, "iterations": true, "vus": true}
+
+	workload := make([]bench.ParamSchema, 0, len(params))
+	for _, schema := range params {
+		if standard[schema.Name] {
+			continue
+		}
+
+		schema.Description = ""
+		workload = append(workload, schema)
+	}
+
+	return workload
+}

--- a/internal/workloads/params_test.go
+++ b/internal/workloads/params_test.go
@@ -153,17 +153,16 @@ func param(
 	aliases ...string,
 ) bench.ParamSchema {
 	return bench.ParamSchema{
-		Name: name, Type: typ, Default: defaultValue, Env: env,
+		Name: name, Flag: "--" + name, Scope: bench.ParamScopeWorkload,
+		Type: typ, Default: defaultValue, Env: env,
 		LegacyEnvAliases: aliases, Config: config,
 	}
 }
 
 func workloadParams(params []bench.ParamSchema) []bench.ParamSchema {
-	standard := map[string]bool{"duration": true, "executor": true, "iterations": true, "vus": true}
-
 	workload := make([]bench.ParamSchema, 0, len(params))
 	for _, schema := range params {
-		if standard[schema.Name] {
+		if schema.Scope != bench.ParamScopeWorkload {
 			continue
 		}
 

--- a/internal/workloads/params_test.go
+++ b/internal/workloads/params_test.go
@@ -133,7 +133,13 @@ func isEnvRead(name string) bool {
 
 func tpccParamSchema() []bench.ParamSchema {
 	return []bench.ParamSchema{
-		param("load-items", bench.ParamTypeBool, true, "LOAD_ITEMS", "loadItems"),
+		derivedParam(
+			"load-items",
+			bench.ParamTypeBool,
+			"LOAD_ITEMS",
+			"loadItems",
+			"true when warehouse-start is 1; false otherwise",
+		),
 		param("load-workers", bench.ParamTypeInt, 1, "LOAD_WORKERS", "loadWorkers"),
 		param("pacing", bench.ParamTypeBool, false, "PACING", "pacing"),
 		param("pg-unlogged", bench.ParamTypeBool, false, "PG_UNLOGGED", "pgUnlogged"),
@@ -157,6 +163,17 @@ func param(
 		Type: typ, Default: defaultValue, Env: env,
 		LegacyEnvAliases: aliases, Config: config,
 	}
+}
+
+func derivedParam(
+	name string,
+	typ bench.ParamType,
+	env, config, defaultDescription string,
+) bench.ParamSchema {
+	schema := param(name, typ, nil, env, config)
+	schema.DefaultDescription = defaultDescription
+
+	return schema
 }
 
 func workloadParams(params []bench.ParamSchema) []bench.ParamSchema {

--- a/internal/workloads/simple/simple.go
+++ b/internal/workloads/simple/simple.go
@@ -30,9 +30,15 @@ type workload struct {
 	pick *rand.Rand
 }
 
-func init() { bench.Register(&workload{pick: rand.New(rand.NewPCG(demoSeed^1, 0))}) } //nolint:gosec // G404: data RNG
+func init() {
+	bench.Register(func() bench.Workload {
+		return &workload{pick: rand.New(rand.NewPCG(demoSeed^1, 0))} //nolint:gosec // G404: data RNG
+	})
+}
 
 func (*workload) Name() string { return "simple" }
+
+func (*workload) Define(*bench.Def) error { return nil }
 
 func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	if err := b.Step("drop_schema", func() error {

--- a/internal/workloads/tpcb/params_test.go
+++ b/internal/workloads/tpcb/params_test.go
@@ -1,0 +1,62 @@
+package tpcb
+
+import (
+	"testing"
+
+	"github.com/stroppy-io/stroppy/pkg/bench"
+)
+
+func TestLoadWorkersReachInsertRequests(t *testing.T) {
+	const workers = 7
+
+	requests := map[string]int{
+		"branches": branchesRequest(1, workers).Workers,
+		"tellers":  tellersRequest(1, workers).Workers,
+		"accounts": accountsRequest(1, workers).Workers,
+	}
+	for name, got := range requests {
+		if got != workers {
+			t.Errorf("%s workers = %d, want %d", name, got, workers)
+		}
+	}
+}
+
+func TestDriverDerivedDefaults(t *testing.T) {
+	isolationTests := []struct {
+		driver bench.DriverTypeName
+		want   bench.TxIsolationName
+	}{
+		{bench.DriverPostgres, bench.IsoReadCommitted},
+		{bench.DriverMySQL, bench.IsoReadCommitted},
+		{bench.DriverPicodata, bench.IsoNone},
+		{bench.DriverYDB, bench.IsoSerializable},
+	}
+	for _, tt := range isolationTests {
+		if got := resolveIsolation(tt.driver, ""); got != tt.want {
+			t.Errorf("resolveIsolation(%s) = %s, want %s", tt.driver, got, tt.want)
+		}
+	}
+
+	if got := resolveIsolation(bench.DriverPostgres, bench.IsoSerializable); got != bench.IsoSerializable {
+		t.Fatalf("isolation override = %s, want %s", got, bench.IsoSerializable)
+	}
+
+	sqlTests := []struct {
+		driver bench.DriverTypeName
+		want   string
+	}{
+		{bench.DriverPostgres, "pg.sql"},
+		{bench.DriverMySQL, "mysql.sql"},
+		{bench.DriverPicodata, "pico.sql"},
+		{bench.DriverYDB, "ydb.sql"},
+	}
+	for _, tt := range sqlTests {
+		if got := sqlFile(tt.driver, ""); got != tt.want {
+			t.Errorf("sqlFile(%s) = %s, want %s", tt.driver, got, tt.want)
+		}
+	}
+
+	if got := sqlFile(bench.DriverPostgres, "custom.sql"); got != "custom.sql" {
+		t.Fatalf("SQL override = %s, want custom.sql", got)
+	}
+}

--- a/internal/workloads/tpcb/tpcb.go
+++ b/internal/workloads/tpcb/tpcb.go
@@ -35,10 +35,13 @@ const (
 )
 
 type workload struct {
-	sql        *bench.SQL
-	driverType bench.DriverTypeName
-	iso        bench.TxIsolationName
-	scale      int64
+	sql           *bench.SQL
+	driverType    bench.DriverTypeName
+	iso           bench.TxIsolationName
+	scale         int64
+	retryAttempts int
+	sqlFile       string
+	loadWorkers   int
 
 	retryMetricOnce sync.Once
 	retryMetric     *bench.Metric
@@ -51,15 +54,22 @@ func init() { bench.Register(func() bench.Workload { return &workload{} }) }
 
 func (*workload) Name() string { return "tpcb/tx" }
 
-func (*workload) Define(*bench.Def) error { return nil }
+func (w *workload) Define(d *bench.Def) error {
+	w.scale = int64(max(d.Param.Int("scale-factor", 1, "TPC-B scale factor.").Value(), 1))
+	w.retryAttempts = d.Param.Int("retry-attempts", 3, "Maximum transaction attempts.").Value()
+	w.iso = bench.TxIsolationName(d.Param.String("tx-isolation", "", "Transaction isolation override.").Value())
+	w.sqlFile = d.Param.String("sql-file", "", "SQL dialect file override.").Value()
+	w.loadWorkers = d.Param.Int("load-workers", 1, "Workers used to load each table.").Value()
+	w.loadWorkers = max(w.loadWorkers, 1)
+
+	return nil
+}
 
 func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	w.driverType = b.DriverTypeName()
 
-	w.scale = int64(max(bench.EnvInt("SCALE_FACTOR", 1), 1))
-
-	w.iso = resolveIsolation(w.driverType)
-	w.sql = mustLoadSQL(w.driverType)
+	w.iso = resolveIsolation(w.driverType, w.iso)
+	w.sql = mustLoadSQL(w.driverType, w.sqlFile)
 
 	runSection := func(name string) error {
 		for _, q := range w.sql.Section(name) {
@@ -78,15 +88,15 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 		{"drop_schema", func() error { return runSection("drop_schema") }},
 		{"create_schema", func() error { return runSection("create_schema") }},
 		{"load_data", func() error {
-			if _, err := b.Insert(ctx, branchesRequest(w.scale)); err != nil {
+			if _, err := b.Insert(ctx, branchesRequest(w.scale, w.loadWorkers)); err != nil {
 				return err
 			}
 
-			if _, err := b.Insert(ctx, tellersRequest(w.scale)); err != nil {
+			if _, err := b.Insert(ctx, tellersRequest(w.scale, w.loadWorkers)); err != nil {
 				return err
 			}
 
-			if _, err := b.Insert(ctx, accountsRequest(w.scale)); err != nil {
+			if _, err := b.Insert(ctx, accountsRequest(w.scale, w.loadWorkers)); err != nil {
 				return err
 			}
 
@@ -104,7 +114,7 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 
 	b.StepBegin("workload")
 	w.retryPolicy = b.TxRetryPolicy(bench.TxRetryPolicyOptions{
-		MaxAttempts: bench.EnvInt("RETRY_ATTEMPTS", 3),
+		MaxAttempts: w.retryAttempts,
 		OnRetry:     func(int, error, bench.RetryDecision) { w.retryCounter(b).Add(1) },
 	})
 
@@ -167,9 +177,9 @@ func branches(s int64) int64 { return s }
 func tellers(s int64) int64  { return 10 * s }
 func accounts(s int64) int64 { return 100_000 * s }
 
-func resolveIsolation(dt bench.DriverTypeName) bench.TxIsolationName {
-	if v := bench.Env("TX_ISOLATION", ""); v != "" {
-		return bench.TxIsolationName(v)
+func resolveIsolation(dt bench.DriverTypeName, override bench.TxIsolationName) bench.TxIsolationName {
+	if override != "" {
+		return override
 	}
 
 	switch dt {
@@ -182,9 +192,9 @@ func resolveIsolation(dt bench.DriverTypeName) bench.TxIsolationName {
 	}
 }
 
-func sqlFile(dt bench.DriverTypeName) string {
-	if v := bench.Env("SQL_FILE", ""); v != "" {
-		return v
+func sqlFile(dt bench.DriverTypeName, override string) string {
+	if override != "" {
+		return override
 	}
 
 	switch dt {
@@ -199,8 +209,8 @@ func sqlFile(dt bench.DriverTypeName) string {
 	}
 }
 
-func mustLoadSQL(dt bench.DriverTypeName) *bench.SQL {
-	s, err := bench.LoadSQL(preset, sqlFile(dt))
+func mustLoadSQL(dt bench.DriverTypeName, override string) *bench.SQL {
+	s, err := bench.LoadSQL(preset, sqlFile(dt, override))
 	if err != nil {
 		panic(err)
 	}
@@ -256,43 +266,33 @@ func (w *workload) retryCounter(b *bench.Bench) *bench.Metric {
 
 // --- typed insert requests (plain Go row formulas) ---
 
-// loadWorkers returns the per-table worker fan-out from LOAD_WORKERS, or 1
-// when unset. Replaces the legacy workers() *dgproto.Parallelism helper.
-func loadWorkers() int {
-	if n := bench.EnvInt("LOAD_WORKERS", 0); n > 0 {
-		return n
-	}
-
-	return 1
-}
-
 // branchesRequest builds the typed insert request for pgbench_branches.
 // bid is the 1-based row counter, bbalance is 0, filler is a fixed-width
 // [A-Za-z] string. Preserves the legacy table name, method (NATIVE), and
 // seedBranches derivation.
-func branchesRequest(scale int64) *driver.InsertRequest {
+func branchesRequest(scale int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedBranches)
 
 	return &driver.InsertRequest{
-		Table: "pgbench_branches", Method: driver.InsertNative, Workers: loadWorkers(),
+		Table: "pgbench_branches", Method: driver.InsertNative, Workers: workers,
 		Source: branchesSource(root, branches(scale)),
 	}
 }
 
-func tellersRequest(scale int64) *driver.InsertRequest {
+func tellersRequest(scale int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedTellers)
 
 	return &driver.InsertRequest{
-		Table: "pgbench_tellers", Method: driver.InsertNative, Workers: loadWorkers(),
+		Table: "pgbench_tellers", Method: driver.InsertNative, Workers: workers,
 		Source: tellersSource(root, tellers(scale)),
 	}
 }
 
-func accountsRequest(scale int64) *driver.InsertRequest {
+func accountsRequest(scale int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedAccounts)
 
 	return &driver.InsertRequest{
-		Table: "pgbench_accounts", Method: driver.InsertNative, Workers: loadWorkers(),
+		Table: "pgbench_accounts", Method: driver.InsertNative, Workers: workers,
 		Source: accountsSource(root, accounts(scale)),
 	}
 }

--- a/internal/workloads/tpcb/tpcb.go
+++ b/internal/workloads/tpcb/tpcb.go
@@ -47,9 +47,11 @@ type workload struct {
 	vuStates sync.Map // uint64 -> *vuState
 }
 
-func init() { bench.Register(&workload{}) }
+func init() { bench.Register(func() bench.Workload { return &workload{} }) }
 
 func (*workload) Name() string { return "tpcb/tx" }
+
+func (*workload) Define(*bench.Def) error { return nil }
 
 func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	w.driverType = b.DriverTypeName()

--- a/internal/workloads/tpcc/config.go
+++ b/internal/workloads/tpcc/config.go
@@ -47,9 +47,9 @@ var (
 var txWeights = []int{45, 43, 4, 4, 4}
 
 // resolveIsolation mirrors tpcc_common: pg/mysql→repeatable_read, pico→none, ydb→serializable.
-func resolveIsolation(dt bench.DriverTypeName) bench.TxIsolationName {
-	if v := bench.Env("TX_ISOLATION", ""); v != "" {
-		return bench.TxIsolationName(v)
+func resolveIsolation(dt bench.DriverTypeName, override bench.TxIsolationName) bench.TxIsolationName {
+	if override != "" {
+		return override
 	}
 
 	switch dt {
@@ -62,9 +62,9 @@ func resolveIsolation(dt bench.DriverTypeName) bench.TxIsolationName {
 	}
 }
 
-func sqlFile(dt bench.DriverTypeName) string {
-	if v := bench.Env("SQL_FILE", ""); v != "" {
-		return v
+func sqlFile(dt bench.DriverTypeName, override string) string {
+	if override != "" {
+		return override
 	}
 
 	switch dt {
@@ -79,8 +79,8 @@ func sqlFile(dt bench.DriverTypeName) string {
 	}
 }
 
-func mustLoadSQL(dt bench.DriverTypeName) *bench.SQL {
-	s, err := bench.LoadSQL(preset, sqlFile(dt))
+func mustLoadSQL(dt bench.DriverTypeName, override string) *bench.SQL {
+	s, err := bench.LoadSQL(preset, sqlFile(dt, override))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/workloads/tpcc/load.go
+++ b/internal/workloads/tpcc/load.go
@@ -3,7 +3,6 @@ package tpcc
 import (
 	"time"
 
-	"github.com/stroppy-io/stroppy/pkg/bench"
 	"github.com/stroppy-io/stroppy/pkg/driver"
 	"github.com/stroppy-io/stroppy/pkg/gen"
 )
@@ -124,22 +123,12 @@ const (
 	lastNameCSalt uint64 = 0xC1A57
 )
 
-// loadWorkersCount returns the per-table worker fan-out from LOAD_WORKERS, or
-// 1 when unset. The typed counterpart of the legacy workers() helper.
-func loadWorkersCount() int {
-	if n := bench.EnvInt("LOAD_WORKERS", 0); n > 0 {
-		return n
-	}
-
-	return 1
-}
-
 // warehouseRequest builds the typed insert request for the warehouse table.
-func warehouseRequest(scale, warehouseStart int64) *driver.InsertRequest {
+func warehouseRequest(scale, warehouseStart int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedWarehouse)
 
 	return &driver.InsertRequest{
-		Table: "warehouse", Method: driver.InsertNative, Workers: loadWorkersCount(),
+		Table: "warehouse", Method: driver.InsertNative, Workers: workers,
 		Source: warehouseSource(root, scale, warehouseStart),
 	}
 }
@@ -217,11 +206,11 @@ func varFields(d gen.Domain, name string) (length, content gen.Field) {
 }
 
 // districtRequest builds the typed insert request for the district table.
-func districtRequest(scale, warehouseStart int64) *driver.InsertRequest {
+func districtRequest(scale, warehouseStart int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedDistrict)
 
 	return &driver.InsertRequest{
-		Table: "district", Method: driver.InsertNative, Workers: loadWorkersCount(),
+		Table: "district", Method: driver.InsertNative, Workers: workers,
 		Source: districtSource(root, scale, warehouseStart),
 	}
 }
@@ -299,11 +288,11 @@ func districtSource(root gen.Root, scale, warehouseStart int64) *gen.IndexedSour
 }
 
 // customerRequest builds the typed insert request for the customer table.
-func customerRequest(scale, warehouseStart, loadDays int64) *driver.InsertRequest {
+func customerRequest(scale, warehouseStart, loadDays int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedCustomer)
 
 	return &driver.InsertRequest{
-		Table: "customer", Method: driver.InsertNative, Workers: loadWorkersCount(),
+		Table: "customer", Method: driver.InsertNative, Workers: workers,
 		Source: customerSource(root, scale, warehouseStart, loadDays),
 	}
 }
@@ -451,11 +440,11 @@ func customerSource(root gen.Root, scale, warehouseStart, loadDays int64) *gen.I
 }
 
 // itemRequest builds the typed insert request for the item table.
-func itemRequest() *driver.InsertRequest {
+func itemRequest(workers int) *driver.InsertRequest {
 	root := gen.New(seedItem)
 
 	return &driver.InsertRequest{
-		Table: "item", Method: driver.InsertNative, Workers: loadWorkersCount(),
+		Table: "item", Method: driver.InsertNative, Workers: workers,
 		Source: itemSource(root),
 	}
 }
@@ -502,11 +491,11 @@ func itemSource(root gen.Root) *gen.IndexedSource {
 }
 
 // stockRequest builds the typed insert request for the stock table.
-func stockRequest(scale, warehouseStart int64) *driver.InsertRequest {
+func stockRequest(scale, warehouseStart int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedStock)
 
 	return &driver.InsertRequest{
-		Table: "stock", Method: driver.InsertNative, Workers: loadWorkersCount(),
+		Table: "stock", Method: driver.InsertNative, Workers: workers,
 		Source: stockSource(root, scale, warehouseStart),
 	}
 }
@@ -572,11 +561,11 @@ func stockSource(root gen.Root, scale, warehouseStart int64) *gen.IndexedSource 
 }
 
 // ordersRequest builds the typed insert request for the orders table.
-func ordersRequest(scale, warehouseStart, loadDays int64) *driver.InsertRequest {
+func ordersRequest(scale, warehouseStart, loadDays int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedOrders)
 
 	return &driver.InsertRequest{
-		Table: "orders", Method: driver.InsertNative, Workers: loadWorkersCount(),
+		Table: "orders", Method: driver.InsertNative, Workers: workers,
 		Source: ordersSource(root, scale, warehouseStart, loadDays),
 	}
 }
@@ -649,11 +638,11 @@ func ordersSource(root gen.Root, scale, warehouseStart, loadDays int64) *gen.Ind
 }
 
 // orderLineRequest builds the typed insert request for the order_line table.
-func orderLineRequest(scale, warehouseStart, loadDays int64) *driver.InsertRequest {
+func orderLineRequest(scale, warehouseStart, loadDays int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedOrderLine)
 
 	return &driver.InsertRequest{
-		Table: "order_line", Method: driver.InsertNative, Workers: loadWorkersCount(),
+		Table: "order_line", Method: driver.InsertNative, Workers: workers,
 		Source: orderLineSource(root, scale, warehouseStart, loadDays),
 	}
 }
@@ -731,11 +720,11 @@ func orderLineSource(root gen.Root, scale, warehouseStart, loadDays int64) *gen.
 
 // newOrderRequest builds the typed insert request for the new_order table.
 // perWh = ordersUndelivered * districtsPerWarehouse (9000).
-func newOrderRequest(scale, warehouseStart int64) *driver.InsertRequest {
+func newOrderRequest(scale, warehouseStart int64, workers int) *driver.InsertRequest {
 	root := gen.New(seedNewOrder)
 
 	return &driver.InsertRequest{
-		Table: "new_order", Method: driver.InsertNative, Workers: loadWorkersCount(),
+		Table: "new_order", Method: driver.InsertNative, Workers: workers,
 		Source: newOrderSource(root, scale, warehouseStart),
 	}
 }

--- a/internal/workloads/tpcc/params_test.go
+++ b/internal/workloads/tpcc/params_test.go
@@ -1,0 +1,203 @@
+package tpcc
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/stroppy-io/stroppy/pkg/bench"
+	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	"github.com/stroppy-io/stroppy/pkg/driver"
+	_ "github.com/stroppy-io/stroppy/pkg/driver/noop"
+)
+
+type parameterCaptureWorkload struct {
+	*workload
+	name     string
+	captured chan<- *workload
+}
+
+func (w *parameterCaptureWorkload) Name() string { return w.name }
+
+func (w *parameterCaptureWorkload) Setup(context.Context, *bench.Bench) error {
+	w.captured <- w.workload
+
+	return nil
+}
+
+func (*parameterCaptureWorkload) Iterate(context.Context, *bench.Bench) error  { return nil }
+func (*parameterCaptureWorkload) Teardown(context.Context, *bench.Bench) error { return nil }
+
+func TestTypedParameterCompatibility(t *testing.T) {
+	unsetEnv(
+		t,
+		"SCALE_FACTOR", "WAREHOUSES", "WAREHOUSE_START", "LOAD_ITEMS", "LOAD_WORKERS",
+		"EXECUTOR", "VUS", "ITERATIONS", "ITER", "DURATION",
+	)
+
+	const (
+		txName    = "tpcc/test-parameters-tx"
+		procsName = "tpcc/test-parameters-procs"
+	)
+
+	captured := make(chan *workload, 2)
+
+	registerCapture := func(name, variant string) {
+		bench.Register(func() bench.Workload {
+			return &parameterCaptureWorkload{
+				workload: &workload{variant: variant},
+				name:     name, captured: captured,
+			}
+		})
+	}
+	registerCapture(txName, "tx")
+	registerCapture(procsName, "procs")
+
+	tests := []struct {
+		name           string
+		workloadName   string
+		legacy         map[string]string
+		wantWarehouses int64
+	}{
+		{
+			name:           "tx accepts WAREHOUSES alias",
+			workloadName:   txName,
+			legacy:         map[string]string{"WAREHOUSES": "4"},
+			wantWarehouses: 4,
+		},
+		{
+			name:         "procs prefers projected SCALE_FACTOR",
+			workloadName: procsName,
+			legacy: map[string]string{
+				"SCALE_FACTOR": "2", "WAREHOUSES": "4",
+				"WAREHOUSE_START": "2", "LOAD_WORKERS": "0",
+			},
+			wantWarehouses: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runCapture(t, tt.workloadName, captured, bench.ParamInputs{LegacyEnv: tt.legacy})
+			if got.warehouses != tt.wantWarehouses {
+				t.Fatalf("warehouses = %d, want %d", got.warehouses, tt.wantWarehouses)
+			}
+
+			if tt.workloadName == procsName {
+				if got.loadItems {
+					t.Fatal("loadItems = true, want dynamic default false for warehouse-start 2")
+				}
+
+				if got.loadWorkers != 1 {
+					t.Fatalf("loadWorkers = %d, want normalized 1", got.loadWorkers)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadWorkersReachInsertRequests(t *testing.T) {
+	const workers = 7
+
+	requests := map[string]*driver.InsertRequest{
+		"warehouse":  warehouseRequest(1, 1, workers),
+		"district":   districtRequest(1, 1, workers),
+		"customer":   customerRequest(1, 1, 1, workers),
+		"item":       itemRequest(workers),
+		"stock":      stockRequest(1, 1, workers),
+		"orders":     ordersRequest(1, 1, 1, workers),
+		"order_line": orderLineRequest(1, 1, 1, workers),
+		"new_order":  newOrderRequest(1, 1, workers),
+	}
+
+	for name, request := range requests {
+		if request.Workers != workers {
+			t.Errorf("%s workers = %d, want %d", name, request.Workers, workers)
+		}
+	}
+}
+
+func TestDriverDerivedDefaults(t *testing.T) {
+	isolationTests := []struct {
+		driver bench.DriverTypeName
+		want   bench.TxIsolationName
+	}{
+		{bench.DriverPostgres, bench.IsoRepeatableRead},
+		{bench.DriverMySQL, bench.IsoRepeatableRead},
+		{bench.DriverPicodata, bench.IsoNone},
+		{bench.DriverYDB, bench.IsoSerializable},
+	}
+	for _, tt := range isolationTests {
+		if got := resolveIsolation(tt.driver, ""); got != tt.want {
+			t.Errorf("resolveIsolation(%s) = %s, want %s", tt.driver, got, tt.want)
+		}
+	}
+
+	if got := resolveIsolation(bench.DriverPostgres, bench.IsoSerializable); got != bench.IsoSerializable {
+		t.Fatalf("isolation override = %s, want %s", got, bench.IsoSerializable)
+	}
+
+	sqlTests := []struct {
+		driver bench.DriverTypeName
+		want   string
+	}{
+		{bench.DriverPostgres, "pg.sql"},
+		{bench.DriverMySQL, "mysql.sql"},
+		{bench.DriverPicodata, "pico.sql"},
+		{bench.DriverYDB, "ydb.sql"},
+	}
+	for _, tt := range sqlTests {
+		if got := sqlFile(tt.driver, ""); got != tt.want {
+			t.Errorf("sqlFile(%s) = %s, want %s", tt.driver, got, tt.want)
+		}
+	}
+
+	if got := sqlFile(bench.DriverPostgres, "custom.sql"); got != "custom.sql" {
+		t.Fatalf("SQL override = %s, want custom.sql", got)
+	}
+}
+
+func runCapture(
+	t *testing.T,
+	name string,
+	captured <-chan *workload,
+	inputs bench.ParamInputs,
+) *workload {
+	t.Helper()
+
+	err := bench.Run(
+		context.Background(),
+		name,
+		map[int]*stroppy.DriverConfig{0: {DriverType: stroppy.DriverConfig_DRIVER_TYPE_NOOP}},
+		nil,
+		inputs,
+		zap.NewNop(),
+		&bench.MetricsConfig{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return <-captured
+}
+
+func unsetEnv(t *testing.T, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		value, present := os.LookupEnv(name)
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(name, value)
+			} else {
+				_ = os.Unsetenv(name)
+			}
+		})
+	}
+}

--- a/internal/workloads/tpcc/tpcc.go
+++ b/internal/workloads/tpcc/tpcc.go
@@ -38,12 +38,16 @@ type workload struct {
 	sql     *bench.SQL
 	variant string // "tx" (DML steps) or "procs" (stored procedures)
 
-	driverType   bench.DriverTypeName
-	iso          bench.TxIsolationName
-	isPicodata   bool
-	isYdb        bool
-	hasReturning bool
-	pacing       bool
+	driverType    bench.DriverTypeName
+	iso           bench.TxIsolationName
+	isPicodata    bool
+	isYdb         bool
+	hasReturning  bool
+	pacing        bool
+	pgUnlogged    bool
+	retryAttempts int
+	sqlFile       string
+	loadWorkers   int
 
 	warehouses     int64
 	warehouseStart int64
@@ -73,7 +77,24 @@ func init() {
 
 func (w *workload) Name() string { return "tpcc/" + w.variant }
 
-func (*workload) Define(*bench.Def) error { return nil }
+func (w *workload) Define(d *bench.Def) error {
+	warehouses := d.Param.Int(
+		"scale-factor", 1, "Number of warehouses.", bench.LegacyEnvAliases("WAREHOUSES"),
+	).Value()
+	w.warehouses = int64(max(warehouses, 1))
+	w.warehouseStart = int64(d.Param.Int("warehouse-start", 1, "First warehouse ID.").Value())
+	w.wIDMax = w.warehouseStart + w.warehouses - 1
+	w.loadItems = d.Param.Bool("load-items", w.warehouseStart == 1, "Load the shared item table.").Value()
+	w.pacing = d.Param.Bool("pacing", false, "Apply TPC-C keying and think times.").Value()
+	w.retryAttempts = d.Param.Int("retry-attempts", 3, "Maximum transaction attempts.").Value()
+	w.pgUnlogged = d.Param.Bool("pg-unlogged", false, "Use unlogged PostgreSQL tables while loading.").Value()
+	w.iso = bench.TxIsolationName(d.Param.String("tx-isolation", "", "Transaction isolation override.").Value())
+	w.sqlFile = d.Param.String("sql-file", "", "SQL dialect file override.").Value()
+	w.loadWorkers = d.Param.Int("load-workers", 1, "Workers used to load each table.").Value()
+	w.loadWorkers = max(w.loadWorkers, 1)
+
+	return nil
+}
 
 // renderDDL expands the ydb.sql {partition_keys}/{partition_count} tablet-split
 // placeholders from the warehouse range (one tablet per warehouse in
@@ -109,10 +130,10 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	}
 
 	w.initConfig()
-	useUnlogged := bench.Env("PG_UNLOGGED", "false") == "true" && w.driverType == bench.DriverPostgres
+	useUnlogged := w.pgUnlogged && w.driverType == bench.DriverPostgres
 	w.m = w.initMetrics(b)
 	w.retryPolicy = b.TxRetryPolicy(bench.TxRetryPolicyOptions{
-		MaxAttempts: bench.EnvInt("RETRY_ATTEMPTS", 3),
+		MaxAttempts: w.retryAttempts,
 		OnRetry:     func(int, error, bench.RetryDecision) { w.m.retryAttempts.Add(1) },
 	})
 
@@ -183,18 +204,10 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	return nil
 }
 
-// initConfig reads env-driven workload tuning into w fields.
+// initConfig resolves driver-specific workload configuration.
 func (w *workload) initConfig() {
-	w.warehouses = max(int64(bench.EnvInt("SCALE_FACTOR", bench.EnvInt("WAREHOUSES", 1))), 1)
-	w.warehouseStart = int64(bench.EnvInt("WAREHOUSE_START", 1))
-	w.wIDMax = w.warehouseStart + w.warehouses - 1
-
-	defLoadItems := w.warehouseStart == 1
-	w.loadItems = bench.Env("LOAD_ITEMS", boolStr(defLoadItems)) == "true"
-
-	w.pacing = bench.Env("PACING", "false") == "true"
-	w.iso = resolveIsolation(w.driverType)
-	w.sql = mustLoadSQL(w.driverType)
+	w.iso = resolveIsolation(w.driverType, w.iso)
+	w.sql = mustLoadSQL(w.driverType, w.sqlFile)
 	w.isPicodata = w.driverType == bench.DriverPicodata
 	w.isYdb = w.driverType == bench.DriverYDB
 	w.hasReturning = w.driverType == bench.DriverPostgres || w.driverType == bench.DriverYDB
@@ -228,37 +241,37 @@ func (w *workload) initMetrics(b *bench.Bench) *metrics {
 // loadData loads warehouse, district, customer, item, stock, orders,
 // order_line, and new_order through typed insert requests.
 func (w *workload) loadData(ctx context.Context, b *bench.Bench, loadDays int64) error {
-	if _, err := b.Insert(ctx, warehouseRequest(w.warehouses, w.warehouseStart)); err != nil {
+	if _, err := b.Insert(ctx, warehouseRequest(w.warehouses, w.warehouseStart, w.loadWorkers)); err != nil {
 		return err
 	}
 
-	if _, err := b.Insert(ctx, districtRequest(w.warehouses, w.warehouseStart)); err != nil {
+	if _, err := b.Insert(ctx, districtRequest(w.warehouses, w.warehouseStart, w.loadWorkers)); err != nil {
 		return err
 	}
 
-	if _, err := b.Insert(ctx, customerRequest(w.warehouses, w.warehouseStart, loadDays)); err != nil {
+	if _, err := b.Insert(ctx, customerRequest(w.warehouses, w.warehouseStart, loadDays, w.loadWorkers)); err != nil {
 		return err
 	}
 
 	if w.loadItems {
-		if _, err := b.Insert(ctx, itemRequest()); err != nil {
+		if _, err := b.Insert(ctx, itemRequest(w.loadWorkers)); err != nil {
 			return err
 		}
 	}
 
-	if _, err := b.Insert(ctx, stockRequest(w.warehouses, w.warehouseStart)); err != nil {
+	if _, err := b.Insert(ctx, stockRequest(w.warehouses, w.warehouseStart, w.loadWorkers)); err != nil {
 		return err
 	}
 
-	if _, err := b.Insert(ctx, ordersRequest(w.warehouses, w.warehouseStart, loadDays)); err != nil {
+	if _, err := b.Insert(ctx, ordersRequest(w.warehouses, w.warehouseStart, loadDays, w.loadWorkers)); err != nil {
 		return err
 	}
 
-	if _, err := b.Insert(ctx, orderLineRequest(w.warehouses, w.warehouseStart, loadDays)); err != nil {
+	if _, err := b.Insert(ctx, orderLineRequest(w.warehouses, w.warehouseStart, loadDays, w.loadWorkers)); err != nil {
 		return err
 	}
 
-	if _, err := b.Insert(ctx, newOrderRequest(w.warehouses, w.warehouseStart)); err != nil {
+	if _, err := b.Insert(ctx, newOrderRequest(w.warehouses, w.warehouseStart, w.loadWorkers)); err != nil {
 		return err
 	}
 
@@ -1253,14 +1266,6 @@ func toStr(v any) string {
 func fmtAmount(amount float64) string {
 	// tx.ts used amount.toFixed(2) on the float draw; mirror the 2-decimal form.
 	return fmt.Sprintf("%.2f", amount)
-}
-
-func boolStr(b bool) string {
-	if b {
-		return "true"
-	}
-
-	return "false"
 }
 
 func sleepSeconds(s float64) {

--- a/internal/workloads/tpcc/tpcc.go
+++ b/internal/workloads/tpcc/tpcc.go
@@ -84,7 +84,12 @@ func (w *workload) Define(d *bench.Def) error {
 	w.warehouses = int64(max(warehouses, 1))
 	w.warehouseStart = int64(d.Param.Int("warehouse-start", 1, "First warehouse ID.").Value())
 	w.wIDMax = w.warehouseStart + w.warehouses - 1
-	w.loadItems = d.Param.Bool("load-items", w.warehouseStart == 1, "Load the shared item table.").Value()
+	w.loadItems = d.Param.Bool(
+		"load-items",
+		w.warehouseStart == 1,
+		"Load the shared item table.",
+		bench.DerivedDefault("true when warehouse-start is 1; false otherwise"),
+	).Value()
 	w.pacing = d.Param.Bool("pacing", false, "Apply TPC-C keying and think times.").Value()
 	w.retryAttempts = d.Param.Int("retry-attempts", 3, "Maximum transaction attempts.").Value()
 	w.pgUnlogged = d.Param.Bool("pg-unlogged", false, "Use unlogged PostgreSQL tables while loading.").Value()

--- a/internal/workloads/tpcc/tpcc.go
+++ b/internal/workloads/tpcc/tpcc.go
@@ -67,11 +67,13 @@ type metrics struct {
 }
 
 func init() {
-	bench.Register(&workload{variant: "tx"})
-	bench.Register(&workload{variant: "procs"})
+	bench.Register(func() bench.Workload { return &workload{variant: "tx"} })
+	bench.Register(func() bench.Workload { return &workload{variant: "procs"} })
 }
 
 func (w *workload) Name() string { return "tpcc/" + w.variant }
+
+func (*workload) Define(*bench.Def) error { return nil }
 
 // renderDDL expands the ydb.sql {partition_keys}/{partition_count} tablet-split
 // placeholders from the warehouse range (one tablet per warehouse in

--- a/internal/workloads/tpcds/config.go
+++ b/internal/workloads/tpcds/config.go
@@ -20,19 +20,29 @@ var tpcdsTables = [24]string{
 	"web_sales", "web_returns",
 }
 
-// dialectFile maps a driver to its (schema, query) SQL files. SQL_FILE / SCHEMA_FILE
-// env overrides take precedence. Dialects without their own query file fall back to pg.
-func dialectFiles(dt bench.DriverTypeName) (schema, queries string) {
+// dialectFiles maps a driver to its (schema, query) SQL files. Explicit file
+// parameters take precedence over driver defaults.
+func dialectFiles(dt bench.DriverTypeName, schemaOverride, queryOverride string) (schema, queries string) {
 	switch dt {
 	case bench.DriverMySQL:
-		return bench.Env("SCHEMA_FILE", "schema.mysql.sql"), bench.Env("SQL_FILE", "mysql.sql")
+		schema, queries = "schema.mysql.sql", "mysql.sql"
 	case bench.DriverPicodata:
-		return bench.Env("SCHEMA_FILE", "schema.pico.sql"), bench.Env("SQL_FILE", "pico.sql")
+		schema, queries = "schema.pico.sql", "pico.sql"
 	case bench.DriverYDB:
-		return bench.Env("SCHEMA_FILE", "schema.ydb.sql"), bench.Env("SQL_FILE", "ydb.sql")
+		schema, queries = "schema.ydb.sql", "ydb.sql"
 	default:
-		return bench.Env("SCHEMA_FILE", "schema.pg.sql"), bench.Env("SQL_FILE", "pg.sql")
+		schema, queries = "schema.pg.sql", "pg.sql"
 	}
+
+	if schemaOverride != "" {
+		schema = schemaOverride
+	}
+
+	if queryOverride != "" {
+		queries = queryOverride
+	}
+
+	return schema, queries
 }
 
 func mustLoad(preset, file string) *bench.SQL {

--- a/internal/workloads/tpcds/params_test.go
+++ b/internal/workloads/tpcds/params_test.go
@@ -83,7 +83,7 @@ func TestTypedParameterSemantics(t *testing.T) {
 		{
 			name: "typed config false remains false",
 			inputs: bench.ParamInputs{
-				Config: map[string]json.RawMessage{"validateForce": json.RawMessage("false")},
+				WorkloadConfig: map[string]json.RawMessage{"validateForce": json.RawMessage("false")},
 			},
 			wantStream: -1,
 		},

--- a/internal/workloads/tpcds/params_test.go
+++ b/internal/workloads/tpcds/params_test.go
@@ -1,0 +1,177 @@
+package tpcds
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/stroppy-io/stroppy/pkg/bench"
+	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	_ "github.com/stroppy-io/stroppy/pkg/driver/noop"
+)
+
+const captureWorkloadName = "tpcds/test-parameters"
+
+type captureWorkload struct {
+	*workload
+	captured chan<- *workload
+}
+
+func (*captureWorkload) Name() string { return captureWorkloadName }
+
+func (w *captureWorkload) Setup(context.Context, *bench.Bench) error {
+	w.captured <- w.workload
+
+	return nil
+}
+
+func (*captureWorkload) Iterate(context.Context, *bench.Bench) error  { return nil }
+func (*captureWorkload) Teardown(context.Context, *bench.Bench) error { return nil }
+
+func TestTypedParameterSemantics(t *testing.T) {
+	unsetProcessEnv(
+		t,
+		"QUERY_STREAM", "VALIDATE_FORCE",
+		"EXECUTOR", "VUS", "ITERATIONS", "ITER", "DURATION",
+	)
+
+	captured := make(chan *workload, 8)
+
+	bench.Register(func() bench.Workload {
+		return &captureWorkload{workload: &workload{}, captured: captured}
+	})
+
+	tests := []struct {
+		name       string
+		inputs     bench.ParamInputs
+		processEnv map[string]string
+		wantStream int
+		wantForce  bool
+	}{
+		{name: "query stream unset", wantStream: -1},
+		{
+			name:       "query stream explicit zero",
+			inputs:     bench.ParamInputs{CLI: map[string]string{"query-stream": "0"}},
+			wantStream: 0,
+		},
+		{
+			name: "legacy env false remains presence based",
+			inputs: bench.ParamInputs{
+				LegacyEnv: map[string]string{"VALIDATE_FORCE": "false"},
+			},
+			wantStream: -1,
+			wantForce:  true,
+		},
+		{
+			name: "legacy config env zero remains presence based",
+			inputs: bench.ParamInputs{
+				LegacyConfigEnv: map[string]string{"VALIDATE_FORCE": "0"},
+			},
+			wantStream: -1,
+			wantForce:  true,
+		},
+		{
+			name: "typed CLI false remains false",
+			inputs: bench.ParamInputs{
+				CLI: map[string]string{"validate-force": "false"},
+			},
+			wantStream: -1,
+		},
+		{
+			name: "typed config false remains false",
+			inputs: bench.ParamInputs{
+				Config: map[string]json.RawMessage{"validateForce": json.RawMessage("false")},
+			},
+			wantStream: -1,
+		},
+		{
+			name:       "process env zero remains presence based",
+			processEnv: map[string]string{"VALIDATE_FORCE": "0"},
+			wantStream: -1,
+			wantForce:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for name, value := range tt.processEnv {
+				t.Setenv(name, value)
+			}
+
+			got := runCaptured(t, captured, tt.inputs)
+			if got.genStream != tt.wantStream {
+				t.Fatalf("genStream = %d, want %d", got.genStream, tt.wantStream)
+			}
+
+			if got.validateForce != tt.wantForce {
+				t.Fatalf("validateForce = %t, want %t", got.validateForce, tt.wantForce)
+			}
+		})
+	}
+}
+
+func TestDialectFileDefaults(t *testing.T) {
+	tests := []struct {
+		driver      bench.DriverTypeName
+		wantSchema  string
+		wantQueries string
+	}{
+		{bench.DriverPostgres, "schema.pg.sql", "pg.sql"},
+		{bench.DriverMySQL, "schema.mysql.sql", "mysql.sql"},
+		{bench.DriverPicodata, "schema.pico.sql", "pico.sql"},
+		{bench.DriverYDB, "schema.ydb.sql", "ydb.sql"},
+	}
+	for _, tt := range tests {
+		schema, queries := dialectFiles(tt.driver, "", "")
+		if schema != tt.wantSchema || queries != tt.wantQueries {
+			t.Errorf("dialectFiles(%s) = (%s, %s), want (%s, %s)",
+				tt.driver, schema, queries, tt.wantSchema, tt.wantQueries)
+		}
+	}
+
+	schema, queries := dialectFiles(bench.DriverPostgres, "custom-schema.sql", "custom.sql")
+	if schema != "custom-schema.sql" || queries != "custom.sql" {
+		t.Fatalf("file overrides = (%s, %s), want custom files", schema, queries)
+	}
+}
+
+func runCaptured(t *testing.T, captured <-chan *workload, inputs bench.ParamInputs) *workload {
+	t.Helper()
+
+	err := bench.Run(
+		context.Background(),
+		captureWorkloadName,
+		map[int]*stroppy.DriverConfig{0: {DriverType: stroppy.DriverConfig_DRIVER_TYPE_NOOP}},
+		nil,
+		inputs,
+		zap.NewNop(),
+		&bench.MetricsConfig{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return <-captured
+}
+
+func unsetProcessEnv(t *testing.T, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		value, present := os.LookupEnv(name)
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(name, value)
+			} else {
+				_ = os.Unsetenv(name)
+			}
+		})
+	}
+}

--- a/internal/workloads/tpcds/tpcds.go
+++ b/internal/workloads/tpcds/tpcds.go
@@ -25,9 +25,13 @@ type workload struct {
 	isPgOrMs  bool
 	ydbColumn bool
 
-	scaleFactor float64
-	loadWorkers int
-	useUnlogged bool
+	scaleFactor   float64
+	loadWorkers   int
+	useUnlogged   bool
+	ydbStoreMode  string
+	schemaFile    string
+	sqlFile       string
+	validateForce bool
 
 	throughput bool
 	streams    int
@@ -44,39 +48,48 @@ func init() { bench.Register(func() bench.Workload { return &workload{} }) }
 
 func (*workload) Name() string { return "tpcds" }
 
-func (*workload) Define(*bench.Def) error { return nil }
+func (w *workload) Define(d *bench.Def) error {
+	w.scaleFactor = d.Param.Float64("scale-factor", 1, "TPC-DS scale factor.").Value()
+	w.loadWorkers = d.Param.Int("load-workers", 0, "Workers used to load each table.").Value()
+	w.useUnlogged = d.Param.Bool("pg-unlogged", false, "Use unlogged PostgreSQL tables while loading.").Value()
+	w.ydbStoreMode = d.Param.String("ydb-store-mode", "column", "YDB table store mode.").Value()
+	w.streams = d.Param.Int("streams", 1, "Number of query streams.").Value()
+	w.seed = int64(d.Param.Int("query-seed", 19620718, "Query generator seed.").Value())
 
-func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
-	w.driver = b.DriverTypeName()
-	w.isPgOrMs = w.driver == bench.DriverPostgres || w.driver == bench.DriverMySQL
-	w.ydbColumn = w.driver == bench.DriverYDB && bench.Env("YDB_STORE_MODE", "column") == "column"
+	queryStream := d.Param.Int("query-stream", 0, "Query stream to generate.")
+	if queryStream.Explicit() {
+		w.genStream = queryStream.Value()
+	} else {
+		w.genStream = -1
+	}
 
-	w.scaleFactor = bench.EnvFloat("SCALE_FACTOR", 1)
+	w.schemaFile = d.Param.String("schema-file", "", "Schema SQL file override.").Value()
+	w.sqlFile = d.Param.String("sql-file", "", "Query SQL file override.").Value()
+	w.validateForce = d.Param.Bool("validate-force", false, "Validate answers outside scale factor 1.").Value()
+
 	if w.scaleFactor <= 0 {
 		return fmt.Errorf("%w, got %v", errScaleFactorMustBePositive, w.scaleFactor)
 	}
 
-	w.loadWorkers = bench.EnvInt("LOAD_WORKERS", 0)
-	w.useUnlogged = bench.Env("PG_UNLOGGED", "false") == "true" && w.driver == bench.DriverPostgres
+	return nil
+}
+
+func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
+	w.driver = b.DriverTypeName()
+	w.isPgOrMs = w.driver == bench.DriverPostgres || w.driver == bench.DriverMySQL
+	w.ydbColumn = w.driver == bench.DriverYDB && w.ydbStoreMode == "column"
+	w.useUnlogged = w.useUnlogged && w.driver == bench.DriverPostgres
 
 	// Query source. Throughput (STREAMS>1) or an explicit QUERY_STREAM selects the
 	// in-process generator; otherwise the baked canonical set. ydb runs the baked set
 	// only — the generator targets ANSI/pg/MySQL, not YQL.
-	w.streams = bench.EnvInt("STREAMS", 1)
 	w.throughput = w.streams > 1
-
-	w.seed = int64(bench.EnvInt("QUERY_SEED", 19620718))
-	if qs := bench.Env("QUERY_STREAM", ""); qs != "" {
-		w.genStream = bench.EnvInt("QUERY_STREAM", 0)
-	} else {
-		w.genStream = -1
-	}
 
 	if w.driver == bench.DriverYDB && (w.throughput || w.genStream >= 0) {
 		return errYdbBakedOnly
 	}
 
-	schemaFile, queryFile := dialectFiles(w.driver)
+	schemaFile, queryFile := dialectFiles(w.driver, w.schemaFile, w.sqlFile)
 	w.schemaSQL = mustLoad(preset, schemaFile)
 	w.querySQL = mustLoad(preset, queryFile)
 
@@ -141,7 +154,10 @@ func (w *workload) runSteps(ctx context.Context, b *bench.Bench) error {
 	// (mirrors the tpch port), so the queries execute twice at SF=1.
 	if !w.throughput && w.genStream < 0 && w.isPgOrMs {
 		if err := addStep("validate_answers", func() error {
-			validateAnswers(ctx, b, w.schemaSQL, w.querySQL, w.querySQL.Names(""), w.scaleFactor, w.driver)
+			validateAnswers(
+				ctx, b, w.schemaSQL, w.querySQL, w.querySQL.Names(""),
+				w.scaleFactor, w.driver, w.validateForce,
+			)
 
 			return nil
 		}); err != nil {

--- a/internal/workloads/tpcds/tpcds.go
+++ b/internal/workloads/tpcds/tpcds.go
@@ -40,9 +40,11 @@ type namedQuery struct {
 	sql  string
 }
 
-func init() { bench.Register(&workload{}) }
+func init() { bench.Register(func() bench.Workload { return &workload{} }) }
 
 func (*workload) Name() string { return "tpcds" }
+
+func (*workload) Define(*bench.Def) error { return nil }
 
 func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	w.driver = b.DriverTypeName()

--- a/internal/workloads/tpcds/tpcds.go
+++ b/internal/workloads/tpcds/tpcds.go
@@ -65,7 +65,16 @@ func (w *workload) Define(d *bench.Def) error {
 
 	w.schemaFile = d.Param.String("schema-file", "", "Schema SQL file override.").Value()
 	w.sqlFile = d.Param.String("sql-file", "", "Query SQL file override.").Value()
-	w.validateForce = d.Param.Bool("validate-force", false, "Validate answers outside scale factor 1.").Value()
+	validateForce := d.Param.Bool("validate-force", false, "Validate answers outside scale factor 1.")
+
+	w.validateForce = validateForce.Value()
+
+	legacyForce := validateForce.Source() == bench.ParamSourceProcessEnv ||
+		validateForce.Source() == bench.ParamSourceLegacyEnv ||
+		validateForce.Source() == bench.ParamSourceLegacyConfigEnv
+	if validateForce.Explicit() && legacyForce {
+		w.validateForce = true
+	}
 
 	if w.scaleFactor <= 0 {
 		return fmt.Errorf("%w, got %v", errScaleFactorMustBePositive, w.scaleFactor)

--- a/internal/workloads/tpcds/validate.go
+++ b/internal/workloads/tpcds/validate.go
@@ -248,7 +248,7 @@ func cellDeltas(i int, g, w []string) []string {
 func validateAnswers(
 	ctx context.Context, b *bench.Bench,
 	schema, queries *bench.SQL, names []string,
-	scaleFactor float64, dt bench.DriverTypeName,
+	scaleFactor float64, dt bench.DriverTypeName, force bool,
 ) {
 	lg := b.Logger().Sugar()
 	if dt != bench.DriverPostgres && dt != bench.DriverMySQL {
@@ -257,7 +257,7 @@ func validateAnswers(
 		return
 	}
 
-	if math.Abs(scaleFactor-1) > 1e-9 && bench.Env("VALIDATE_FORCE", "") == "" {
+	if math.Abs(scaleFactor-1) > 1e-9 && !force {
 		lg.Info("[tpcds_validate] skipped: answers_sf1 is SF=1 only (set VALIDATE_FORCE=1 to run anyway)")
 
 		return

--- a/internal/workloads/tpch/config.go
+++ b/internal/workloads/tpch/config.go
@@ -21,9 +21,9 @@ func init() {
 	}
 }
 
-func sqlFile(dt bench.DriverTypeName) string {
-	if v := bench.Env("SQL_FILE", ""); v != "" {
-		return v
+func sqlFile(dt bench.DriverTypeName, override string) string {
+	if override != "" {
+		return override
 	}
 
 	switch dt {
@@ -38,8 +38,8 @@ func sqlFile(dt bench.DriverTypeName) string {
 	}
 }
 
-func mustLoadSQL(dt bench.DriverTypeName) *bench.SQL {
-	s, err := bench.LoadSQL(preset, sqlFile(dt))
+func mustLoadSQL(dt bench.DriverTypeName, override string) *bench.SQL {
+	s, err := bench.LoadSQL(preset, sqlFile(dt, override))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/workloads/tpch/params_test.go
+++ b/internal/workloads/tpch/params_test.go
@@ -1,0 +1,28 @@
+package tpch
+
+import (
+	"testing"
+
+	"github.com/stroppy-io/stroppy/pkg/bench"
+)
+
+func TestSQLFileDefaults(t *testing.T) {
+	tests := []struct {
+		driver bench.DriverTypeName
+		want   string
+	}{
+		{bench.DriverPostgres, "pg.sql"},
+		{bench.DriverMySQL, "mysql.sql"},
+		{bench.DriverPicodata, "pico.sql"},
+		{bench.DriverYDB, "ydb.sql"},
+	}
+	for _, tt := range tests {
+		if got := sqlFile(tt.driver, ""); got != tt.want {
+			t.Errorf("sqlFile(%s) = %s, want %s", tt.driver, got, tt.want)
+		}
+	}
+
+	if got := sqlFile(bench.DriverPostgres, "custom.sql"); got != "custom.sql" {
+		t.Fatalf("SQL override = %s, want custom.sql", got)
+	}
+}

--- a/internal/workloads/tpch/tpch.go
+++ b/internal/workloads/tpch/tpch.go
@@ -25,6 +25,8 @@ type workload struct {
 	loadWorkers   int
 	useUnlogged   bool
 	ydbColumn     bool
+	ydbStoreMode  string
+	sqlFile       string
 
 	params map[string]map[string]any // final per-query params (end dates + q1 cutoff precomputed)
 	m      map[string]*queryMetrics
@@ -41,14 +43,24 @@ func init() { bench.Register(func() bench.Workload { return &workload{} }) }
 
 func (*workload) Name() string { return "tpch/tx" }
 
-func (*workload) Define(*bench.Def) error { return nil }
+func (w *workload) Define(d *bench.Def) error {
+	w.scaleFactor = d.Param.Float64("scale-factor", 1, "TPC-H scale factor.").Value()
+	w.loadWorkers = d.Param.Int("load-workers", 0, "Workers used to load each table.").Value()
+	w.useUnlogged = d.Param.Bool("pg-unlogged", false, "Use unlogged PostgreSQL tables while loading.").Value()
+	w.ydbStoreMode = d.Param.String("ydb-store-mode", "column", "YDB table store mode.").Value()
+	w.sqlFile = d.Param.String("sql-file", "", "SQL dialect file override.").Value()
+
+	if w.scaleFactor <= 0 {
+		return fmt.Errorf("%w, got %v", errScaleFactorMustBePositive, w.scaleFactor)
+	}
+
+	return nil
+}
 
 func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	w.driverType = b.DriverTypeName()
 
-	if err := w.initConfig(); err != nil {
-		return err
-	}
+	w.initConfig()
 
 	// Per-query metrics (22 × 4).
 	w.m = w.initMetrics(b)
@@ -123,21 +135,13 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	return nil
 }
 
-// initConfig reads env-driven workload tuning into w fields.
-func (w *workload) initConfig() error {
-	w.scaleFactor = bench.EnvFloat("SCALE_FACTOR", 1)
-	if w.scaleFactor <= 0 {
-		return fmt.Errorf("%w, got %v", errScaleFactorMustBePositive, w.scaleFactor)
-	}
-
-	w.loadWorkers = bench.EnvInt("LOAD_WORKERS", 0)
-	w.useUnlogged = bench.Env("PG_UNLOGGED", "false") == "true" && w.driverType == bench.DriverPostgres
-	w.ydbColumn = w.driverType == bench.DriverYDB && bench.Env("YDB_STORE_MODE", "column") == "column"
+// initConfig resolves driver-specific workload configuration.
+func (w *workload) initConfig() {
+	w.useUnlogged = w.useUnlogged && w.driverType == bench.DriverPostgres
+	w.ydbColumn = w.driverType == bench.DriverYDB && w.ydbStoreMode == "column"
 	w.isPicodata = w.driverType == bench.DriverPicodata
 	w.needsEndDates = w.isPicodata || w.driverType == bench.DriverYDB
-	w.sql = mustLoadSQL(w.driverType)
-
-	return nil
+	w.sql = mustLoadSQL(w.driverType, w.sqlFile)
 }
 
 // initMetrics wires the per-query duration/counters (22 × 4).

--- a/internal/workloads/tpch/tpch.go
+++ b/internal/workloads/tpch/tpch.go
@@ -37,9 +37,11 @@ type queryMetrics struct {
 	elapsedTotal *bench.Metric
 }
 
-func init() { bench.Register(&workload{}) }
+func init() { bench.Register(func() bench.Workload { return &workload{} }) }
 
 func (*workload) Name() string { return "tpch/tx" }
+
+func (*workload) Define(*bench.Def) error { return nil }
 
 func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	w.driverType = b.DriverTypeName()

--- a/pkg/bench/param.go
+++ b/pkg/bench/param.go
@@ -1,0 +1,590 @@
+package bench
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParamInputs keeps typed parameter channels separate from compatibility env channels.
+type ParamInputs struct {
+	CLI             map[string]string
+	LegacyEnv       map[string]string
+	Config          map[string]json.RawMessage
+	LegacyConfigEnv map[string]string
+}
+
+// ParamSource identifies the channel that supplied a resolved parameter value.
+type ParamSource string
+
+const (
+	ParamSourceDefault         ParamSource = "default"
+	ParamSourceCLI             ParamSource = "cli"
+	ParamSourceProcessEnv      ParamSource = "process-env"
+	ParamSourceLegacyEnv       ParamSource = "legacy-env"
+	ParamSourceConfig          ParamSource = "config"
+	ParamSourceLegacyConfigEnv ParamSource = "legacy-config-env"
+)
+
+// Param is one typed value resolved for a single workload operation.
+type Param[T any] struct {
+	value  T
+	source ParamSource
+}
+
+func (p Param[T]) Value() T            { return p.value }
+func (p Param[T]) Source() ParamSource { return p.source }
+func (p Param[T]) Explicit() bool      { return p.source != ParamSourceDefault }
+
+// ParamType is the concrete type exposed by a parameter declaration.
+type ParamType string
+
+const (
+	ParamTypeString   ParamType = "string"
+	ParamTypeBool     ParamType = "bool"
+	ParamTypeInt      ParamType = "int"
+	ParamTypeInt64    ParamType = "int64"
+	ParamTypeUint64   ParamType = "uint64"
+	ParamTypeFloat64  ParamType = "float64"
+	ParamTypeDuration ParamType = "duration"
+)
+
+// ParamSchema is a copied projection of one parameter declaration.
+type ParamSchema struct {
+	Name             string
+	Type             ParamType
+	Description      string
+	Default          any
+	Env              string
+	LegacyEnvAliases []string
+	Config           string
+}
+
+// Description is the discoverable, default-only schema for a workload.
+type Description struct {
+	Name   string
+	Params []ParamSchema
+}
+
+// ParamOption customizes declaration metadata.
+type ParamOption interface {
+	apply(desc *paramDescriptor) error
+}
+
+type paramOption func(*paramDescriptor) error
+
+func (o paramOption) apply(desc *paramDescriptor) error { return o(desc) }
+
+// LegacyEnvAliases accepts old environment names in addition to the projected name.
+func LegacyEnvAliases(names ...string) ParamOption {
+	aliases := slices.Clone(names)
+
+	return paramOption(func(desc *paramDescriptor) error {
+		desc.legacyEnvAliases = append(desc.legacyEnvAliases, aliases...)
+
+		return nil
+	})
+}
+
+type paramDescriptor struct {
+	name             string
+	typ              ParamType
+	description      string
+	defaultValue     any
+	env              string
+	legacyEnvAliases []string
+	config           string
+}
+
+type paramParser[T any] struct {
+	text func(string) (T, error)
+	raw  func(json.RawMessage) (T, error)
+}
+
+// Def is the immediate workload definition and resolution operation.
+type Def struct {
+	Param ParamDeclarations
+
+	inputs       ParamInputs
+	defaultsOnly bool
+	standard     bool
+	descriptors  []paramDescriptor
+	names        map[string]struct{}
+	envNames     map[string]string
+	errs         []error
+}
+
+// ParamDeclarations contains the concrete typed declaration accessors.
+type ParamDeclarations struct {
+	def *Def
+}
+
+var (
+	paramNamePattern = regexp.MustCompile(`^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`)
+	envNamePattern   = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+	errNilParamOption        = errors.New("nil parameter option")
+	errInvalidParamName      = errors.New("invalid parameter name")
+	errReservedParamName     = errors.New("reserved parameter name")
+	errDuplicateParamName    = errors.New("duplicate parameter name")
+	errInvalidLegacyEnvAlias = errors.New("invalid legacy env alias")
+	errProjectedEnvAlias     = errors.New("legacy env alias duplicates its projected env name")
+	errDuplicateLegacyAlias  = errors.New("duplicate legacy env alias")
+	errDuplicateParamEnvName = errors.New("parameter env name already registered")
+	errNullParamValue        = errors.New("null is not allowed")
+	errNonFiniteParamValue   = errors.New("must be finite")
+	errUnknownCLIParam       = errors.New("unknown CLI parameter")
+	errUnknownConfigParam    = errors.New("unknown config parameter")
+)
+
+var reservedWorkloadParamNames = map[string]struct{}{
+	"driver": {}, "driver-opt": {}, "duration": {}, "env": {}, "executor": {},
+	"file": {}, "help": {}, "iterations": {}, "no-steps": {}, "steps": {}, "vus": {},
+}
+
+func newDef(inputs ParamInputs, defaultsOnly bool) *Def {
+	d := &Def{
+		inputs:       cloneParamInputs(inputs),
+		defaultsOnly: defaultsOnly,
+		standard:     true,
+		names:        make(map[string]struct{}),
+		envNames:     make(map[string]string),
+	}
+	d.Param.def = d
+
+	return d
+}
+
+func cloneParamInputs(inputs ParamInputs) ParamInputs {
+	return ParamInputs{
+		CLI:             cloneStringMap(inputs.CLI),
+		LegacyEnv:       cloneStringMap(inputs.LegacyEnv),
+		Config:          cloneRawMap(inputs.Config),
+		LegacyConfigEnv: cloneStringMap(inputs.LegacyConfigEnv),
+	}
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+
+	return dst
+}
+
+func cloneRawMap(src map[string]json.RawMessage) map[string]json.RawMessage {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]json.RawMessage, len(src))
+	for key, value := range src {
+		dst[key] = slices.Clone(value)
+	}
+
+	return dst
+}
+
+func (p ParamDeclarations) String(
+	name, defaultValue, description string,
+	opts ...ParamOption,
+) Param[string] {
+	return declareParam(p.def, name, ParamTypeString, defaultValue, description, paramParser[string]{
+		text: func(value string) (string, error) { return value, nil },
+		raw:  decodeJSON[string],
+	}, opts...)
+}
+
+func (p ParamDeclarations) Bool(
+	name string,
+	defaultValue bool,
+	description string,
+	opts ...ParamOption,
+) Param[bool] {
+	return declareParam(p.def, name, ParamTypeBool, defaultValue, description, paramParser[bool]{
+		text: strconv.ParseBool,
+		raw:  decodeJSON[bool],
+	}, opts...)
+}
+
+func (p ParamDeclarations) Int(
+	name string,
+	defaultValue int,
+	description string,
+	opts ...ParamOption,
+) Param[int] {
+	return declareParam(p.def, name, ParamTypeInt, defaultValue, description, paramParser[int]{
+		text: strconv.Atoi,
+		raw:  decodeJSON[int],
+	}, opts...)
+}
+
+func (p ParamDeclarations) Int64(
+	name string,
+	defaultValue int64,
+	description string,
+	opts ...ParamOption,
+) Param[int64] {
+	return declareParam(p.def, name, ParamTypeInt64, defaultValue, description, paramParser[int64]{
+		text: func(value string) (int64, error) { return strconv.ParseInt(value, 10, 64) },
+		raw:  decodeJSON[int64],
+	}, opts...)
+}
+
+func (p ParamDeclarations) Uint64(
+	name string,
+	defaultValue uint64,
+	description string,
+	opts ...ParamOption,
+) Param[uint64] {
+	return declareParam(p.def, name, ParamTypeUint64, defaultValue, description, paramParser[uint64]{
+		text: func(value string) (uint64, error) { return strconv.ParseUint(value, 10, 64) },
+		raw:  decodeJSON[uint64],
+	}, opts...)
+}
+
+func (p ParamDeclarations) Float64(
+	name string,
+	defaultValue float64,
+	description string,
+	opts ...ParamOption,
+) Param[float64] {
+	return declareParam(p.def, name, ParamTypeFloat64, defaultValue, description, paramParser[float64]{
+		text: parseFiniteFloat,
+		raw:  decodeFiniteFloat,
+	}, opts...)
+}
+
+func (p ParamDeclarations) Duration(
+	name string,
+	defaultValue time.Duration,
+	description string,
+	opts ...ParamOption,
+) Param[time.Duration] {
+	return declareParam(p.def, name, ParamTypeDuration, defaultValue, description, paramParser[time.Duration]{
+		text: time.ParseDuration,
+		raw: func(raw json.RawMessage) (time.Duration, error) {
+			value, err := decodeJSON[string](raw)
+			if err != nil {
+				return 0, err
+			}
+
+			return time.ParseDuration(value)
+		},
+	}, opts...)
+}
+
+func declareParam[T any](
+	d *Def,
+	name string,
+	typ ParamType,
+	defaultValue T,
+	description string,
+	parser paramParser[T],
+	opts ...ParamOption,
+) Param[T] {
+	desc := paramDescriptor{
+		name:         name,
+		typ:          typ,
+		description:  description,
+		defaultValue: defaultValue,
+		env:          kebabToEnv(name),
+		config:       kebabToCamel(name),
+	}
+
+	for _, opt := range opts {
+		if opt == nil {
+			d.addError(fmt.Errorf("%w for parameter %q", errNilParamOption, name))
+
+			continue
+		}
+
+		if err := opt.apply(&desc); err != nil {
+			d.addError(fmt.Errorf("parameter %q option: %w", name, err))
+		}
+	}
+
+	valid := d.register(&desc)
+	if !valid || d.defaultsOnly {
+		return Param[T]{value: defaultValue, source: ParamSourceDefault}
+	}
+
+	value, source, ok, err := resolveParam(d.inputs, &desc, parser)
+	if err != nil {
+		d.addError(fmt.Errorf("parameter %q from %s: %w", name, source, err))
+
+		return Param[T]{value: defaultValue, source: ParamSourceDefault}
+	}
+
+	if !ok {
+		return Param[T]{value: defaultValue, source: ParamSourceDefault}
+	}
+
+	return Param[T]{value: value, source: source}
+}
+
+func (d *Def) register(desc *paramDescriptor) bool {
+	valid := true
+
+	if !paramNamePattern.MatchString(desc.name) {
+		d.addError(fmt.Errorf("%w %q: use lower-case kebab-case", errInvalidParamName, desc.name))
+
+		valid = false
+	}
+
+	if !d.standard {
+		if _, reserved := reservedWorkloadParamNames[desc.name]; reserved {
+			d.addError(fmt.Errorf("%w %q", errReservedParamName, desc.name))
+
+			valid = false
+		}
+	}
+
+	if _, duplicate := d.names[desc.name]; duplicate {
+		d.addError(fmt.Errorf("%w %q", errDuplicateParamName, desc.name))
+
+		valid = false
+	} else {
+		d.names[desc.name] = struct{}{}
+	}
+
+	seenAliases := make(map[string]struct{}, len(desc.legacyEnvAliases))
+	for _, alias := range desc.legacyEnvAliases {
+		if !envNamePattern.MatchString(alias) {
+			d.addError(fmt.Errorf("parameter %q: %w %q", desc.name, errInvalidLegacyEnvAlias, alias))
+
+			valid = false
+		}
+
+		if alias == desc.env {
+			d.addError(fmt.Errorf("parameter %q: %w %q", desc.name, errProjectedEnvAlias, alias))
+
+			valid = false
+		}
+
+		if _, duplicate := seenAliases[alias]; duplicate {
+			d.addError(fmt.Errorf("parameter %q: %w %q", desc.name, errDuplicateLegacyAlias, alias))
+
+			valid = false
+		}
+
+		seenAliases[alias] = struct{}{}
+	}
+
+	for _, envName := range append([]string{desc.env}, desc.legacyEnvAliases...) {
+		if owner, duplicate := d.envNames[envName]; duplicate {
+			d.addError(fmt.Errorf(
+				"parameter %q: %w: %q belongs to parameter %q",
+				desc.name,
+				errDuplicateParamEnvName,
+				envName,
+				owner,
+			))
+
+			valid = false
+		} else {
+			d.envNames[envName] = desc.name
+		}
+	}
+
+	if valid {
+		d.descriptors = append(d.descriptors, *desc)
+	}
+
+	return valid
+}
+
+func resolveParam[T any](
+	inputs ParamInputs,
+	desc *paramDescriptor,
+	parser paramParser[T],
+) (resolved T, source ParamSource, found bool, err error) {
+	var zero T
+
+	if value, ok := inputs.CLI[desc.name]; ok {
+		parsed, err := parser.text(value)
+
+		return parsed, ParamSourceCLI, true, err
+	}
+
+	if value, ok := lookupProcessEnv(desc); ok {
+		parsed, err := parser.text(value)
+
+		return parsed, ParamSourceProcessEnv, true, err
+	}
+
+	if value, ok := lookupEnvMap(inputs.LegacyEnv, desc); ok {
+		parsed, err := parser.text(value)
+
+		return parsed, ParamSourceLegacyEnv, true, err
+	}
+
+	if value, ok := inputs.Config[desc.config]; ok {
+		parsed, err := parser.raw(value)
+
+		return parsed, ParamSourceConfig, true, err
+	}
+
+	if value, ok := lookupEnvMap(inputs.LegacyConfigEnv, desc); ok {
+		parsed, err := parser.text(value)
+
+		return parsed, ParamSourceLegacyConfigEnv, true, err
+	}
+
+	return zero, ParamSourceDefault, false, nil
+}
+
+func lookupProcessEnv(desc *paramDescriptor) (string, bool) {
+	if value, ok := os.LookupEnv(desc.env); ok {
+		return value, true
+	}
+
+	for _, alias := range desc.legacyEnvAliases {
+		if value, ok := os.LookupEnv(alias); ok {
+			return value, true
+		}
+	}
+
+	return "", false
+}
+
+func lookupEnvMap(values map[string]string, desc *paramDescriptor) (string, bool) {
+	if value, ok := values[desc.env]; ok {
+		return value, true
+	}
+
+	for _, alias := range desc.legacyEnvAliases {
+		if value, ok := values[alias]; ok {
+			return value, true
+		}
+	}
+
+	return "", false
+}
+
+func decodeJSON[T any](raw json.RawMessage) (T, error) {
+	var value T
+
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return value, errNullParamValue
+	}
+
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return value, err
+	}
+
+	return value, nil
+}
+
+func parseFiniteFloat(value string) (float64, error) {
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	if math.IsInf(parsed, 0) || math.IsNaN(parsed) {
+		return 0, errNonFiniteParamValue
+	}
+
+	return parsed, nil
+}
+
+func decodeFiniteFloat(raw json.RawMessage) (float64, error) {
+	value, err := decodeJSON[float64](raw)
+	if err != nil {
+		return 0, err
+	}
+
+	if math.IsInf(value, 0) || math.IsNaN(value) {
+		return 0, errNonFiniteParamValue
+	}
+
+	return value, nil
+}
+
+func (d *Def) finish() error {
+	for _, name := range sortedKeys(d.inputs.CLI) {
+		if _, ok := d.names[name]; !ok {
+			d.addError(fmt.Errorf("%w %q", errUnknownCLIParam, name))
+		}
+	}
+
+	configNames := make(map[string]struct{}, len(d.descriptors))
+	for _, desc := range d.descriptors {
+		configNames[desc.config] = struct{}{}
+	}
+
+	for _, name := range sortedKeys(d.inputs.Config) {
+		if _, ok := configNames[name]; !ok {
+			d.addError(fmt.Errorf("%w %q", errUnknownConfigParam, name))
+		}
+	}
+
+	return errors.Join(d.errs...)
+}
+
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+
+	slices.Sort(keys)
+
+	return keys
+}
+
+func (d *Def) schema() []ParamSchema {
+	schema := make([]ParamSchema, len(d.descriptors))
+	for idx, desc := range d.descriptors {
+		schema[idx] = ParamSchema{
+			Name:             desc.name,
+			Type:             desc.typ,
+			Description:      desc.description,
+			Default:          desc.defaultValue,
+			Env:              desc.env,
+			LegacyEnvAliases: slices.Clone(desc.legacyEnvAliases),
+			Config:           desc.config,
+		}
+	}
+
+	slices.SortFunc(schema, func(left, right ParamSchema) int {
+		return strings.Compare(left.Name, right.Name)
+	})
+
+	return schema
+}
+
+func (d *Def) addError(err error) {
+	if err != nil {
+		d.errs = append(d.errs, err)
+	}
+}
+
+func kebabToEnv(name string) string {
+	return strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+}
+
+func kebabToCamel(name string) string {
+	parts := strings.Split(name, "-")
+	for idx := 1; idx < len(parts); idx++ {
+		if parts[idx] != "" {
+			parts[idx] = strings.ToUpper(parts[idx][:1]) + parts[idx][1:]
+		}
+	}
+
+	return strings.Join(parts, "")
+}

--- a/pkg/bench/param.go
+++ b/pkg/bench/param.go
@@ -18,7 +18,8 @@ import (
 type ParamInputs struct {
 	CLI             map[string]string
 	LegacyEnv       map[string]string
-	Config          map[string]json.RawMessage
+	RunConfig       map[string]json.RawMessage
+	WorkloadConfig  map[string]json.RawMessage
 	LegacyConfigEnv map[string]string
 }
 
@@ -57,9 +58,19 @@ const (
 	ParamTypeDuration ParamType = "duration"
 )
 
+// ParamScope identifies the config object that owns a declaration.
+type ParamScope string
+
+const (
+	ParamScopeRun      ParamScope = "run"
+	ParamScopeWorkload ParamScope = "workload"
+)
+
 // ParamSchema is a copied projection of one parameter declaration.
 type ParamSchema struct {
 	Name             string
+	Flag             string
+	Scope            ParamScope
 	Type             ParamType
 	Description      string
 	Default          any
@@ -96,6 +107,7 @@ func LegacyEnvAliases(names ...string) ParamOption {
 
 type paramDescriptor struct {
 	name             string
+	scope            ParamScope
 	typ              ParamType
 	description      string
 	defaultValue     any
@@ -115,7 +127,7 @@ type Def struct {
 
 	inputs       ParamInputs
 	defaultsOnly bool
-	standard     bool
+	scope        ParamScope
 	descriptors  []paramDescriptor
 	names        map[string]struct{}
 	envNames     map[string]string
@@ -142,7 +154,8 @@ var (
 	errNullParamValue        = errors.New("null is not allowed")
 	errNonFiniteParamValue   = errors.New("must be finite")
 	errUnknownCLIParam       = errors.New("unknown CLI parameter")
-	errUnknownConfigParam    = errors.New("unknown config parameter")
+	errUnknownRunConfigParam = errors.New("unknown run config parameter")
+	errUnknownWorkloadConfig = errors.New("unknown workload config parameter")
 )
 
 var reservedWorkloadParamNames = map[string]struct{}{
@@ -154,7 +167,7 @@ func newDef(inputs ParamInputs, defaultsOnly bool) *Def {
 	d := &Def{
 		inputs:       cloneParamInputs(inputs),
 		defaultsOnly: defaultsOnly,
-		standard:     true,
+		scope:        ParamScopeRun,
 		names:        make(map[string]struct{}),
 		envNames:     make(map[string]string),
 	}
@@ -167,7 +180,8 @@ func cloneParamInputs(inputs ParamInputs) ParamInputs {
 	return ParamInputs{
 		CLI:             cloneStringMap(inputs.CLI),
 		LegacyEnv:       cloneStringMap(inputs.LegacyEnv),
-		Config:          cloneRawMap(inputs.Config),
+		RunConfig:       cloneRawMap(inputs.RunConfig),
+		WorkloadConfig:  cloneRawMap(inputs.WorkloadConfig),
 		LegacyConfigEnv: cloneStringMap(inputs.LegacyConfigEnv),
 	}
 }
@@ -262,6 +276,10 @@ func (p ParamDeclarations) Float64(
 	description string,
 	opts ...ParamOption,
 ) Param[float64] {
+	if math.IsInf(defaultValue, 0) || math.IsNaN(defaultValue) {
+		p.def.addError(fmt.Errorf("parameter %q default: %w", name, errNonFiniteParamValue))
+	}
+
 	return declareParam(p.def, name, ParamTypeFloat64, defaultValue, description, paramParser[float64]{
 		text: parseFiniteFloat,
 		raw:  decodeFiniteFloat,
@@ -298,6 +316,7 @@ func declareParam[T any](
 ) Param[T] {
 	desc := paramDescriptor{
 		name:         name,
+		scope:        d.scope,
 		typ:          typ,
 		description:  description,
 		defaultValue: defaultValue,
@@ -345,7 +364,7 @@ func (d *Def) register(desc *paramDescriptor) bool {
 		valid = false
 	}
 
-	if !d.standard {
+	if desc.scope == ParamScopeWorkload {
 		if _, reserved := reservedWorkloadParamNames[desc.name]; reserved {
 			d.addError(fmt.Errorf("%w %q", errReservedParamName, desc.name))
 
@@ -432,7 +451,12 @@ func resolveParam[T any](
 		return parsed, ParamSourceLegacyEnv, true, err
 	}
 
-	if value, ok := inputs.Config[desc.config]; ok {
+	config := inputs.WorkloadConfig
+	if desc.scope == ParamScopeRun {
+		config = inputs.RunConfig
+	}
+
+	if value, ok := config[desc.config]; ok {
 		parsed, err := parser.raw(value)
 
 		return parsed, ParamSourceConfig, true, err
@@ -522,14 +546,27 @@ func (d *Def) finish() error {
 		}
 	}
 
-	configNames := make(map[string]struct{}, len(d.descriptors))
-	for _, desc := range d.descriptors {
-		configNames[desc.config] = struct{}{}
+	runConfigNames := make(map[string]struct{})
+	workloadConfigNames := make(map[string]struct{})
+
+	for idx := range d.descriptors {
+		desc := &d.descriptors[idx]
+		if desc.scope == ParamScopeRun {
+			runConfigNames[desc.config] = struct{}{}
+		} else {
+			workloadConfigNames[desc.config] = struct{}{}
+		}
 	}
 
-	for _, name := range sortedKeys(d.inputs.Config) {
-		if _, ok := configNames[name]; !ok {
-			d.addError(fmt.Errorf("%w %q", errUnknownConfigParam, name))
+	for _, name := range sortedKeys(d.inputs.RunConfig) {
+		if _, ok := runConfigNames[name]; !ok {
+			d.addError(fmt.Errorf("%w %q", errUnknownRunConfigParam, name))
+		}
+	}
+
+	for _, name := range sortedKeys(d.inputs.WorkloadConfig) {
+		if _, ok := workloadConfigNames[name]; !ok {
+			d.addError(fmt.Errorf("%w %q", errUnknownWorkloadConfig, name))
 		}
 	}
 
@@ -549,9 +586,12 @@ func sortedKeys[V any](values map[string]V) []string {
 
 func (d *Def) schema() []ParamSchema {
 	schema := make([]ParamSchema, len(d.descriptors))
-	for idx, desc := range d.descriptors {
+	for idx := range d.descriptors {
+		desc := &d.descriptors[idx]
 		schema[idx] = ParamSchema{
 			Name:             desc.name,
+			Flag:             "--" + desc.name,
+			Scope:            desc.scope,
 			Type:             desc.typ,
 			Description:      desc.description,
 			Default:          desc.defaultValue,
@@ -562,6 +602,10 @@ func (d *Def) schema() []ParamSchema {
 	}
 
 	slices.SortFunc(schema, func(left, right ParamSchema) int {
+		if left.Scope != right.Scope {
+			return strings.Compare(string(left.Scope), string(right.Scope))
+		}
+
 		return strings.Compare(left.Name, right.Name)
 	})
 

--- a/pkg/bench/param.go
+++ b/pkg/bench/param.go
@@ -68,15 +68,16 @@ const (
 
 // ParamSchema is a copied projection of one parameter declaration.
 type ParamSchema struct {
-	Name             string
-	Flag             string
-	Scope            ParamScope
-	Type             ParamType
-	Description      string
-	Default          any
-	Env              string
-	LegacyEnvAliases []string
-	Config           string
+	Name               string
+	Flag               string
+	Scope              ParamScope
+	Type               ParamType
+	Description        string
+	Default            any
+	DefaultDescription string
+	Env                string
+	LegacyEnvAliases   []string
+	Config             string
 }
 
 // Description is the discoverable, default-only schema for a workload.
@@ -105,15 +106,25 @@ func LegacyEnvAliases(names ...string) ParamOption {
 	})
 }
 
+// DerivedDefault hides the concrete fallback when its effective value is contextual.
+func DerivedDefault(description string) ParamOption {
+	return paramOption(func(desc *paramDescriptor) error {
+		desc.defaultDescription = description
+
+		return nil
+	})
+}
+
 type paramDescriptor struct {
-	name             string
-	scope            ParamScope
-	typ              ParamType
-	description      string
-	defaultValue     any
-	env              string
-	legacyEnvAliases []string
-	config           string
+	name               string
+	scope              ParamScope
+	typ                ParamType
+	description        string
+	defaultValue       any
+	defaultDescription string
+	env                string
+	legacyEnvAliases   []string
+	config             string
 }
 
 type paramParser[T any] struct {
@@ -365,7 +376,8 @@ func (d *Def) register(desc *paramDescriptor) bool {
 	}
 
 	if desc.scope == ParamScopeWorkload {
-		if _, reserved := reservedWorkloadParamNames[desc.name]; reserved {
+		_, staticReserved := reservedWorkloadParamNames[desc.name]
+		if staticReserved || indexedDriverParamReserved(desc.name) {
 			d.addError(fmt.Errorf("%w %q", errReservedParamName, desc.name))
 
 			valid = false
@@ -588,16 +600,23 @@ func (d *Def) schema() []ParamSchema {
 	schema := make([]ParamSchema, len(d.descriptors))
 	for idx := range d.descriptors {
 		desc := &d.descriptors[idx]
+
+		defaultValue := desc.defaultValue
+		if desc.defaultDescription != "" {
+			defaultValue = nil
+		}
+
 		schema[idx] = ParamSchema{
-			Name:             desc.name,
-			Flag:             "--" + desc.name,
-			Scope:            desc.scope,
-			Type:             desc.typ,
-			Description:      desc.description,
-			Default:          desc.defaultValue,
-			Env:              desc.env,
-			LegacyEnvAliases: slices.Clone(desc.legacyEnvAliases),
-			Config:           desc.config,
+			Name:               desc.name,
+			Flag:               "--" + desc.name,
+			Scope:              desc.scope,
+			Type:               desc.typ,
+			Description:        desc.description,
+			Default:            defaultValue,
+			DefaultDescription: desc.defaultDescription,
+			Env:                desc.env,
+			LegacyEnvAliases:   slices.Clone(desc.legacyEnvAliases),
+			Config:             desc.config,
 		}
 	}
 
@@ -616,6 +635,22 @@ func (d *Def) addError(err error) {
 	if err != nil {
 		d.errs = append(d.errs, err)
 	}
+}
+
+func indexedDriverParamReserved(name string) bool {
+	suffix, ok := strings.CutPrefix(name, "driver")
+	if !ok {
+		return false
+	}
+
+	suffix = strings.TrimSuffix(suffix, "-opt")
+	if suffix == "" {
+		return false
+	}
+
+	_, err := strconv.Atoi(suffix)
+
+	return err == nil
 }
 
 func kebabToEnv(name string) string {

--- a/pkg/bench/param_test.go
+++ b/pkg/bench/param_test.go
@@ -278,6 +278,51 @@ func TestParamConfigScopesRejectCrossedKeys(t *testing.T) {
 	}
 }
 
+func TestDerivedDefaultHidesConcreteSchemaDefault(t *testing.T) {
+	def := newDef(ParamInputs{}, true)
+	def.scope = ParamScopeWorkload
+
+	binding := def.Param.Int("batch-size", 10, "", DerivedDefault("selected by driver"))
+	if err := def.finish(); err != nil {
+		t.Fatalf("finish() error = %v", err)
+	}
+
+	if binding.Value() != 10 || binding.Source() != ParamSourceDefault {
+		t.Fatalf("binding = %#v", binding)
+	}
+
+	schema := def.schema()
+	if len(schema) != 1 || schema[0].Default != nil || schema[0].DefaultDescription != "selected by driver" {
+		t.Fatalf("schema = %#v", schema)
+	}
+}
+
+func TestParamRejectsIndexedDriverFlagNames(t *testing.T) {
+	for _, name := range []string{
+		"driver0", "driver1", "driver01", "driver-0", "driver-1",
+		"driver0-opt", "driver1-opt", "driver01-opt", "driver-1-opt",
+	} {
+		t.Run(name, func(t *testing.T) {
+			def := newDef(ParamInputs{}, true)
+			def.scope = ParamScopeWorkload
+			def.Param.String(name, "", "")
+
+			err := def.finish()
+			if err == nil || !strings.Contains(err.Error(), "reserved parameter name") {
+				t.Fatalf("finish() error = %v", err)
+			}
+		})
+	}
+
+	def := newDef(ParamInputs{}, true)
+	def.scope = ParamScopeWorkload
+	def.Param.String("driver999999999999999999999999999999", "", "")
+
+	if err := def.finish(); err != nil {
+		t.Fatalf("overflowing non-driver index was reserved: %v", err)
+	}
+}
+
 func TestParamNamesAliasesAndDeferredUnknownChecks(t *testing.T) {
 	clearParamEnv(t, "FIRST_VALUE", "SECOND_VALUE", "OLD_SECOND")
 

--- a/pkg/bench/param_test.go
+++ b/pkg/bench/param_test.go
@@ -588,6 +588,10 @@ func TestScenarioLegacyDurationIgnoresLegacyIterations(t *testing.T) {
 		"legacy -e": {
 			LegacyEnv: map[string]string{"DURATION": "2s", "ITER": "0"},
 		},
+		"legacy -e with explicit constant-vus": {
+			CLI:       map[string]string{"executor": "constant-vus"},
+			LegacyEnv: map[string]string{"DURATION": "2s", "ITER": "invalid"},
+		},
 		"legacy config env": {
 			LegacyConfigEnv: map[string]string{"DURATION": "2s", "ITER": "invalid"},
 		},
@@ -603,12 +607,26 @@ func TestScenarioLegacyDurationIgnoresLegacyIterations(t *testing.T) {
 func TestScenarioLegacyDurationStillValidatesTypedIterations(t *testing.T) {
 	clearScenarioEnv(t)
 
-	_, err := scenarioForTest(ParamInputs{
-		CLI:       map[string]string{"iterations": "0"},
-		LegacyEnv: map[string]string{"DURATION": "2s"},
-	}, zap.NewNop())
-	if err == nil || !strings.Contains(err.Error(), "iterations must be at least 1") {
-		t.Fatalf("typed iterations error = %v", err)
+	for name, inputs := range map[string]ParamInputs{
+		"CLI": {
+			CLI: map[string]string{
+				"executor":   "constant-vus",
+				"iterations": "0",
+			},
+			LegacyEnv: map[string]string{"DURATION": "2s"},
+		},
+		"run config": {
+			CLI:       map[string]string{"executor": "constant-vus"},
+			RunConfig: map[string]json.RawMessage{"iterations": json.RawMessage(`0`)},
+			LegacyEnv: map[string]string{"DURATION": "2s"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := scenarioForTest(inputs, zap.NewNop())
+			if err == nil || !strings.Contains(err.Error(), "iterations must be at least 1") {
+				t.Fatalf("typed iterations error = %v", err)
+			}
+		})
 	}
 }
 

--- a/pkg/bench/param_test.go
+++ b/pkg/bench/param_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 	"reflect"
 	"strings"
@@ -30,7 +31,7 @@ func TestParamResolutionPrecedence(t *testing.T) {
 			inputs: ParamInputs{
 				CLI:             map[string]string{"sample-value": "cli"},
 				LegacyEnv:       map[string]string{"SAMPLE_VALUE": "legacy-env"},
-				Config:          map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
+				WorkloadConfig:  map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
 				LegacyConfigEnv: map[string]string{"SAMPLE_VALUE": "config-env"},
 			},
 			processEnv: stringPointer("process"),
@@ -42,7 +43,7 @@ func TestParamResolutionPrecedence(t *testing.T) {
 			processEnv: stringPointer("process"),
 			inputs: ParamInputs{
 				LegacyEnv:       map[string]string{"SAMPLE_VALUE": "legacy-env"},
-				Config:          map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
+				WorkloadConfig:  map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
 				LegacyConfigEnv: map[string]string{"SAMPLE_VALUE": "config-env"},
 			},
 			want:       "process",
@@ -52,7 +53,7 @@ func TestParamResolutionPrecedence(t *testing.T) {
 			name: "legacy -e",
 			inputs: ParamInputs{
 				LegacyEnv:       map[string]string{"SAMPLE_VALUE": "legacy-env"},
-				Config:          map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
+				WorkloadConfig:  map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
 				LegacyConfigEnv: map[string]string{"SAMPLE_VALUE": "config-env"},
 			},
 			want:       "legacy-env",
@@ -61,7 +62,7 @@ func TestParamResolutionPrecedence(t *testing.T) {
 		{
 			name: "typed config",
 			inputs: ParamInputs{
-				Config:          map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
+				WorkloadConfig:  map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
 				LegacyConfigEnv: map[string]string{"SAMPLE_VALUE": "config-env"},
 			},
 			want:       "config",
@@ -87,7 +88,7 @@ func TestParamResolutionPrecedence(t *testing.T) {
 			}
 
 			def := newDef(test.inputs, false)
-			def.standard = false
+			def.scope = ParamScopeWorkload
 
 			param := def.Param.String(
 				"sample-value", "default", "sample", LegacyEnvAliases("OLD_SAMPLE_VALUE"),
@@ -119,7 +120,7 @@ func TestParamConcreteTypesFromCLI(t *testing.T) {
 		"ratio":    "1.25",
 		"timeout":  "1m30s",
 	}}, false)
-	def.standard = false
+	def.scope = ParamScopeWorkload
 
 	empty := def.Param.String("empty", "fallback", "")
 	enabled := def.Param.Bool("enabled", false, "")
@@ -145,7 +146,7 @@ func TestParamConcreteTypesFromCLI(t *testing.T) {
 func TestParamConcreteTypesFromNativeConfig(t *testing.T) {
 	clearParamEnv(t, "TEXT", "ENABLED", "COUNT", "LARGE", "UNSIGNED", "RATIO", "TIMEOUT")
 
-	def := newDef(ParamInputs{Config: map[string]json.RawMessage{
+	def := newDef(ParamInputs{WorkloadConfig: map[string]json.RawMessage{
 		"text":     json.RawMessage(`"value"`),
 		"enabled":  json.RawMessage(`true`),
 		"count":    json.RawMessage(`-12`),
@@ -154,7 +155,7 @@ func TestParamConcreteTypesFromNativeConfig(t *testing.T) {
 		"ratio":    json.RawMessage(`1.25`),
 		"timeout":  json.RawMessage(`"1m30s"`),
 	}}, false)
-	def.standard = false
+	def.scope = ParamScopeWorkload
 
 	text := def.Param.String("text", "", "")
 	enabled := def.Param.Bool("enabled", false, "")
@@ -193,25 +194,25 @@ func TestParamRejectsEmptyNonStringAndInvalidConfigTypes(t *testing.T) {
 		},
 		{
 			name:   "config null",
-			inputs: ParamInputs{Config: map[string]json.RawMessage{"count": json.RawMessage(`null`)}},
+			inputs: ParamInputs{WorkloadConfig: map[string]json.RawMessage{"count": json.RawMessage(`null`)}},
 			define: func(def *Def) { def.Param.Int("count", 1, "") },
 			want:   "null is not allowed",
 		},
 		{
 			name:   "config number as string",
-			inputs: ParamInputs{Config: map[string]json.RawMessage{"count": json.RawMessage(`"1"`)}},
+			inputs: ParamInputs{WorkloadConfig: map[string]json.RawMessage{"count": json.RawMessage(`"1"`)}},
 			define: func(def *Def) { def.Param.Int("count", 1, "") },
 			want:   "cannot unmarshal string",
 		},
 		{
 			name:   "config duration as number",
-			inputs: ParamInputs{Config: map[string]json.RawMessage{"timeout": json.RawMessage(`10`)}},
+			inputs: ParamInputs{WorkloadConfig: map[string]json.RawMessage{"timeout": json.RawMessage(`10`)}},
 			define: func(def *Def) { def.Param.Duration("timeout", time.Second, "") },
 			want:   "cannot unmarshal number",
 		},
 		{
 			name:   "config string as bool",
-			inputs: ParamInputs{Config: map[string]json.RawMessage{"enabled": json.RawMessage(`"true"`)}},
+			inputs: ParamInputs{WorkloadConfig: map[string]json.RawMessage{"enabled": json.RawMessage(`"true"`)}},
 			define: func(def *Def) { def.Param.Bool("enabled", false, "") },
 			want:   "cannot unmarshal string",
 		},
@@ -220,7 +221,7 @@ func TestParamRejectsEmptyNonStringAndInvalidConfigTypes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			def := newDef(test.inputs, false)
-			def.standard = false
+			def.scope = ParamScopeWorkload
 			test.define(def)
 
 			err := def.finish()
@@ -231,6 +232,52 @@ func TestParamRejectsEmptyNonStringAndInvalidConfigTypes(t *testing.T) {
 	}
 }
 
+func TestParamRejectsNonFiniteFloatDefaults(t *testing.T) {
+	for name, value := range map[string]float64{
+		"nan":      math.NaN(),
+		"positive": math.Inf(1),
+		"negative": math.Inf(-1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			def := newDef(ParamInputs{}, true)
+			def.scope = ParamScopeWorkload
+			def.Param.Float64("ratio", value, "")
+
+			err := def.finish()
+			if err == nil || !strings.Contains(err.Error(), "must be finite") {
+				t.Fatalf("finish() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestParamConfigScopesRejectCrossedKeys(t *testing.T) {
+	clearScenarioEnv(t)
+	clearParamEnv(t, "SCALE_FACTOR")
+
+	workload := &paramTestWorkload{
+		name: "test/scoped-config",
+		define: func(def *Def) error {
+			def.Param.Float64("scale-factor", 1, "")
+
+			return nil
+		},
+	}
+
+	_, _, err := defineWorkload(workload, ParamInputs{
+		RunConfig:      map[string]json.RawMessage{"scaleFactor": json.RawMessage(`2`)},
+		WorkloadConfig: map[string]json.RawMessage{"vus": json.RawMessage(`3`)},
+	}, false)
+	if err == nil {
+		t.Fatal("defineWorkload() error = nil")
+	}
+
+	if !strings.Contains(err.Error(), `unknown run config parameter "scaleFactor"`) ||
+		!strings.Contains(err.Error(), `unknown workload config parameter "vus"`) {
+		t.Fatalf("defineWorkload() error = %v", err)
+	}
+}
+
 func TestParamNamesAliasesAndDeferredUnknownChecks(t *testing.T) {
 	clearParamEnv(t, "FIRST_VALUE", "SECOND_VALUE", "OLD_SECOND")
 
@@ -238,7 +285,7 @@ func TestParamNamesAliasesAndDeferredUnknownChecks(t *testing.T) {
 		def := newDef(ParamInputs{
 			CLI: map[string]string{"second-value": "set"},
 		}, false)
-		def.standard = false
+		def.scope = ParamScopeWorkload
 		first := def.Param.String("first-value", "first", "")
 		second := def.Param.String("second-value", "second", "", LegacyEnvAliases("OLD_SECOND"))
 
@@ -260,11 +307,11 @@ func TestParamNamesAliasesAndDeferredUnknownChecks(t *testing.T) {
 		{
 			name: "unknown typed inputs sorted",
 			inputs: ParamInputs{
-				CLI:    map[string]string{"z-last": "1"},
-				Config: map[string]json.RawMessage{"aFirst": json.RawMessage(`1`)},
+				CLI:            map[string]string{"z-last": "1"},
+				WorkloadConfig: map[string]json.RawMessage{"aFirst": json.RawMessage(`1`)},
 			},
 			define: func(*Def) {},
-			want:   []string{`unknown CLI parameter "z-last"`, `unknown config parameter "aFirst"`},
+			want:   []string{`unknown CLI parameter "z-last"`, `unknown workload config parameter "aFirst"`},
 		},
 		{
 			name:   "duplicate",
@@ -291,7 +338,7 @@ func TestParamNamesAliasesAndDeferredUnknownChecks(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			def := newDef(test.inputs, false)
-			def.standard = false
+			def.scope = ParamScopeWorkload
 			test.define(def)
 
 			err := def.finish()
@@ -347,6 +394,8 @@ func TestDescribeUsesDefaultsAndCopiesSchema(t *testing.T) {
 
 	want := ParamSchema{
 		Name:             "batch-size",
+		Flag:             "--batch-size",
+		Scope:            ParamScopeWorkload,
 		Type:             ParamTypeInt,
 		Description:      "Rows in a batch.",
 		Default:          10,
@@ -354,19 +403,19 @@ func TestDescribeUsesDefaultsAndCopiesSchema(t *testing.T) {
 		LegacyEnvAliases: []string{"OLD_BATCH_SIZE"},
 		Config:           "batchSize",
 	}
-	if !reflect.DeepEqual(description.Params[0], want) {
-		t.Fatalf("workload schema = %#v, want %#v", description.Params[0], want)
+	if !reflect.DeepEqual(description.Params[4], want) {
+		t.Fatalf("workload schema = %#v, want %#v", description.Params[4], want)
 	}
 
-	description.Params[0].LegacyEnvAliases[0] = "MUTATED"
+	description.Params[4].LegacyEnvAliases[0] = "MUTATED"
 
 	again, err := Describe("test/describe-params")
 	if err != nil {
 		t.Fatalf("Describe() again error = %v", err)
 	}
 
-	if again.Params[0].LegacyEnvAliases[0] != "OLD_BATCH_SIZE" {
-		t.Fatalf("schema alias was mutated: %#v", again.Params[0])
+	if again.Params[4].LegacyEnvAliases[0] != "OLD_BATCH_SIZE" {
+		t.Fatalf("schema alias was mutated: %#v", again.Params[4])
 	}
 }
 
@@ -394,6 +443,41 @@ func TestRegistryFactoriesAreFreshAndDuplicatesPanic(t *testing.T) {
 	}()
 
 	Register(func() Workload { return &paramTestWorkload{name: "test/fresh-factory"} })
+}
+
+func TestRegisterRejectsTypedNilWorkload(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Register() accepted a typed-nil workload")
+		}
+	}()
+
+	var workload *paramTestWorkload
+
+	Register(func() Workload { return workload })
+}
+
+func TestLookupRejectsTypedNilWorkload(t *testing.T) {
+	calls := 0
+
+	Register(func() Workload {
+		calls++
+		if calls != 2 {
+			return &paramTestWorkload{name: "test/typed-nil-lookup"}
+		}
+
+		var workload *paramTestWorkload
+
+		return workload
+	})
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Lookup() accepted a typed-nil workload")
+		}
+	}()
+
+	_, _ = Lookup("test/typed-nil-lookup")
 }
 
 func TestDescribeAllIsSorted(t *testing.T) {
@@ -430,7 +514,7 @@ func TestScenarioTypedDurationRequiresExplicitConstantVUs(t *testing.T) {
 		t.Fatalf("scenario = %#v", spec)
 	}
 
-	spec, err = scenarioForTest(ParamInputs{Config: map[string]json.RawMessage{
+	spec, err = scenarioForTest(ParamInputs{RunConfig: map[string]json.RawMessage{
 		"executor": json.RawMessage(`"constant-vus"`),
 		"duration": json.RawMessage(`"3s"`),
 	}}, zap.NewNop())
@@ -480,6 +564,51 @@ func TestScenarioLegacyDurationInfersConstantVUsWithWarning(t *testing.T) {
 				t.Fatalf("executor = %q", legacySpec.executor)
 			}
 		})
+	}
+}
+
+func TestScenarioLegacyDurationIgnoresLegacyIterations(t *testing.T) {
+	clearScenarioEnv(t)
+
+	t.Setenv("DURATION", "2s")
+	t.Setenv("ITER", "invalid")
+
+	spec, err := scenarioForTest(ParamInputs{}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("legacy duration scenario error = %v", err)
+	}
+
+	if spec.executor != "constant-vus" || spec.duration != 2*time.Second {
+		t.Fatalf("scenario = %#v", spec)
+	}
+
+	clearParamEnv(t, "DURATION", "ITER")
+
+	for name, inputs := range map[string]ParamInputs{
+		"legacy -e": {
+			LegacyEnv: map[string]string{"DURATION": "2s", "ITER": "0"},
+		},
+		"legacy config env": {
+			LegacyConfigEnv: map[string]string{"DURATION": "2s", "ITER": "invalid"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := scenarioForTest(inputs, zap.NewNop()); err != nil {
+				t.Fatalf("legacy duration scenario error = %v", err)
+			}
+		})
+	}
+}
+
+func TestScenarioLegacyDurationStillValidatesTypedIterations(t *testing.T) {
+	clearScenarioEnv(t)
+
+	_, err := scenarioForTest(ParamInputs{
+		CLI:       map[string]string{"iterations": "0"},
+		LegacyEnv: map[string]string{"DURATION": "2s"},
+	}, zap.NewNop())
+	if err == nil || !strings.Contains(err.Error(), "iterations must be at least 1") {
+		t.Fatalf("typed iterations error = %v", err)
 	}
 }
 

--- a/pkg/bench/param_test.go
+++ b/pkg/bench/param_test.go
@@ -1,0 +1,616 @@
+package bench
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestParamResolutionPrecedence(t *testing.T) {
+	clearParamEnv(t, "SAMPLE_VALUE", "OLD_SAMPLE_VALUE")
+
+	tests := []struct {
+		name       string
+		processEnv *string
+		inputs     ParamInputs
+		want       string
+		wantSource ParamSource
+	}{
+		{
+			name: "CLI",
+			inputs: ParamInputs{
+				CLI:             map[string]string{"sample-value": "cli"},
+				LegacyEnv:       map[string]string{"SAMPLE_VALUE": "legacy-env"},
+				Config:          map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
+				LegacyConfigEnv: map[string]string{"SAMPLE_VALUE": "config-env"},
+			},
+			processEnv: stringPointer("process"),
+			want:       "cli",
+			wantSource: ParamSourceCLI,
+		},
+		{
+			name:       "process env",
+			processEnv: stringPointer("process"),
+			inputs: ParamInputs{
+				LegacyEnv:       map[string]string{"SAMPLE_VALUE": "legacy-env"},
+				Config:          map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
+				LegacyConfigEnv: map[string]string{"SAMPLE_VALUE": "config-env"},
+			},
+			want:       "process",
+			wantSource: ParamSourceProcessEnv,
+		},
+		{
+			name: "legacy -e",
+			inputs: ParamInputs{
+				LegacyEnv:       map[string]string{"SAMPLE_VALUE": "legacy-env"},
+				Config:          map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
+				LegacyConfigEnv: map[string]string{"SAMPLE_VALUE": "config-env"},
+			},
+			want:       "legacy-env",
+			wantSource: ParamSourceLegacyEnv,
+		},
+		{
+			name: "typed config",
+			inputs: ParamInputs{
+				Config:          map[string]json.RawMessage{"sampleValue": json.RawMessage(`"config"`)},
+				LegacyConfigEnv: map[string]string{"SAMPLE_VALUE": "config-env"},
+			},
+			want:       "config",
+			wantSource: ParamSourceConfig,
+		},
+		{
+			name: "legacy config env",
+			inputs: ParamInputs{
+				LegacyConfigEnv: map[string]string{"SAMPLE_VALUE": "config-env"},
+			},
+			want:       "config-env",
+			wantSource: ParamSourceLegacyConfigEnv,
+		},
+		{name: "default", want: "default", wantSource: ParamSourceDefault},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearParamEnv(t, "SAMPLE_VALUE", "OLD_SAMPLE_VALUE")
+
+			if test.processEnv != nil {
+				t.Setenv("SAMPLE_VALUE", *test.processEnv)
+			}
+
+			def := newDef(test.inputs, false)
+			def.standard = false
+
+			param := def.Param.String(
+				"sample-value", "default", "sample", LegacyEnvAliases("OLD_SAMPLE_VALUE"),
+			)
+			if err := def.finish(); err != nil {
+				t.Fatalf("finish() error = %v", err)
+			}
+
+			if param.Value() != test.want || param.Source() != test.wantSource {
+				t.Fatalf("param = (%q, %q), want (%q, %q)", param.Value(), param.Source(), test.want, test.wantSource)
+			}
+
+			if param.Explicit() != (test.wantSource != ParamSourceDefault) {
+				t.Fatalf("Explicit() = %v, source = %q", param.Explicit(), param.Source())
+			}
+		})
+	}
+}
+
+func TestParamConcreteTypesFromCLI(t *testing.T) {
+	clearParamEnv(t, "EMPTY", "ENABLED", "COUNT", "LARGE", "UNSIGNED", "RATIO", "TIMEOUT")
+
+	def := newDef(ParamInputs{CLI: map[string]string{
+		"empty":    "",
+		"enabled":  "true",
+		"count":    "-12",
+		"large":    "9223372036854775807",
+		"unsigned": "18446744073709551615",
+		"ratio":    "1.25",
+		"timeout":  "1m30s",
+	}}, false)
+	def.standard = false
+
+	empty := def.Param.String("empty", "fallback", "")
+	enabled := def.Param.Bool("enabled", false, "")
+	count := def.Param.Int("count", 0, "")
+	large := def.Param.Int64("large", 0, "")
+	unsigned := def.Param.Uint64("unsigned", 0, "")
+	ratio := def.Param.Float64("ratio", 0, "")
+	timeout := def.Param.Duration("timeout", 0, "")
+
+	if err := def.finish(); err != nil {
+		t.Fatalf("finish() error = %v", err)
+	}
+
+	if empty.Value() != "" || !enabled.Value() || count.Value() != -12 ||
+		large.Value() != int64(9223372036854775807) ||
+		unsigned.Value() != uint64(18446744073709551615) ||
+		ratio.Value() != 1.25 || timeout.Value() != 90*time.Second {
+		t.Fatalf("unexpected typed values: %q %v %d %d %d %v %s",
+			empty.Value(), enabled.Value(), count.Value(), large.Value(), unsigned.Value(), ratio.Value(), timeout.Value())
+	}
+}
+
+func TestParamConcreteTypesFromNativeConfig(t *testing.T) {
+	clearParamEnv(t, "TEXT", "ENABLED", "COUNT", "LARGE", "UNSIGNED", "RATIO", "TIMEOUT")
+
+	def := newDef(ParamInputs{Config: map[string]json.RawMessage{
+		"text":     json.RawMessage(`"value"`),
+		"enabled":  json.RawMessage(`true`),
+		"count":    json.RawMessage(`-12`),
+		"large":    json.RawMessage(`9223372036854775807`),
+		"unsigned": json.RawMessage(`18446744073709551615`),
+		"ratio":    json.RawMessage(`1.25`),
+		"timeout":  json.RawMessage(`"1m30s"`),
+	}}, false)
+	def.standard = false
+
+	text := def.Param.String("text", "", "")
+	enabled := def.Param.Bool("enabled", false, "")
+	count := def.Param.Int("count", 0, "")
+	large := def.Param.Int64("large", 0, "")
+	unsigned := def.Param.Uint64("unsigned", 0, "")
+	ratio := def.Param.Float64("ratio", 0, "")
+	timeout := def.Param.Duration("timeout", 0, "")
+
+	if err := def.finish(); err != nil {
+		t.Fatalf("finish() error = %v", err)
+	}
+
+	if text.Value() != "value" || !enabled.Value() || count.Value() != -12 ||
+		large.Value() != int64(9223372036854775807) ||
+		unsigned.Value() != uint64(18446744073709551615) ||
+		ratio.Value() != 1.25 || timeout.Value() != 90*time.Second {
+		t.Fatalf("unexpected typed config values")
+	}
+}
+
+func TestParamRejectsEmptyNonStringAndInvalidConfigTypes(t *testing.T) {
+	clearParamEnv(t, "ENABLED", "COUNT", "TIMEOUT", "TEXT")
+
+	tests := []struct {
+		name   string
+		inputs ParamInputs
+		define func(*Def)
+		want   string
+	}{
+		{
+			name:   "empty bool",
+			inputs: ParamInputs{CLI: map[string]string{"enabled": ""}},
+			define: func(def *Def) { def.Param.Bool("enabled", false, "") },
+			want:   "invalid syntax",
+		},
+		{
+			name:   "config null",
+			inputs: ParamInputs{Config: map[string]json.RawMessage{"count": json.RawMessage(`null`)}},
+			define: func(def *Def) { def.Param.Int("count", 1, "") },
+			want:   "null is not allowed",
+		},
+		{
+			name:   "config number as string",
+			inputs: ParamInputs{Config: map[string]json.RawMessage{"count": json.RawMessage(`"1"`)}},
+			define: func(def *Def) { def.Param.Int("count", 1, "") },
+			want:   "cannot unmarshal string",
+		},
+		{
+			name:   "config duration as number",
+			inputs: ParamInputs{Config: map[string]json.RawMessage{"timeout": json.RawMessage(`10`)}},
+			define: func(def *Def) { def.Param.Duration("timeout", time.Second, "") },
+			want:   "cannot unmarshal number",
+		},
+		{
+			name:   "config string as bool",
+			inputs: ParamInputs{Config: map[string]json.RawMessage{"enabled": json.RawMessage(`"true"`)}},
+			define: func(def *Def) { def.Param.Bool("enabled", false, "") },
+			want:   "cannot unmarshal string",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			def := newDef(test.inputs, false)
+			def.standard = false
+			test.define(def)
+
+			err := def.finish()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("finish() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestParamNamesAliasesAndDeferredUnknownChecks(t *testing.T) {
+	clearParamEnv(t, "FIRST_VALUE", "SECOND_VALUE", "OLD_SECOND")
+
+	t.Run("later declaration is known", func(t *testing.T) {
+		def := newDef(ParamInputs{
+			CLI: map[string]string{"second-value": "set"},
+		}, false)
+		def.standard = false
+		first := def.Param.String("first-value", "first", "")
+		second := def.Param.String("second-value", "second", "", LegacyEnvAliases("OLD_SECOND"))
+
+		if err := def.finish(); err != nil {
+			t.Fatalf("finish() error = %v", err)
+		}
+
+		if first.Value() != "first" || second.Value() != "set" {
+			t.Fatalf("values = %q, %q", first.Value(), second.Value())
+		}
+	})
+
+	tests := []struct {
+		name   string
+		inputs ParamInputs
+		define func(*Def)
+		want   []string
+	}{
+		{
+			name: "unknown typed inputs sorted",
+			inputs: ParamInputs{
+				CLI:    map[string]string{"z-last": "1"},
+				Config: map[string]json.RawMessage{"aFirst": json.RawMessage(`1`)},
+			},
+			define: func(*Def) {},
+			want:   []string{`unknown CLI parameter "z-last"`, `unknown config parameter "aFirst"`},
+		},
+		{
+			name:   "duplicate",
+			define: func(def *Def) { def.Param.Int("batch-size", 1, ""); def.Param.Int("batch-size", 2, "") },
+			want:   []string{`duplicate parameter name "batch-size"`},
+		},
+		{
+			name:   "reserved",
+			define: func(def *Def) { def.Param.String("duration", "", "") },
+			want:   []string{`reserved parameter name "duration"`},
+		},
+		{
+			name:   "invalid name",
+			define: func(def *Def) { def.Param.String("Bad_Name", "", "") },
+			want:   []string{`invalid parameter name "Bad_Name"`},
+		},
+		{
+			name:   "invalid alias",
+			define: func(def *Def) { def.Param.String("value", "", "", LegacyEnvAliases("old-value")) },
+			want:   []string{`invalid legacy env alias "old-value"`},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			def := newDef(test.inputs, false)
+			def.standard = false
+			test.define(def)
+
+			err := def.finish()
+			if err == nil {
+				t.Fatal("finish() error = nil")
+			}
+
+			for _, want := range test.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("finish() error = %v, want containing %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDescribeUsesDefaultsAndCopiesSchema(t *testing.T) {
+	clearParamEnv(t, "BATCH_SIZE", "OLD_BATCH_SIZE", "VUS", "ITERATIONS", "ITER", "DURATION", "EXECUTOR")
+	t.Setenv("BATCH_SIZE", "99")
+	t.Setenv("VUS", "not-an-int")
+
+	var setupCalls atomic.Int64
+
+	Register(func() Workload {
+		return &paramTestWorkload{
+			name: "test/describe-params",
+			define: func(def *Def) error {
+				param := def.Param.Int(
+					"batch-size", 10, "Rows in a batch.", LegacyEnvAliases("OLD_BATCH_SIZE"),
+				)
+				if param.Value() != 10 || param.Source() != ParamSourceDefault {
+					return errors.New("description resolved a current value")
+				}
+
+				return nil
+			},
+			setup: func() { setupCalls.Add(1) },
+		}
+	})
+
+	description, err := Describe("test/describe-params")
+	if err != nil {
+		t.Fatalf("Describe() error = %v", err)
+	}
+
+	if setupCalls.Load() != 0 {
+		t.Fatalf("Setup calls = %d, want 0", setupCalls.Load())
+	}
+
+	if description.Name != "test/describe-params" || len(description.Params) != 5 {
+		t.Fatalf("description = %#v", description)
+	}
+
+	want := ParamSchema{
+		Name:             "batch-size",
+		Type:             ParamTypeInt,
+		Description:      "Rows in a batch.",
+		Default:          10,
+		Env:              "BATCH_SIZE",
+		LegacyEnvAliases: []string{"OLD_BATCH_SIZE"},
+		Config:           "batchSize",
+	}
+	if !reflect.DeepEqual(description.Params[0], want) {
+		t.Fatalf("workload schema = %#v, want %#v", description.Params[0], want)
+	}
+
+	description.Params[0].LegacyEnvAliases[0] = "MUTATED"
+
+	again, err := Describe("test/describe-params")
+	if err != nil {
+		t.Fatalf("Describe() again error = %v", err)
+	}
+
+	if again.Params[0].LegacyEnvAliases[0] != "OLD_BATCH_SIZE" {
+		t.Fatalf("schema alias was mutated: %#v", again.Params[0])
+	}
+}
+
+func TestRegistryFactoriesAreFreshAndDuplicatesPanic(t *testing.T) {
+	Register(func() Workload { return &paramTestWorkload{name: "test/fresh-factory"} })
+
+	first, ok := Lookup("test/fresh-factory")
+	if !ok {
+		t.Fatal("first Lookup() missed registered workload")
+	}
+
+	second, ok := Lookup("test/fresh-factory")
+	if !ok {
+		t.Fatal("second Lookup() missed registered workload")
+	}
+
+	if first == second {
+		t.Fatal("Lookup() returned the same workload instance")
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("duplicate Register() did not panic")
+		}
+	}()
+
+	Register(func() Workload { return &paramTestWorkload{name: "test/fresh-factory"} })
+}
+
+func TestDescribeAllIsSorted(t *testing.T) {
+	descriptions, err := DescribeAll()
+	if err != nil {
+		t.Fatalf("DescribeAll() error = %v", err)
+	}
+
+	for idx := 1; idx < len(descriptions); idx++ {
+		if descriptions[idx-1].Name > descriptions[idx].Name {
+			t.Fatalf("descriptions are not sorted at %d: %q > %q", idx, descriptions[idx-1].Name, descriptions[idx].Name)
+		}
+	}
+}
+
+func TestScenarioTypedDurationRequiresExplicitConstantVUs(t *testing.T) {
+	clearScenarioEnv(t)
+
+	_, err := scenarioForTest(ParamInputs{CLI: map[string]string{"duration": "2s"}}, zap.NewNop())
+	if err == nil || !strings.Contains(err.Error(), "explicit constant-vus") {
+		t.Fatalf("typed duration error = %v", err)
+	}
+
+	spec, err := scenarioForTest(ParamInputs{CLI: map[string]string{
+		"executor": "constant-vus",
+		"duration": "2s",
+		"vus":      "3",
+	}}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("scenarioForTest() error = %v", err)
+	}
+
+	if spec.executor != "constant-vus" || spec.duration != 2*time.Second || spec.vus != 3 {
+		t.Fatalf("scenario = %#v", spec)
+	}
+
+	spec, err = scenarioForTest(ParamInputs{Config: map[string]json.RawMessage{
+		"executor": json.RawMessage(`"constant-vus"`),
+		"duration": json.RawMessage(`"3s"`),
+	}}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("config scenario error = %v", err)
+	}
+
+	if spec.executor != "constant-vus" || spec.duration != 3*time.Second {
+		t.Fatalf("config scenario = %#v", spec)
+	}
+}
+
+func TestScenarioLegacyDurationInfersConstantVUsWithWarning(t *testing.T) {
+	clearScenarioEnv(t)
+
+	core, observed := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	t.Setenv("DURATION", "2s")
+
+	spec, err := scenarioForTest(ParamInputs{}, logger)
+	if err != nil {
+		t.Fatalf("process env scenario error = %v", err)
+	}
+
+	if spec.executor != "constant-vus" || spec.duration != 2*time.Second {
+		t.Fatalf("process env scenario = %#v", spec)
+	}
+
+	if observed.FilterMessage("legacy DURATION inferred the constant-vus executor; set executor explicitly").Len() != 1 {
+		t.Fatalf("warnings = %#v", observed.All())
+	}
+
+	clearParamEnv(t, "DURATION")
+
+	for name, inputs := range map[string]ParamInputs{
+		"legacy -e":         {LegacyEnv: map[string]string{"DURATION": "3s"}},
+		"legacy config env": {LegacyConfigEnv: map[string]string{"DURATION": "4s"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			legacySpec, err := scenarioForTest(inputs, zap.NewNop())
+			if err != nil {
+				t.Fatalf("scenario error = %v", err)
+			}
+
+			if legacySpec.executor != "constant-vus" {
+				t.Fatalf("executor = %q", legacySpec.executor)
+			}
+		})
+	}
+}
+
+func TestScenarioValidation(t *testing.T) {
+	clearScenarioEnv(t)
+
+	tests := []struct {
+		name   string
+		cli    map[string]string
+		legacy map[string]string
+		want   string
+	}{
+		{name: "vus", cli: map[string]string{"vus": "0"}, want: "vus must be at least 1"},
+		{name: "iterations", cli: map[string]string{"iterations": "0"}, want: "iterations must be at least 1"},
+		{name: "executor", cli: map[string]string{"executor": "other"}, want: "unsupported executor"},
+		{name: "constant needs duration", cli: map[string]string{"executor": "constant-vus"}, want: "requires duration"},
+		{
+			name: "duration positive",
+			cli:  map[string]string{"executor": "constant-vus", "duration": "0s"},
+			want: "duration must be positive",
+		},
+		{
+			name:   "explicit shared rejects legacy duration",
+			cli:    map[string]string{"executor": "shared-iterations"},
+			legacy: map[string]string{"DURATION": "1s"},
+			want:   "only valid with the constant-vus",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := scenarioForTest(ParamInputs{CLI: test.cli, LegacyEnv: test.legacy}, zap.NewNop())
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("scenario error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestRunResolvesParamsBeforeDriverInitialization(t *testing.T) {
+	clearScenarioEnv(t)
+	clearParamEnv(t, "COUNT")
+
+	Register(func() Workload {
+		return &paramTestWorkload{
+			name: "test/invalid-before-driver",
+			define: func(def *Def) error {
+				def.Param.Int("count", 1, "")
+
+				return nil
+			},
+		}
+	})
+
+	err := Run(
+		context.Background(),
+		"test/invalid-before-driver",
+		nil,
+		nil,
+		ParamInputs{CLI: map[string]string{"count": "invalid"}},
+		zap.NewNop(),
+		&MetricsConfig{},
+	)
+
+	if err == nil || !strings.Contains(err.Error(), `parameter "count"`) {
+		t.Fatalf("Run() error = %v, want parameter parse error", err)
+	}
+
+	if strings.Contains(err.Error(), errDriverIndexMissing.Error()) {
+		t.Fatalf("Run() initialized driver before params: %v", err)
+	}
+}
+
+func scenarioForTest(inputs ParamInputs, logger *zap.Logger) (scenarioSpec, error) {
+	params, _, err := defineWorkload(&paramTestWorkload{name: "test/scenario"}, inputs, false)
+	if err != nil {
+		return scenarioSpec{}, err
+	}
+
+	return params.spec(logger)
+}
+
+type paramTestWorkload struct {
+	name   string
+	define func(*Def) error
+	setup  func()
+}
+
+func (w *paramTestWorkload) Name() string { return w.name }
+
+func (w *paramTestWorkload) Define(def *Def) error {
+	if w.define == nil {
+		return nil
+	}
+
+	return w.define(def)
+}
+
+func (w *paramTestWorkload) Setup(context.Context, *Bench) error {
+	if w.setup != nil {
+		w.setup()
+	}
+
+	return nil
+}
+
+func (*paramTestWorkload) Iterate(context.Context, *Bench) error  { return nil }
+func (*paramTestWorkload) Teardown(context.Context, *Bench) error { return nil }
+
+func clearScenarioEnv(t *testing.T) {
+	t.Helper()
+	clearParamEnv(t, "EXECUTOR", "VUS", "ITERATIONS", "ITER", "DURATION")
+}
+
+func clearParamEnv(t *testing.T, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		value, present := os.LookupEnv(name)
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("Unsetenv(%q): %v", name, err)
+		}
+
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(name, value)
+			} else {
+				_ = os.Unsetenv(name)
+			}
+		})
+	}
+}
+
+func stringPointer(value string) *string { return &value }

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -17,10 +18,12 @@ import (
 	"github.com/stroppy-io/stroppy/pkg/driver"
 )
 
-// Workload is a Go-native benchmark. Setup runs once (schema + load steps);
-// Iterate is the measured body driven across VUs by the executor; Teardown runs once.
+// Workload is a Go-native benchmark. Define declares and binds typed parameters;
+// Setup runs once (schema + load steps); Iterate is the measured body driven across
+// VUs by the executor; Teardown runs once.
 type Workload interface {
 	Name() string
+	Define(def *Def) error
 	Setup(ctx context.Context, b *Bench) error
 	Iterate(ctx context.Context, b *Bench) error
 	Teardown(ctx context.Context, b *Bench) error
@@ -58,42 +61,116 @@ func (b *Bench) Logger() *zap.Logger { return b.lg }
 // --- registry ---
 
 var (
-	regMu        sync.Mutex
-	regWorkloads = map[string]Workload{}
+	regMu        sync.RWMutex
+	regWorkloads = map[string]func() Workload{}
 
-	errNoWorkloadRegistered = errors.New("bench: no workload registered")
-	errDriverIndexMissing   = errors.New("bench: driver index 0 not configured")
-	errUnsupportedExecutor  = errors.New("unsupported executor")
+	errNoWorkloadRegistered      = errors.New("bench: no workload registered")
+	errDriverIndexMissing        = errors.New("bench: driver index 0 not configured")
+	errUnsupportedExecutor       = errors.New("unsupported executor")
+	errVUsOutOfRange             = errors.New("vus must be at least 1")
+	errIterationsOutOfRange      = errors.New("iterations must be at least 1")
+	errDurationOutOfRange        = errors.New("duration must be positive")
+	errDurationNeedsExecutor     = errors.New("duration requires an explicit constant-vus executor")
+	errDurationWithWrongExecutor = errors.New("duration is only valid with the constant-vus executor")
+	errConstantVUsNeedsDuration  = errors.New("constant-vus requires duration")
 )
 
-// Register a Go workload (called from workload init()).
-func Register(w Workload) {
+// Register adds a workload factory. Workload packages call it during init.
+func Register(factory func() Workload) {
+	if factory == nil {
+		panic("bench: register nil workload factory")
+	}
+
+	wl := factory()
+	if wl == nil {
+		panic("bench: workload factory returned nil")
+	}
+
+	name := wl.Name()
+	if name == "" {
+		panic("bench: register workload with empty name")
+	}
+
 	regMu.Lock()
 	defer regMu.Unlock()
 
-	regWorkloads[w.Name()] = w
+	if _, exists := regWorkloads[name]; exists {
+		panic(fmt.Sprintf("bench: workload %q already registered", name))
+	}
+
+	regWorkloads[name] = factory
 }
 
-// Lookup a registered Go workload by name.
+// Lookup returns a fresh instance of a registered Go workload.
 func Lookup(name string) (Workload, bool) {
-	regMu.Lock()
-	defer regMu.Unlock()
+	regMu.RLock()
 
-	w, ok := regWorkloads[name]
+	factory, ok := regWorkloads[name]
 
-	return w, ok
+	regMu.RUnlock()
+
+	if !ok {
+		return nil, false
+	}
+
+	wl := factory()
+	if wl == nil || wl.Name() != name {
+		panic(fmt.Sprintf("bench: workload factory for %q returned an invalid workload", name))
+	}
+
+	return wl, true
 }
 
-// Run looks up the named Go workload and executes it: Setup once, Iterate across the
-// scenario, Teardown once. drivers carries the resolved per-index driver configs (same
-// *stroppy.DriverConfig the TS path consumes); env is the script env (-e overrides +
-// config), consulted by Env after the real process environment. Scenario comes from
-// VUS/DURATION/ITER env.
+// Describe returns a workload's deterministic parameter schema without setup or drivers.
+func Describe(name string) (Description, error) {
+	wl, ok := Lookup(name)
+	if !ok {
+		return Description{}, fmt.Errorf("%w as %q", errNoWorkloadRegistered, name)
+	}
+
+	_, schema, err := defineWorkload(wl, ParamInputs{}, true)
+	if err != nil {
+		return Description{}, fmt.Errorf("define workload %q: %w", name, err)
+	}
+
+	return Description{Name: name, Params: schema}, nil
+}
+
+// DescribeAll returns all registered workload schemas ordered by workload name.
+func DescribeAll() ([]Description, error) {
+	regMu.RLock()
+
+	names := make([]string, 0, len(regWorkloads))
+	for name := range regWorkloads {
+		names = append(names, name)
+	}
+
+	regMu.RUnlock()
+
+	slices.Sort(names)
+
+	descriptions := make([]Description, 0, len(names))
+	for _, name := range names {
+		description, err := Describe(name)
+		if err != nil {
+			return nil, err
+		}
+
+		descriptions = append(descriptions, description)
+	}
+
+	return descriptions, nil
+}
+
+// Run looks up a fresh workload instance and executes it: Define and parameter
+// resolution first, Setup once, Iterate across the scenario, then Teardown once.
+// env remains available to legacy workload Env calls through the root state.
 func Run(
 	ctx context.Context,
 	name string,
 	drivers map[int]*stroppy.DriverConfig,
 	env map[string]string,
+	paramInputs ParamInputs,
 	lg *zap.Logger,
 	metricsConfig *MetricsConfig,
 ) error {
@@ -102,7 +179,15 @@ func Run(
 		return fmt.Errorf("%w as %q", errNoWorkloadRegistered, name)
 	}
 
-	var err error
+	scenarioParams, _, err := defineWorkload(wl, paramInputs, false)
+	if err != nil {
+		return fmt.Errorf("define workload %q: %w", name, err)
+	}
+
+	sc, err := scenarioParams.spec(lg)
+	if err != nil {
+		return fmt.Errorf("scenario: %w", err)
+	}
 
 	root, err = newRootState(lg, ctx, env, metricsConfig)
 	if err != nil {
@@ -136,7 +221,6 @@ func Run(
 		return fmt.Errorf("setup: %w", err)
 	}
 
-	sc := readScenario()
 	if err := runScenario(ctx, sc, func(vu *VU) error {
 		b := &Bench{
 			root: root, vu: vu,
@@ -156,7 +240,7 @@ func Run(
 	return nil
 }
 
-// --- scenario (read from env, mirrors declareScenario) ---
+// --- scenario ---
 
 type scenarioSpec struct {
 	name       string
@@ -166,26 +250,94 @@ type scenarioSpec struct {
 	duration   time.Duration
 }
 
-func readScenario() scenarioSpec {
-	spec := scenarioSpec{name: "workload"}
+type scenarioParams struct {
+	executor   Param[string]
+	vus        Param[int]
+	iterations Param[int64]
+	duration   Param[time.Duration]
+}
 
-	spec.vus = max(EnvInt("VUS", 1), 1)
+func defineWorkload(
+	wl Workload,
+	inputs ParamInputs,
+	defaultsOnly bool,
+) (scenarioParams, []ParamSchema, error) {
+	def := newDef(inputs, defaultsOnly)
+	params := scenarioParams{
+		executor: def.Param.String(
+			"executor", "shared-iterations", "Scenario executor: shared-iterations or constant-vus.",
+		),
+		vus: def.Param.Int("vus", 1, "Number of concurrent virtual users."),
+		iterations: def.Param.Int64(
+			"iterations", 1, "Total shared iterations.", LegacyEnvAliases("ITER"),
+		),
+		duration: def.Param.Duration("duration", 0, "Duration of a constant-vus scenario."),
+	}
 
-	if d := Env("DURATION", ""); d != "" {
-		dur, err := time.ParseDuration(d)
-		if err == nil {
-			spec.executor = "constant-vus"
-			spec.duration = dur
+	def.standard = false
+	defineErr := wl.Define(def)
 
-			return spec
+	return params, def.schema(), errors.Join(defineErr, def.finish())
+}
+
+func (params *scenarioParams) spec(lg *zap.Logger) (scenarioSpec, error) {
+	executor := params.executor.Value()
+	legacyDuration := params.duration.Explicit() && slices.Contains([]ParamSource{
+		ParamSourceProcessEnv,
+		ParamSourceLegacyEnv,
+		ParamSourceLegacyConfigEnv,
+	}, params.duration.Source())
+
+	if legacyDuration && !params.executor.Explicit() {
+		executor = "constant-vus"
+
+		if lg != nil {
+			lg.Warn(
+				"legacy DURATION inferred the constant-vus executor; set executor explicitly",
+				zap.String("source", string(params.duration.Source())),
+			)
 		}
 	}
 
-	spec.executor = "shared-iterations"
+	if params.vus.Value() < 1 {
+		return scenarioSpec{}, fmt.Errorf("%w, got %d", errVUsOutOfRange, params.vus.Value())
+	}
 
-	spec.iterations = int64(max(EnvInt("ITER", 1), 1))
+	if params.iterations.Value() < 1 {
+		return scenarioSpec{}, fmt.Errorf("%w, got %d", errIterationsOutOfRange, params.iterations.Value())
+	}
 
-	return spec
+	if params.duration.Explicit() && params.duration.Value() <= 0 {
+		return scenarioSpec{}, fmt.Errorf("%w, got %s", errDurationOutOfRange, params.duration.Value())
+	}
+
+	if params.duration.Explicit() && !legacyDuration &&
+		(!params.executor.Explicit() || executor != "constant-vus") {
+		return scenarioSpec{}, errDurationNeedsExecutor
+	}
+
+	spec := scenarioSpec{
+		name:       "workload",
+		executor:   executor,
+		vus:        params.vus.Value(),
+		iterations: params.iterations.Value(),
+		duration:   params.duration.Value(),
+	}
+
+	switch executor {
+	case "shared-iterations":
+		if params.duration.Explicit() {
+			return scenarioSpec{}, errDurationWithWrongExecutor
+		}
+	case "constant-vus":
+		if !params.duration.Explicit() {
+			return scenarioSpec{}, errConstantVUsNeedsDuration
+		}
+	default:
+		return scenarioSpec{}, fmt.Errorf("%w %q", errUnsupportedExecutor, executor)
+	}
+
+	return spec, nil
 }
 
 // --- executor (shared-iterations + constant-vus) ---

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -82,7 +83,7 @@ func Register(factory func() Workload) {
 	}
 
 	wl := factory()
-	if wl == nil {
+	if nilWorkload(wl) {
 		panic("bench: workload factory returned nil")
 	}
 
@@ -114,11 +115,25 @@ func Lookup(name string) (Workload, bool) {
 	}
 
 	wl := factory()
-	if wl == nil || wl.Name() != name {
+	if nilWorkload(wl) || wl.Name() != name {
 		panic(fmt.Sprintf("bench: workload factory for %q returned an invalid workload", name))
 	}
 
 	return wl, true
+}
+
+func nilWorkload(workload Workload) bool {
+	if workload == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(workload)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // Describe returns a workload's deterministic parameter schema without setup or drivers.
@@ -263,21 +278,75 @@ func defineWorkload(
 	defaultsOnly bool,
 ) (scenarioParams, []ParamSchema, error) {
 	def := newDef(inputs, defaultsOnly)
+
+	iterationOptions := []ParamOption{LegacyEnvAliases("ITER")}
+	if !defaultsOnly && legacyDurationWillInfer(inputs) {
+		iterationOptions = nil
+	}
+
 	params := scenarioParams{
 		executor: def.Param.String(
 			"executor", "shared-iterations", "Scenario executor: shared-iterations or constant-vus.",
 		),
 		vus: def.Param.Int("vus", 1, "Number of concurrent virtual users."),
 		iterations: def.Param.Int64(
-			"iterations", 1, "Total shared iterations.", LegacyEnvAliases("ITER"),
+			"iterations", 1, "Total shared iterations.", iterationOptions...,
 		),
 		duration: def.Param.Duration("duration", 0, "Duration of a constant-vus scenario."),
 	}
 
-	def.standard = false
+	def.scope = ParamScopeWorkload
 	defineErr := wl.Define(def)
 
 	return params, def.schema(), errors.Join(defineErr, def.finish())
+}
+
+func legacyDurationWillInfer(inputs ParamInputs) bool {
+	legacyDuration := false
+
+	if _, ok := inputs.CLI["duration"]; ok {
+		return false
+	}
+
+	_, processDuration := os.LookupEnv("DURATION")
+	_, legacyEnvDuration := inputs.LegacyEnv["DURATION"]
+	_, runConfigDuration := inputs.RunConfig["duration"]
+	_, configEnvDuration := inputs.LegacyConfigEnv["DURATION"]
+
+	switch {
+	case processDuration:
+		legacyDuration = true
+	case legacyEnvDuration:
+		legacyDuration = true
+	case runConfigDuration:
+		return false
+	case configEnvDuration:
+		legacyDuration = true
+	}
+
+	return legacyDuration && !executorExplicit(inputs)
+}
+
+func executorExplicit(inputs ParamInputs) bool {
+	if _, ok := inputs.CLI["executor"]; ok {
+		return true
+	}
+
+	if _, ok := os.LookupEnv("EXECUTOR"); ok {
+		return true
+	}
+
+	if _, ok := inputs.LegacyEnv["EXECUTOR"]; ok {
+		return true
+	}
+
+	if _, ok := inputs.RunConfig["executor"]; ok {
+		return true
+	}
+
+	_, ok := inputs.LegacyConfigEnv["EXECUTOR"]
+
+	return ok
 }
 
 func (params *scenarioParams) spec(lg *zap.Logger) (scenarioSpec, error) {

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -280,7 +280,7 @@ func defineWorkload(
 	def := newDef(inputs, defaultsOnly)
 
 	iterationOptions := []ParamOption{LegacyEnvAliases("ITER")}
-	if !defaultsOnly && legacyDurationWillInfer(inputs) {
+	if !defaultsOnly && effectiveDurationIsLegacy(inputs) {
 		iterationOptions = nil
 	}
 
@@ -301,9 +301,7 @@ func defineWorkload(
 	return params, def.schema(), errors.Join(defineErr, def.finish())
 }
 
-func legacyDurationWillInfer(inputs ParamInputs) bool {
-	legacyDuration := false
-
+func effectiveDurationIsLegacy(inputs ParamInputs) bool {
 	if _, ok := inputs.CLI["duration"]; ok {
 		return false
 	}
@@ -314,39 +312,13 @@ func legacyDurationWillInfer(inputs ParamInputs) bool {
 	_, configEnvDuration := inputs.LegacyConfigEnv["DURATION"]
 
 	switch {
-	case processDuration:
-		legacyDuration = true
-	case legacyEnvDuration:
-		legacyDuration = true
+	case processDuration, legacyEnvDuration:
+		return true
 	case runConfigDuration:
 		return false
-	case configEnvDuration:
-		legacyDuration = true
+	default:
+		return configEnvDuration
 	}
-
-	return legacyDuration && !executorExplicit(inputs)
-}
-
-func executorExplicit(inputs ParamInputs) bool {
-	if _, ok := inputs.CLI["executor"]; ok {
-		return true
-	}
-
-	if _, ok := os.LookupEnv("EXECUTOR"); ok {
-		return true
-	}
-
-	if _, ok := inputs.LegacyEnv["EXECUTOR"]; ok {
-		return true
-	}
-
-	if _, ok := inputs.RunConfig["executor"]; ok {
-		return true
-	}
-
-	_, ok := inputs.LegacyConfigEnv["EXECUTOR"]
-
-	return ok
 }
 
 func (params *scenarioParams) spec(lg *zap.Logger) (scenarioSpec, error) {

--- a/pkg/bench/runtime_test.go
+++ b/pkg/bench/runtime_test.go
@@ -75,14 +75,20 @@ func TestRunScenarioReturnsParentCancellation(t *testing.T) {
 }
 
 func TestRunPassesScenarioCancellationToWorkload(t *testing.T) {
-	workload := &fatalContextWorkload{secondStarted: make(chan struct{})}
-	Register(workload)
+	var workload *fatalContextWorkload
+
+	Register(func() Workload {
+		workload = &fatalContextWorkload{secondStarted: make(chan struct{})}
+
+		return workload
+	})
 
 	err := Run(
 		context.Background(),
-		workload.Name(),
+		"test/fatal-context",
 		map[int]*stroppy.DriverConfig{0: {DriverType: stroppy.DriverConfig_DRIVER_TYPE_NOOP}},
 		map[string]string{"VUS": "2", "ITER": "2"},
+		ParamInputs{LegacyEnv: map[string]string{"VUS": "2", "ITER": "2"}},
 		zap.NewNop(),
 		&MetricsConfig{},
 	)
@@ -103,6 +109,8 @@ type fatalContextWorkload struct {
 }
 
 func (*fatalContextWorkload) Name() string { return "test/fatal-context" }
+
+func (*fatalContextWorkload) Define(*Def) error { return nil }
 
 func (w *fatalContextWorkload) Setup(context.Context, *Bench) error {
 	w.fatalErr = errors.New("fatal iteration")

--- a/testdata/csv/tpcb_sf1/README.md
+++ b/testdata/csv/tpcb_sf1/README.md
@@ -1,8 +1,7 @@
 # Golden SHA-256 hashes — TPC-B SF=1 via the CSV driver
 
 Each `<table>.csv.sha256` is the hex-encoded SHA-256 of the
-corresponding merged CSV emitted by `workloads/tpcb/tx.ts` at
-`SCALE_FACTOR=1` with the CSV driver's default options (`?merge=true`,
+corresponding merged CSV emitted by `tpcb/tx` at a scale factor of 1 with the CSV driver's default options (`?merge=true`,
 comma separator, headers on).
 
 Shape: header row + 1 / 10 / 100_000 data rows for
@@ -14,11 +13,11 @@ line endings, RFC-4180 quoting as produced by `encoding/csv`.
 ## Regenerate
 
 ```
-./build/stroppy run ./workloads/tpcb/tx.ts \
+./build/stroppy run tpcb/tx \
   -D url='/tmp/tpcb-csv?merge=true&workload=tpcb_sf1' \
   -D driverType=csv \
-  -e SCALE_FACTOR=1 \
-  -e LOAD_WORKERS=1 \
+  --scale-factor 1 \
+  --load-workers 1 \
   --steps drop_schema,create_schema,load_data
 
 sha256sum /tmp/tpcb-csv/tpcb_sf1/*.csv > new-hashes.txt

--- a/workloads/tpcb/README.md
+++ b/workloads/tpcb/README.md
@@ -28,18 +28,18 @@ Replace `pg` with `mysql`, `pico`, or `ydb` to change driver.
 ./build/stroppy run ./workloads/tpcb/tx.ts \
   -D url='/tmp/tpcb-csv?merge=true&workload=tpcb' \
   -D driverType=csv \
-  -e SCALE_FACTOR=1 \
+  --scale-factor 1 \
   --steps drop_schema,create_schema,load_data
 
 # Stored-procs variant (pg / mysql only)
 ./build/stroppy run tpcb/procs -d pg
 ```
 
-Useful env overrides:
+Useful parameters (`stroppy run tpcb/tx --help` lists the full schema):
 
 ```bash
--e scale_factor=10     # N branches × 10 tellers × 100_000 accounts
--e pool_size=200       # per-VU connection pool size
+--scale-factor 10       # N branches × 10 tellers × 100_000 accounts
+-e pool_size=200        # compatibility override for the driver pool size
 ```
 
 ## Steps
@@ -73,22 +73,23 @@ go test -tags=integration -run TestTpcbWorkloadEndToEnd ./test/integration/... -
 
 ## Run shapes and the two-run flow
 
-All TPC workloads share one set of run knobs (set with `-e KEY=VALUE`, **not** the
-`-u/-d/-i` k6 shortcuts, which would discard the scenario):
+All TPC workloads share typed run flags:
 
-- `DURATION` set → fixed-duration throughput test (constant `VUS`); result is TPS.
-- `DURATION` unset → power test (`ITER` iterations); result is elapsed time.
-- `MAX_DURATION` (default `24h`) lifts k6's 10-minute per-iteration cap for large loads.
-- `PG_UNLOGGED=true` enables the PostgreSQL `UNLOGGED` bulk-load dance (off by default).
+- `--executor shared-iterations --iterations N` runs a fixed iteration count.
+- `--executor constant-vus --vus N --duration 1h` runs a throughput test.
+- `--pg-unlogged` enables the PostgreSQL `UNLOGGED` bulk-load dance.
+
+Select the executor explicitly. Legacy `DURATION` without an executor remains
+compatible, infers `constant-vus`, and emits a warning.
 
 The measured workload is a single gatable `workload` step, so prep and measurement
 can run as two passes for a throughput number uncontaminated by load time:
 
 ```bash
 # 1. load only (drop / create / load / create_indexes / analyze), no workload
-./build/stroppy run <workload> -e SCALE_FACTOR=10 --no-steps workload
+./build/stroppy run <workload> --scale-factor 10 --no-steps workload
 # 2. measure only, against the already-loaded data
-./build/stroppy run <workload> -e VUS=64 -e DURATION=1h --steps workload
+./build/stroppy run <workload> --executor constant-vus --vus 64 --duration 1h --steps workload
 ```
 
 A normal single run (no `--steps`) loads and measures in one pass.

--- a/workloads/tpcb/README.md
+++ b/workloads/tpcb/README.md
@@ -77,7 +77,6 @@ All TPC workloads share typed run flags:
 
 - `--executor shared-iterations --iterations N` runs a fixed iteration count.
 - `--executor constant-vus --vus N --duration 1h` runs a throughput test.
-- `--pg-unlogged` enables the PostgreSQL `UNLOGGED` bulk-load dance.
 
 Select the executor explicitly. Legacy `DURATION` without an executor remains
 compatible, infers `constant-vus`, and emits a warning.

--- a/workloads/tpcc/README.md
+++ b/workloads/tpcc/README.md
@@ -25,30 +25,30 @@ spec-mandated ratios.
 ./build/stroppy run tpcc/procs -d pg
 ```
 
-Useful env overrides:
+Useful parameters (`stroppy run tpcc/tx --help` lists the full schema):
 
 ```bash
--e warehouses=1        # scale factor (W); default 1 for smoke
--e pool_size=200       # per-VU pool size
--e warehouse_start=1   # first warehouse id for this instance (>=1)
--e load_items=true     # load the global item table (default: true when WAREHOUSE_START=1)
+--scale-factor 1        # warehouse count (W); default 1 for smoke
+--warehouse-start 1     # first warehouse ID for this instance (>=1)
+--load-items=true       # load the global item table (default at warehouse start 1)
+-e pool_size=200        # compatibility override for the driver pool size
 ```
 
 ## Distributed runs (multiple instances over disjoint warehouse ranges)
 
 Several stroppy instances can target the same database collectively, each
-handling a slice of warehouses. Set `WAREHOUSE_START` per instance so the
+handling a slice of warehouses. Set `--warehouse-start` per instance so the
 slices don't overlap:
 
 ```bash
 # Instance A: warehouses 1..100, also creates schema + loads the global item table.
 ./build/stroppy run tpcc/tx -d pg -D url=postgres://host/db \
-  -e WAREHOUSE_START=1 -e WAREHOUSES=100 \
+  --warehouse-start 1 --scale-factor 100 \
   --steps drop_schema,create_schema,load_data,validate_population
 
 # Instance B: warehouses 101..200, skips schema + item load.
 ./build/stroppy run tpcc/tx -d pg -D url=postgres://host/db \
-  -e WAREHOUSE_START=101 -e WAREHOUSES=100 \
+  --warehouse-start 101 --scale-factor 100 \
   --steps load_data,validate_population
 
 # After every slice is loaded, all instances can run the transaction phase
@@ -56,22 +56,21 @@ slices don't overlap:
 # remote-warehouse picks (Payment §2.5.1.2, New-Order §2.4.1.5) stay
 # inside the local slice.
 ./build/stroppy run tpcc/tx -d pg -D url=postgres://host/db \
-  -e WAREHOUSE_START=1 -e WAREHOUSES=100 \
+  --warehouse-start 1 --scale-factor 100 \
   --no-steps drop_schema,create_schema,load_data,validate_population \
-  -- --vus 50 --duration 5m
+  --executor constant-vus --vus 50 --duration 5m
 ```
 
 Notes:
 
 - The `item` table is global (100 000 rows independent of W). Only the
-  first instance (default `WAREHOUSE_START=1`) loads it; other instances
-  default `LOAD_ITEMS=false`. Override with `-e LOAD_ITEMS=true/false`.
-- For YDB, run `create_schema` once with `WAREHOUSE_START=1` and
-  `WAREHOUSES=<total>` so the partition split keys cover every warehouse
+  first instance (`--warehouse-start=1`) loads it by default; other instances
+  default `--load-items=false`. Override with `--load-items=true/false`.
+- For YDB, run `create_schema` once with `--warehouse-start=1` and
+  `--scale-factor=<total>` so the partition split keys cover every warehouse
   globally. Loader instances then skip `create_schema`.
 - `validate_population` filters all per-warehouse aggregates by
-  `w_id BETWEEN WAREHOUSE_START AND WAREHOUSE_START + WAREHOUSES - 1`,
-  so each instance validates only its own slice.
+  the range selected by `--warehouse-start` and `--scale-factor`, so each instance validates only its own slice.
 
 ## Steps
 
@@ -103,20 +102,18 @@ comparison. To benchmark load time, run both and diff the
 ```bash
 # baseline (1 tablet per table, no indexes)
 stroppy run tpcc/tx tpcc/ydb_no_indexes -d ydb -D url=grpc://host:2136/db \
-  -e SCALE_FACTOR=50 -e LOAD_WORKERS=8 \
-  --steps drop_schema,create_schema,load_data \
-  -- --duration 15s --vus 1
+  --scale-factor 50 --load-workers 8 \
+  --steps drop_schema,create_schema,load_data
 
 # tuned (W tablets per warehouse-keyed table, post-load indexes)
 stroppy run tpcc/tx tpcc/ydb -d ydb -D url=grpc://host:2136/db \
-  -e SCALE_FACTOR=50 -e LOAD_WORKERS=8 \
-  --steps drop_schema,create_schema,load_data,create_indexes \
-  -- --duration 15s --vus 1
+  --scale-factor 50 --load-workers 8 \
+  --steps drop_schema,create_schema,load_data,create_indexes
 ```
 
 The `Start of 'load_data' step` and `End of 'load_data' step` console
-lines mark the load interval. k6 args (`--duration`, `--vus`) must come
-after `--`.
+lines mark the load interval. Typed flags are accepted directly; run
+`stroppy run tpcc/tx --help` for the selected schema.
 
 ## Known simplifications vs spec
 
@@ -140,22 +137,23 @@ go test -tags=integration -run TestTpccWorkloadEndToEnd ./test/integration/... -
 
 ## Run shapes and the two-run flow
 
-All TPC workloads share one set of run knobs (set with `-e KEY=VALUE`, **not** the
-`-u/-d/-i` k6 shortcuts, which would discard the scenario):
+All TPC workloads share typed run flags:
 
-- `DURATION` set → fixed-duration throughput test (constant `VUS`); result is TPS.
-- `DURATION` unset → power test (`ITER` iterations); result is elapsed time.
-- `MAX_DURATION` (default `24h`) lifts k6's 10-minute per-iteration cap for large loads.
-- `PG_UNLOGGED=true` enables the PostgreSQL `UNLOGGED` bulk-load dance (off by default).
+- `--executor shared-iterations --iterations N` runs a fixed iteration count.
+- `--executor constant-vus --vus N --duration 1h` runs a throughput test.
+- `--pg-unlogged` enables the PostgreSQL `UNLOGGED` bulk-load dance.
+
+Select the executor explicitly. Legacy `DURATION` without an executor remains
+compatible, infers `constant-vus`, and emits a warning.
 
 The measured workload is a single gatable `workload` step, so prep and measurement
 can run as two passes for a throughput number uncontaminated by load time:
 
 ```bash
 # 1. load only (drop / create / load / create_indexes / analyze), no workload
-./build/stroppy run <workload> -e SCALE_FACTOR=10 --no-steps workload
+./build/stroppy run <workload> --scale-factor 10 --no-steps workload
 # 2. measure only, against the already-loaded data
-./build/stroppy run <workload> -e VUS=64 -e DURATION=1h --steps workload
+./build/stroppy run <workload> --executor constant-vus --vus 64 --duration 1h --steps workload
 ```
 
 A normal single run (no `--steps`) loads and measures in one pass.

--- a/workloads/tpcds/README.md
+++ b/workloads/tpcds/README.md
@@ -9,45 +9,43 @@ templates at the canonical qualification parameters.
 
 ```bash
 # PostgreSQL
-./build/stroppy run tpcds/tpcds -d pg \
+./build/stroppy run tpcds -d pg \
     -D url=postgres://postgres:postgres@localhost:5432 \
-    -e SCALE_FACTOR=0.01
+    --scale-factor 0.01
 
 # MySQL — note the go-sql-driver DSN form (NOT a mysql:// URL):
-./build/stroppy run tpcds/tpcds -d mysql \
+./build/stroppy run tpcds -d mysql \
     -D "url=root:pass@tcp(127.0.0.1:3306)/stroppy?charset=utf8mb4&parseTime=True&loc=Local" \
-    -e SCALE_FACTOR=0.01 -e LOAD_WORKERS=4
+    --scale-factor 0.01 --load-workers 4
 
 # YDB (YQL via the native driver):
-./build/stroppy run tpcds/tpcds -d ydb \
+./build/stroppy run tpcds -d ydb \
     -D url=grpc://localhost:2136/local \
-    -e SCALE_FACTOR=0.01
+    --scale-factor 0.01
 
 # Picodata (pgwire) — LOAD ONLY. Query execution is not yet supported on
 # picodata (see Status); run the prep steps without the workload:
-./build/stroppy run tpcds/tpcds -d pico \
+./build/stroppy run tpcds -d pico \
     -D url=postgres://admin:T0psecret@localhost:1331/admin \
-    -e SCALE_FACTOR=0.01 --no-steps workload
+    --scale-factor 0.01 --no-steps workload
 ```
 
-Env overrides:
+Typed parameters (`stroppy run tpcds --help` lists the full schema):
 
 ```bash
--e SCALE_FACTOR=0.01   # any positive float; fractional for smoke tests.
--e LOAD_WORKERS=4      # parallel InsertSpec workers per table during load.
--e YDB_STORE_MODE=column # ydb only: 'column' (default) or 'row' storage layout.
--e MAX_DURATION=24h    # run wall-clock cap (default 24h; the workload sets its
-                       # own so large-scale loads aren't killed by k6's 10m default).
--e STREAMS=4           # concurrent throughput streams (1 = single power-test stream).
--e QUERY_STREAM=0      # single generated stream N in-process (empty = baked set).
--e QUERY_SEED=42       # seed for generated streams.
--e SQL_FILE=./pg.sql   # override the per-driver baked query file.
+--scale-factor 0.01      # any positive float; fractional for smoke tests
+--load-workers 4         # parallel workers per table during load
+--ydb-store-mode column  # ydb only: column (default) or row storage
+--streams 4              # number of query streams
+--query-stream 0         # generated stream N (omit for the baked set)
+--query-seed 42          # generated-stream seed
+--sql-file ./pg.sql      # override the per-driver query file
 ```
 
 Note: the static tables (`date_dim`, `time_dim`, `customer_demographics`)
 do not scale down — `customer_demographics` is always ~1.9M rows — so load
-time at small SCALE_FACTOR is dominated by them, especially on MySQL whose
-parameterized bulk INSERT is slower than Postgres COPY (use LOAD_WORKERS).
+time at small scale factors is dominated by them, especially on MySQL whose
+parameterized bulk INSERT is slower than Postgres COPY (increase `--load-workers`).
 
 ## Steps
 
@@ -118,17 +116,17 @@ Postgres does not; the rewrite is semantically identical).
 
 The default run uses the baked, verified `pg.sql` / `mysql.sql` (the canonical
 qualification parameters). For throughput-style runs that vary parameters,
-set `QUERY_STREAM` and the workload generates that stream's queries **in-process**
+set `--query-stream N` and the workload generates that stream's queries **in-process**
 during the run — no offline step:
 
 ```bash
-./build/stroppy run tpcds/tpcds -d pg \
+./build/stroppy run tpcds -d pg \
     -D url=postgres://postgres:postgres@localhost:5432 \
-    -e SCALE_FACTOR=1 -e QUERY_STREAM=0 -e QUERY_SEED=42
+    --scale-factor 1 --query-stream 0 --query-seed 42
 ```
 
-- `QUERY_STREAM=N` selects stream N (empty = baked canonical set).
-- `QUERY_SEED` seeds the generator (reproducible per seed).
+- `--query-stream=N` selects stream N (omit it for the baked canonical set).
+- `--query-seed` seeds the generator (reproducible per seed).
 
 The generator parses the official query templates' `define` headers and produces
 valid, scale-correct parameter values with its own seeded RNG (it does NOT
@@ -146,8 +144,8 @@ The full benchmark is Load + Power + Throughput1 + DataMaint1 + Throughput2 +
 DataMaint2, scored as QphDS@SF. This workload covers:
 
 - **Database Load Test** — `load_data` step. ✅
-- **Power Test** (1 stream, 99 queries serially) — default run (`STREAMS=1`). ✅
-- **Throughput Test** (Sq concurrent streams, each a permuted 99) — `STREAMS=Sq`
+- **Power Test** (1 stream, 99 queries serially) — default run (`--streams=1`). ✅
+- **Throughput Test** (Sq concurrent streams, each a permuted 99) — `--streams=Sq`
   runs Sq VUs, one stream each, load shared once. ✅ (Sq should be even ≥ 4 for a
   compliant run; any value works for testing.)
 - **Data Maintenance Test** (sequential refresh runs: fact insert/delete +
@@ -156,15 +154,15 @@ DataMaint2, scored as QphDS@SF. This workload covers:
 
 ```bash
 # Throughput test: 4 concurrent streams
-./build/stroppy run tpcds/tpcds -d pg -D url=... -e SCALE_FACTOR=1 -e STREAMS=4
+./build/stroppy run tpcds -d pg -D url=... --scale-factor 1 --streams 4
 ```
 
 ## Status / TODO
 
 - PostgreSQL, MySQL, and YDB: load + all 103 statements verified on a local
-  instance at SCALE_FACTOR=0.01.
+  instance at scale factor 0.01.
 - Picodata: **load supported** (schema + all 24-table bulk load verified at
-  SCALE_FACTOR=0.01). **Query execution is not yet supported** — see the
+  scale factor 0.01). **Query execution is not yet supported** — see the
   picodata query blockers note below.
 - Not yet done: the Data Maintenance phase (refresh-data generation + insert/
   delete DM functions) and the QphDS@SF metric; SF=1 answer-set validation
@@ -187,22 +185,23 @@ Load picodata with `--no-steps workload`.
 
 ## Run shapes and the two-run flow
 
-All TPC workloads share one set of run knobs (set with `-e KEY=VALUE`, **not** the
-`-u/-d/-i` k6 shortcuts, which would discard the scenario):
+All TPC workloads share typed run flags:
 
-- `DURATION` set → fixed-duration throughput test (constant `VUS`); result is TPS.
-- `DURATION` unset → power test (`ITER` iterations); result is elapsed time.
-- `MAX_DURATION` (default `24h`) lifts k6's 10-minute per-iteration cap for large loads.
-- `PG_UNLOGGED=true` enables the PostgreSQL `UNLOGGED` bulk-load dance (off by default).
+- `--executor shared-iterations --iterations N` runs a fixed iteration count.
+- `--executor constant-vus --vus N --duration 1h` runs a throughput test.
+- `--pg-unlogged` enables the PostgreSQL `UNLOGGED` bulk-load dance.
+
+Select the executor explicitly. Legacy `DURATION` without an executor remains
+compatible, infers `constant-vus`, and emits a warning.
 
 The measured workload is a single gatable `workload` step, so prep and measurement
 can run as two passes for a throughput number uncontaminated by load time:
 
 ```bash
 # 1. load only (drop / create / load / create_indexes / analyze), no workload
-./build/stroppy run <workload> -e SCALE_FACTOR=10 --no-steps workload
+./build/stroppy run <workload> --scale-factor 10 --no-steps workload
 # 2. measure only, against the already-loaded data
-./build/stroppy run <workload> -e VUS=64 -e DURATION=1h --steps workload
+./build/stroppy run <workload> --executor constant-vus --vus 64 --duration 1h --steps workload
 ```
 
 A normal single run (no `--steps`) loads and measures in one pass.

--- a/workloads/tpcds/README.md
+++ b/workloads/tpcds/README.md
@@ -145,16 +145,19 @@ DataMaint2, scored as QphDS@SF. This workload covers:
 
 - **Database Load Test** — `load_data` step. ✅
 - **Power Test** (1 stream, 99 queries serially) — default run (`--streams=1`). ✅
-- **Throughput Test** (Sq concurrent streams, each a permuted 99) — `--streams=Sq`
-  runs Sq VUs, one stream each, load shared once. ✅ (Sq should be even ≥ 4 for a
-  compliant run; any value works for testing.)
+- **Throughput Test** (concurrent generated streams) — `--streams=Sq` enables
+  per-VU generated streams; run concurrency is controlled separately by `--vus`.
+  Use the constant-VUs executor for overlapping streams. (Sq should be even ≥ 4
+  for a compliant run; this workload does not yet implement the complete scored
+  phase sequencing.)
 - **Data Maintenance Test** (sequential refresh runs: fact insert/delete +
   inventory delete over dsdgen refresh data) — not implemented.
 - **QphDS@SF metric** — not computed (per-step timings are reported by k6).
 
 ```bash
-# Throughput test: 4 concurrent streams
-./build/stroppy run tpcds -d pg -D url=... --scale-factor 1 --streams 4
+# Throughput-style run: 4 concurrent generated streams for 10 minutes
+./build/stroppy run tpcds -d pg -D url=... --scale-factor 1 --streams 4 \
+  --executor constant-vus --vus 4 --duration 10m
 ```
 
 ## Status / TODO

--- a/workloads/tpch/README.md
+++ b/workloads/tpch/README.md
@@ -19,20 +19,19 @@ Two data generators, selected with `TPCH_GENERATOR`:
 ```bash
 ./build/stroppy run tpch/tx -d pg \
     -D url=postgres://postgres:postgres@localhost:5432/stroppy \
-    -e scale_factor=0.01
+    --scale-factor 0.01
 
 ./build/stroppy run tpch/tx -d mysql \
     -D url=mysql://root:pass@localhost:3306/stroppy \
-    -e scale_factor=0.01
+    --scale-factor 0.01
 ```
 
-Useful env overrides:
+Useful parameters (`stroppy run tpch/tx --help` lists the full schema):
 
 ```bash
--e scale_factor=0.01   # 0.01, 1, or any positive float. 1 enables answer validation.
--e pool_size=50        # per-VU pool size
--e load_workers=8      # parallel InsertSpec workers during load_data
--e tpch_generator=relgen   # data generator: gotpc (default) | relgen
+--scale-factor 0.01    # 0.01, 1, or any positive float. 1 enables answer validation.
+--load-workers 8       # parallel workers during load_data
+-e pool_size=50        # compatibility override for the driver pool size
 ```
 
 ## Steps
@@ -93,22 +92,23 @@ make gen-tpch-json   # regenerates distributions.json and answers_sf1.json
 
 ## Run shapes and the two-run flow
 
-All TPC workloads share one set of run knobs (set with `-e KEY=VALUE`, **not** the
-`-u/-d/-i` k6 shortcuts, which would discard the scenario):
+All TPC workloads share typed run flags:
 
-- `DURATION` set → fixed-duration throughput test (constant `VUS`); result is TPS.
-- `DURATION` unset → power test (`ITER` iterations); result is elapsed time.
-- `MAX_DURATION` (default `24h`) lifts k6's 10-minute per-iteration cap for large loads.
-- `PG_UNLOGGED=true` enables the PostgreSQL `UNLOGGED` bulk-load dance (off by default).
+- `--executor shared-iterations --iterations N` runs a fixed iteration count.
+- `--executor constant-vus --vus N --duration 1h` runs a throughput test.
+- `--pg-unlogged` enables the PostgreSQL `UNLOGGED` bulk-load dance.
+
+Select the executor explicitly. Legacy `DURATION` without an executor remains
+compatible, infers `constant-vus`, and emits a warning.
 
 The measured workload is a single gatable `workload` step, so prep and measurement
 can run as two passes for a throughput number uncontaminated by load time:
 
 ```bash
 # 1. load only (drop / create / load / create_indexes / analyze), no workload
-./build/stroppy run <workload> -e SCALE_FACTOR=10 --no-steps workload
+./build/stroppy run <workload> --scale-factor 10 --no-steps workload
 # 2. measure only, against the already-loaded data
-./build/stroppy run <workload> -e VUS=64 -e DURATION=1h --steps workload
+./build/stroppy run <workload> --executor constant-vus --vus 64 --duration 1h --steps workload
 ```
 
 A normal single run (no `--steps`) loads and measures in one pass.


### PR DESCRIPTION
## Summary

- add a definition phase with immediate typed `Def.Param` declarations, immutable schemas, per-run bindings, and fresh workload factories
- resolve scenario and workload parameters from typed CLI flags, process environment, legacy `-e`, native `run`/`params` config values, config `env`, and defaults
- migrate built-in workloads, expose schemas through selected-workload help, shell completion, and `stroppy probe`, and update config schema/docs

## Configuration

```json
{
  "version": "1",
  "script": "tpcc/tx",
  "run": {
    "executor": "constant-vus",
    "vus": 10,
    "duration": "60s"
  },
  "params": {
    "scaleFactor": 10,
    "loadWorkers": 8
  }
}
```

Precedence is:

1. typed `--name` flag
2. process environment
3. legacy `-e KEY=VALUE`
4. matching typed `run` or `params` config value
5. config `env`
6. declared default

## Compatibility

- existing workload environment names remain accepted
- legacy `DURATION` still infers `constant-vus` and emits a warning; new typed usage selects `executor` explicitly
- legacy presence semantics such as `VALIDATE_FORCE` are preserved on compatibility channels
- existing driver, SQL positional, inline SQL, config-driver, and step resolution paths remain supported

## Verification

- `make tests` (race detector and coverage)
- `make linter` (0 issues)
- `make build`
- exercised typed CLI and typed config runs with the noop driver
- exercised dynamic workload help, shell completion, and human/JSON probe output

Closes #121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed workload and run parameters through CLI flags and JSON configuration.
  * Added workload-specific help, shell completion, and parameter schema discovery via `probe`.
  * Added explicit executor options, including shared iterations and constant VUs.
  * Added typed settings for SQL files, load workers, scale factors, isolation, and workload options.

* **Bug Fixes**
  * Improved parameter precedence, validation, completion accuracy, and driver setting preservation.

* **Documentation**
  * Updated guides and examples with typed parameters and legacy compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->