### PR TITLE
fix(build): correct version injection in Docker and nightly builds

### DIFF
--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -44,3 +44,17 @@ jobs:
           tags: |
             ghcr.io/${{ steps.lowercase.outputs.lowercase }}:${{ github.ref_name }}.${{ github.run_number }}
             ghcr.io/${{ steps.lowercase.outputs.lowercase }}:latest
+
+      # Guard: the pushed image's binary must report the pushed tag, not the
+      # Docker ARG fallback. Running it also confirms the pushed image is sound.
+      - name: Verify image version
+        run: |
+          expected="${{ github.ref_name }}"
+          image="ghcr.io/${{ steps.lowercase.outputs.lowercase }}:${{ github.ref_name }}.${{ github.run_number }}"
+          actual="$(docker run --rm "${image}" version --json | jq -r '.stroppy')"
+          echo "expected=${expected}"
+          echo "actual=${actual}"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "version mismatch: ${actual} != ${expected}"
+            exit 1
+          fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,19 @@ jobs:
           VERSION: nightly-${{ steps.sha.outputs.short }}
         run: make build
 
+      # Guard: the produced nightly binary must report exactly nightly-<short-sha>
+      # (not the 0.0.0/unknown fallback), so a broken version injection fails here.
+      - name: Verify binary version
+        run: |
+          expected="nightly-${{ steps.sha.outputs.short }}"
+          actual="$(./build/stroppy version --json | jq -r '.stroppy')"
+          echo "expected=${expected}"
+          echo "actual=${actual}"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "version mismatch: ${actual} != ${expected}"
+            exit 1
+          fi
+
       # Tier 0: scenario-branch smoke on the noop driver — no database, exercises
       # both executor archetypes (constant-vus / shared-iterations) for every
       # workload. Fast and catches executor regressions for ~free.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Verify version
         run: |
           expected="${{ github.ref_name }}"
-          if ! strings build/stroppy | grep -qx "${expected}"; then
+          if ! strings build/stroppy | grep -Fqx "${expected}"; then
             echo "version mismatch: expected '${expected}' not embedded in build/stroppy"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,18 @@ jobs:
           mkdir -p "${{ steps.names.outputs.outdir }}"
           cp build/stroppy "${{ steps.names.outputs.outdir }}/${{ steps.names.outputs.bin }}"
 
+      # Guard: the release binary must embed exactly the release tag. Cross-compiled
+      # binaries (darwin/arm64, linux/arm64, ...) cannot be executed on the ubuntu
+      # runner, so assert the version `-X`-injected into the binary directly.
+      - name: Verify version
+        run: |
+          expected="${{ github.ref_name }}"
+          if ! strings build/stroppy | grep -qx "${expected}"; then
+            echo "version mismatch: expected '${expected}' not embedded in build/stroppy"
+            exit 1
+          fi
+          echo "version ok: ${expected}"
+
       #  [ -f ../README.md ] && EXTRAS+=("../README.md")
       #  [ -f ../LICENSE ] && EXTRAS+=("../LICENSE")
       - name: Package (.tar.gz)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Fixed
 
-- `stroppy version` now reports the real build version for Docker images (pushed tag), nightly artifacts (`nightly-<short-sha>`), and release archives (release tag), instead of the generic `0.0.0` fallback.
+- `stroppy version` now reports the real build version for Docker images (pushed tag), nightly artifacts (`nightly-<short-sha>`), and release archives (release tag), instead of the generic `0.0.0` fallback. ([#144](https://github.com/stroppy-io/stroppy/pull/144))
 - Workload help and shell completion expose typed flags accurately, including explicit booleans and contextual defaults, and SQL override positionals reach registered workload bindings. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - Typed run parameters and SQL sources keep CLI-over-environment precedence, config env names reject case-only collisions, shared driver pool settings remain active alongside driver-specific settings, and invalid pool fields fail clearly instead of being ignored. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - Typed inserts reject malformed requests consistently, and generator ranges remain correct at integer boundaries. ([#126](https://github.com/stroppy-io/stroppy/pull/126))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Fixed
 
+- `stroppy version` now reports the real build version for Docker images (pushed tag), nightly artifacts (`nightly-<short-sha>`), and release archives (release tag), instead of the generic `0.0.0` fallback.
 - Workload help and shell completion expose typed flags accurately, including explicit booleans and contextual defaults, and SQL override positionals reach registered workload bindings. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - Typed run parameters and SQL sources keep CLI-over-environment precedence, config env names reject case-only collisions, shared driver pool settings remain active alongside driver-specific settings, and invalid pool fields fail clearly instead of being ignored. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - Typed inserts reject malformed requests consistently, and generator ranges remain correct at integer boundaries. ([#126](https://github.com/stroppy-io/stroppy/pull/126))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.26-alpine3.22 AS builder
 
-ARG VERSION=0.0.0
+ARG VERSION=unknown
 
 RUN apk add --no-cache make curl git
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PATH:=$(LOCAL_BIN):$(PATH)
 GOPROXY:=proxy.golang.org,direct
 BUILD_TARGET_DIR=$(CURDIR)/build
 
-VERSION=$(shell git describe --tags --always 2>/dev/null || echo "0.0.0")
+VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo "unknown")
 
 default: help
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.0.0"
+var Version = "unknown"


### PR DESCRIPTION
Closes #130

## Problem

The version injected into binaries was effectively hard-coded to `0.0.0` everywhere outside a bare `git describe`. The Makefile used an unconditional `VERSION=$(shell git describe ... || echo "0.0.0")`, which overrides the `VERSION` environment variable that CI and Docker set. Since `.dockerignore` excludes `.git/`, `git describe` fails inside Docker, so every Docker image reported `0.0.0`, and nightly/release artifacts leaked the same fallback when tags were unavailable.

## Fix

1. **Explicit VERSION always wins over git describe** — `Makefile` now uses `VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo "unknown")`. The `?=` conditional assignment leaves an already-set `VERSION` (from `make VERSION=x`, the environment, or a Docker build-arg) untouched.
2. **Local builds derive a useful Git version** — with no explicit value, `?=` evaluates `git describe --tags --always`, so local `make build` continues to report the current commit/tag.
3. **git describe fails gracefully, not to 0.0.0** — the fallback is now `unknown` (Docker build context has no `.git`), and the `internal/version` package default plus the Dockerfile `ARG VERSION` default both became `unknown`.
4. **Docker image reports the pushed tag** — the Dockerfile passes the build-arg through, and `?=` no longer clobbers it, so the image's binary reports `${{ github.ref_name }}`.
5. **Nightly artifact reports exactly `nightly-<short-sha>`** — `integration.yml` already set `VERSION=nightly-<sha>`; it now survives the Makefile.
6. **Release archives report exactly the release tag** — `release.yml` sets `VERSION=${{ github.ref_name }}`, which now reaches the linker.
7. **CI verifies every produced artifact and fails on mismatch** — added version guards to `integration.yml` (runs `stroppy version --json`), `docker-registry.yml` (runs the pushed image), and `release.yml` (asserts the embedded version via `strings`, since cross-compiled binaries can't be executed on the ubuntu runner).