### PR TITLE
Restore the tpcb/procs stored-procedure workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
+- Restored the `tpcb/procs` workload: TPC-B ships both `tx` and `procs` variants again, with `tpcb/procs` running each transaction as one server-side stored-procedure call (`tpcb_transaction`) on PostgreSQL and MySQL. ([#146](https://github.com/stroppy-io/stroppy/pull/146))
 - `stroppy probe` now lists registered workload parameter flags, and its JSON output includes each workload's typed schema for tooling and discovery. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - Typed scenario and workload parameters can be set with `--name` flags or native JSON values in the config file's `run` and `params` objects, and `stroppy run <workload> --help` lists the available parameters. ([#128](https://github.com/stroppy-io/stroppy/pull/128))
 - Go workloads can declare typed string, boolean, numeric, and duration parameters with defaults, descriptions, source tracking, and discoverable schemas. ([#128](https://github.com/stroppy-io/stroppy/pull/128))

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -93,6 +93,7 @@ Config file flags:
 	Example: `
   stroppy run tpcc/tx                           # built-in TPC-C tx workload
   stroppy run tpcb/tx                           # TPC-B tx workload
+  stroppy run tpcb/procs                        # TPC-B stored-procedure variant (pg/mysql)
   stroppy run tpch/tx                           # TPC-H load + query suite
   stroppy run tpcds                             # TPC-DS load + query suite
   stroppy run simple --executor constant-vus --duration 10s --vus 4

--- a/internal/workloads/tpcb/procs_test.go
+++ b/internal/workloads/tpcb/procs_test.go
@@ -2,6 +2,7 @@ package tpcb
 
 import (
 	"context"
+	"errors"
 	"os"
 	"reflect"
 	"strings"
@@ -65,6 +66,21 @@ func TestProcsResolvesProcSection(t *testing.T) {
 		if !strings.Contains(q, "tpcb_transaction") {
 			t.Errorf("%s: proc query %q does not reference tpcb_transaction", dt, q)
 		}
+	}
+}
+
+func TestResolveSQLQueriesRejectsEmptyProcedureQuery(t *testing.T) {
+	sql := bench.ParseSQL(tpcbSQL(struct{ section, query string }{}) + `
+--+ workload_procs
+--= tpcb_transaction
+
+--= trailing
+SELECT 1;
+`)
+	w := &workload{variant: "procs", sql: sql}
+
+	if err := w.resolveSQLQueries(); !errors.Is(err, errEmptyQuery) {
+		t.Fatalf("resolveSQLQueries() error = %v, want %v", err, errEmptyQuery)
 	}
 }
 

--- a/internal/workloads/tpcb/procs_test.go
+++ b/internal/workloads/tpcb/procs_test.go
@@ -1,0 +1,133 @@
+package tpcb
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/stroppy-io/stroppy/pkg/bench"
+	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	_ "github.com/stroppy-io/stroppy/pkg/driver/noop"
+)
+
+// TestProcsRegistered verifies both TPC-B variants are registered and self-name.
+func TestProcsRegistered(t *testing.T) {
+	for _, name := range []string{"tpcb/tx", "tpcb/procs"} {
+		wl, ok := bench.Lookup(name)
+		if !ok {
+			t.Fatalf("workload %q not registered", name)
+		}
+
+		if got := wl.Name(); got != name {
+			t.Fatalf("Name() = %q, want %q", got, name)
+		}
+	}
+}
+
+// TestProcsSharesTxParams verifies tpcb/procs declares exactly the same typed
+// parameters as tpcb/tx (shared Define), so both variants resolve identically.
+func TestProcsSharesTxParams(t *testing.T) {
+	tx, err := bench.Describe("tpcb/tx")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	procs, err := bench.Describe("tpcb/procs")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(tx.Params, procs.Params) {
+		t.Fatalf("procs params diverge from tx:\n  tx:    %+#v\n  procs: %+#v", tx.Params, procs.Params)
+	}
+}
+
+// TestProcsResolvesProcSection verifies pg.sql and mysql.sql still carry the
+// create_procedures + workload_procs/tpcb_transaction contract the procs
+// variant executes.
+func TestProcsResolvesProcSection(t *testing.T) {
+	for _, dt := range []bench.DriverTypeName{bench.DriverPostgres, bench.DriverMySQL} {
+		sql := mustLoadSQL(dt, "")
+
+		if got := sql.Section("create_procedures"); len(got) == 0 {
+			t.Errorf("%s: create_procedures section is empty", dt)
+		}
+
+		q, ok := sql.Query("workload_procs", "tpcb_transaction")
+		if !ok {
+			t.Fatalf("%s: workload_procs/tpcb_transaction not found", dt)
+		}
+
+		if !strings.Contains(q, "tpcb_transaction") {
+			t.Errorf("%s: proc query %q does not reference tpcb_transaction", dt, q)
+		}
+	}
+}
+
+// TestProcsSupported covers the unsupported-driver gate exercised in Setup.
+func TestProcsSupported(t *testing.T) {
+	cases := []struct {
+		driver bench.DriverTypeName
+		want   bool
+	}{
+		{bench.DriverPostgres, true},
+		{bench.DriverMySQL, true},
+		{bench.DriverNoop, true},
+		{bench.DriverPicodata, false},
+		{bench.DriverYDB, false},
+		{bench.DriverCSV, false},
+	}
+	for _, c := range cases {
+		if got := procsSupported(c.driver); got != c.want {
+			t.Errorf("procsSupported(%s) = %v, want %v", c.driver, got, c.want)
+		}
+	}
+}
+
+// TestProcsNoopEndToEnd runs the full tpcb/procs lifecycle (schema, procedures,
+// load, indexes, FKs, analyze, one proc iteration) against the noop driver,
+// proving registration, procs section resolution, and the iterate path without
+// a live database.
+func TestProcsNoopEndToEnd(t *testing.T) {
+	unsetEnv(
+		t,
+		"SCALE_FACTOR", "RETRY_ATTEMPTS", "TX_ISOLATION", "SQL_FILE", "LOAD_WORKERS",
+		"EXECUTOR", "VUS", "ITERATIONS", "ITER", "DURATION",
+	)
+
+	err := bench.Run(
+		context.Background(),
+		"tpcb/procs",
+		map[int]*stroppy.DriverConfig{0: {DriverType: stroppy.DriverConfig_DRIVER_TYPE_NOOP}},
+		nil,
+		bench.ParamInputs{},
+		zap.NewNop(),
+		&bench.MetricsConfig{},
+	)
+	if err != nil {
+		t.Fatalf("tpcb/procs noop run: %v", err)
+	}
+}
+
+func unsetEnv(t *testing.T, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		value, present := os.LookupEnv(name)
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(name, value)
+			} else {
+				_ = os.Unsetenv(name)
+			}
+		})
+	}
+}

--- a/internal/workloads/tpcb/procs_test.go
+++ b/internal/workloads/tpcb/procs_test.go
@@ -42,7 +42,7 @@ func TestProcsSharesTxParams(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(tx.Params, procs.Params) {
-		t.Fatalf("procs params diverge from tx:\n  tx:    %+#v\n  procs: %+#v", tx.Params, procs.Params)
+		t.Fatalf("procs params diverge from the tx variant:\n  tx:    %+#v\n  procs: %+#v", tx.Params, procs.Params)
 	}
 }
 

--- a/internal/workloads/tpcb/tpcb.go
+++ b/internal/workloads/tpcb/tpcb.go
@@ -26,6 +26,7 @@ import (
 var (
 	errAccountNotFound        = errors.New("tpc-b: account not found")
 	errProcsDriverUnsupported = errors.New("tpcb/procs only supports postgres and mysql; use tpcb/tx for picodata/ydb")
+	errProcsMissingQuery      = errors.New("tpc-b/procs: missing query")
 )
 
 const (
@@ -92,7 +93,7 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	if w.variant == "procs" {
 		proc, ok := w.sql.Query("workload_procs", "tpcb_transaction")
 		if !ok {
-			return fmt.Errorf("tpc-b/procs: missing query workload_procs/tpcb_transaction")
+			return fmt.Errorf("%w workload_procs/tpcb_transaction", errProcsMissingQuery)
 		}
 
 		w.procQuery = proc
@@ -165,40 +166,47 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 		return w.iterateProcs(ctx, b, aid, tid, bid, delta, hid)
 	}
 
+	return b.Step("workload", func() error {
+		return bench.Retry0(ctx, w.retryPolicy, func() error {
+			return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "tpcb"}, func(tx *bench.TxX) error {
+				return w.txBody(ctx, tx, aid, tid, bid, delta, hid)
+			})
+		})
+	})
+}
+
+// txBody runs the ordered DML of one client-side TPC-B transaction: update
+// account, read balance, update teller, update branch, insert history. Extracted
+// from Iterate to keep the transaction body out of the retry/begin closures.
+func (w *workload) txBody(ctx context.Context, tx *bench.TxX, aid, tid, bid, delta int, hid int64) error {
 	updateAccount, _ := w.sql.Query("workload_tx_tpcb", "update_account")
 	getBalance, _ := w.sql.Query("workload_tx_tpcb", "get_balance")
 	updateTeller, _ := w.sql.Query("workload_tx_tpcb", "update_teller")
 	updateBranch, _ := w.sql.Query("workload_tx_tpcb", "update_branch")
 	insertHistory, _ := w.sql.Query("workload_tx_tpcb", "insert_history")
 
-	return b.Step("workload", func() error {
-		return bench.Retry0(ctx, w.retryPolicy, func() error {
-			return b.BeginTx(ctx, bench.BeginOpts{Isolation: w.iso, Name: "tpcb"}, func(tx *bench.TxX) error {
-				if err := tx.Exec(ctx, updateAccount, map[string]any{"aid": aid, "delta": delta}); err != nil {
-					return err
-				}
+	if err := tx.Exec(ctx, updateAccount, map[string]any{"aid": aid, "delta": delta}); err != nil {
+		return err
+	}
 
-				abalance, err := tx.QueryValue(ctx, getBalance, map[string]any{"aid": aid})
-				if err != nil {
-					return err
-				}
+	abalance, err := tx.QueryValue(ctx, getBalance, map[string]any{"aid": aid})
+	if err != nil {
+		return err
+	}
 
-				if abalance == nil {
-					return fmt.Errorf("%w: %d", errAccountNotFound, aid)
-				}
+	if abalance == nil {
+		return fmt.Errorf("%w: %d", errAccountNotFound, aid)
+	}
 
-				if err := tx.Exec(ctx, updateTeller, map[string]any{"tid": tid, "delta": delta}); err != nil {
-					return err
-				}
+	if err := tx.Exec(ctx, updateTeller, map[string]any{"tid": tid, "delta": delta}); err != nil {
+		return err
+	}
 
-				if err := tx.Exec(ctx, updateBranch, map[string]any{"bid": bid, "delta": delta}); err != nil {
-					return err
-				}
+	if err := tx.Exec(ctx, updateBranch, map[string]any{"bid": bid, "delta": delta}); err != nil {
+		return err
+	}
 
-				return tx.Exec(ctx, insertHistory, map[string]any{"hid": hid, "tid": tid, "bid": bid, "aid": aid, "delta": delta})
-			})
-		})
-	})
+	return tx.Exec(ctx, insertHistory, map[string]any{"hid": hid, "tid": tid, "bid": bid, "aid": aid, "delta": delta})
 }
 
 // iterateProcs executes the stored procedure tpcb_transaction as a single

--- a/internal/workloads/tpcb/tpcb.go
+++ b/internal/workloads/tpcb/tpcb.go
@@ -324,6 +324,10 @@ func (w *workload) resolveSQLQueries() error {
 		return fmt.Errorf("%w workload_procs/tpcb_transaction", errProcsMissingQuery)
 	}
 
+	if strings.TrimSpace(proc) == "" {
+		return fmt.Errorf("%w workload_procs/tpcb_transaction", errEmptyQuery)
+	}
+
 	w.procQuery = proc
 
 	return nil

--- a/internal/workloads/tpcb/tpcb.go
+++ b/internal/workloads/tpcb/tpcb.go
@@ -1,7 +1,13 @@
-// Package tpcb is the Go-native port of workloads/tpcb/tx.ts: pgbench's canonical
-// 5-statement TPC-B transaction under one explicit transaction per iteration.
-// Shares load/config with the procs variant (not ported here). Supports pg/mysql/
-// picodata/ydb; isolation + SQL file are selected by driver type.
+// Package tpcb is the Go-native port of pgbench's canonical 5-statement TPC-B
+// transaction, shipping two registered variants:
+//
+//   - tpcb/tx runs the five DML steps inline under one client-side transaction
+//     per iteration; supports pg/mysql/picodata/ydb.
+//   - tpcb/procs calls the stored procedure tpcb_transaction (workload_procs
+//     section) as a single server-side round-trip; pg/mysql only.
+//
+// Both variants share parameter declarations, schema/load lifecycle, retry
+// policy, metrics, and data generation.
 package tpcb
 
 import (
@@ -17,7 +23,10 @@ import (
 	"github.com/stroppy-io/stroppy/pkg/gen"
 )
 
-var errAccountNotFound = errors.New("tpc-b: account not found")
+var (
+	errAccountNotFound        = errors.New("tpc-b: account not found")
+	errProcsDriverUnsupported = errors.New("tpcb/procs only supports postgres and mysql; use tpcb/tx for picodata/ydb")
+)
 
 const (
 	preset = "tpcb"
@@ -35,7 +44,10 @@ const (
 )
 
 type workload struct {
+	variant string // "tx" (inline DML) or "procs" (stored procedure)
+
 	sql           *bench.SQL
+	procQuery     string // resolved workload_procs/tpcb_transaction (procs variant)
 	driverType    bench.DriverTypeName
 	iso           bench.TxIsolationName
 	scale         int64
@@ -50,9 +62,12 @@ type workload struct {
 	vuStates sync.Map // uint64 -> *vuState
 }
 
-func init() { bench.Register(func() bench.Workload { return &workload{} }) }
+func init() {
+	bench.Register(func() bench.Workload { return &workload{variant: "tx"} })
+	bench.Register(func() bench.Workload { return &workload{variant: "procs"} })
+}
 
-func (*workload) Name() string { return "tpcb/tx" }
+func (w *workload) Name() string { return "tpcb/" + w.variant }
 
 func (w *workload) Define(d *bench.Def) error {
 	w.scale = int64(max(d.Param.Int("scale-factor", 1, "TPC-B scale factor.").Value(), 1))
@@ -67,9 +82,21 @@ func (w *workload) Define(d *bench.Def) error {
 
 func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 	w.driverType = b.DriverTypeName()
+	if w.variant == "procs" && !procsSupported(w.driverType) {
+		return errProcsDriverUnsupported
+	}
 
 	w.iso = resolveIsolation(w.driverType, w.iso)
 	w.sql = mustLoadSQL(w.driverType, w.sqlFile)
+
+	if w.variant == "procs" {
+		proc, ok := w.sql.Query("workload_procs", "tpcb_transaction")
+		if !ok {
+			return fmt.Errorf("tpc-b/procs: missing query workload_procs/tpcb_transaction")
+		}
+
+		w.procQuery = proc
+	}
 
 	runSection := func(name string) error {
 		for _, q := range w.sql.Section(name) {
@@ -81,13 +108,21 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 		return nil
 	}
 
-	steps := []struct {
+	type step struct {
 		name string
 		fn   func() error
-	}{
+	}
+
+	steps := []step{
 		{"drop_schema", func() error { return runSection("drop_schema") }},
 		{"create_schema", func() error { return runSection("create_schema") }},
-		{"load_data", func() error {
+	}
+	if w.variant == "procs" {
+		steps = append(steps, step{"create_procedures", func() error { return runSection("create_procedures") }})
+	}
+
+	steps = append(steps,
+		step{"load_data", func() error {
 			if _, err := b.Insert(ctx, branchesRequest(w.scale, w.loadWorkers)); err != nil {
 				return err
 			}
@@ -102,10 +137,11 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 
 			return nil
 		}},
-		{"create_indexes", func() error { return runSection("create_indexes") }},
-		{"create_foreign_keys", func() error { return runSection("create_foreign_keys") }},
-		{"analyze", func() error { return runSection("analyze") }},
-	}
+		step{"create_indexes", func() error { return runSection("create_indexes") }},
+		step{"create_foreign_keys", func() error { return runSection("create_foreign_keys") }},
+		step{"analyze", func() error { return runSection("analyze") }},
+	)
+
 	for _, s := range steps {
 		if err := b.Step(s.name, s.fn); err != nil {
 			return err
@@ -123,11 +159,11 @@ func (w *workload) Setup(ctx context.Context, b *bench.Bench) error {
 
 func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 	vs := w.vuState(b.VUID())
-	aid := vs.aid.IntN(int(accounts(w.scale))) + 1
-	tid := vs.tid.IntN(int(tellers(w.scale))) + 1
-	bid := vs.bid.IntN(int(branches(w.scale))) + 1
-	delta := vs.delta.IntN(10001) - 5000
-	hid := vs.nextHid()
+	aid, tid, bid, delta, hid := vs.txParams(w.scale)
+
+	if w.variant == "procs" {
+		return w.iterateProcs(ctx, b, aid, tid, bid, delta, hid)
+	}
 
 	updateAccount, _ := w.sql.Query("workload_tx_tpcb", "update_account")
 	getBalance, _ := w.sql.Query("workload_tx_tpcb", "get_balance")
@@ -165,6 +201,23 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 	})
 }
 
+// iterateProcs executes the stored procedure tpcb_transaction as a single
+// server-side round-trip per iteration (workload_procs section). No client-side
+// BeginTx wraps the call: the procedure body runs the whole 5-statement
+// transaction on the server (postgres' implicit statement transaction; mysql's
+// procedure manages its own START TRANSACTION ... COMMIT). By design the procs
+// variant therefore emits no client-side commit/rollback metric — the commit
+// happens inside the procedure — so its metric shape differs from tpcb/tx.
+func (w *workload) iterateProcs(ctx context.Context, b *bench.Bench, aid, tid, bid, delta int, hid int64) error {
+	return b.Step("workload", func() error {
+		return bench.Retry0(ctx, w.retryPolicy, func() error {
+			return b.Exec(ctx, w.procQuery, map[string]any{
+				"p_aid": aid, "p_tid": tid, "p_bid": bid, "p_delta": delta, "p_hid": hid,
+			})
+		})
+	})
+}
+
 func (*workload) Teardown(ctx context.Context, b *bench.Bench) error {
 	b.StepEnd("workload")
 
@@ -189,6 +242,19 @@ func resolveIsolation(dt bench.DriverTypeName, override bench.TxIsolationName) b
 		return bench.IsoSerializable
 	default:
 		return bench.IsoReadCommitted
+	}
+}
+
+// procsSupported reports whether the procs variant can run on dt: postgres and
+// mysql carry the create_procedures + workload_procs sections, and noop is
+// allowed for offline overhead runs. Everything else (picodata, ydb, csv, ...)
+// is rejected at setup with errProcsDriverUnsupported.
+func procsSupported(dt bench.DriverTypeName) bool {
+	switch dt {
+	case bench.DriverPostgres, bench.DriverMySQL, bench.DriverNoop:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -246,6 +312,16 @@ func (w *workload) vuState(vuid uint64) *vuState {
 }
 
 func (v *vuState) nextHid() int64 { return v.hid.Add(1) }
+
+// txParams draws one iteration's TPC-B transaction parameters. Shared by the
+// tx and procs variants so identical VUs draw identical sequences.
+func (v *vuState) txParams(scale int64) (aid, tid, bid, delta int, hid int64) {
+	return v.aid.IntN(int(accounts(scale))) + 1,
+		v.tid.IntN(int(tellers(scale))) + 1,
+		v.bid.IntN(int(branches(scale))) + 1,
+		v.delta.IntN(10001) - 5000,
+		v.nextHid()
+}
 
 // seedOf mirrors tpcb_common.seedOf: a per-VU, per-slot offset so concurrent VUs
 // draw independent sequences.

--- a/test/integration/tpcb_procs_test.go
+++ b/test/integration/tpcb_procs_test.go
@@ -89,16 +89,22 @@ func TestTpcbProcsPostgres(t *testing.T) {
 		t.Errorf("pgbench_history rows = %d, want 1", history)
 	}
 
-	var branches, tellers, accounts int64
+	var branches, tellers, accounts, historyDelta int64
 	if err := pool.QueryRow(ctx, `
 		SELECT
 			COALESCE((SELECT SUM(bbalance) FROM pgbench_branches), 0),
 			COALESCE((SELECT SUM(tbalance) FROM pgbench_tellers), 0),
-			COALESCE((SELECT SUM(abalance) FROM pgbench_accounts), 0)`).Scan(&branches, &tellers, &accounts); err != nil {
+			COALESCE((SELECT SUM(abalance) FROM pgbench_accounts), 0),
+			(SELECT delta FROM pgbench_history LIMIT 1)`).Scan(
+		&branches, &tellers, &accounts, &historyDelta,
+	); err != nil {
 		t.Fatalf("balance sums: %v", err)
 	}
-	if branches != tellers || tellers != accounts {
-		t.Errorf("balance sums diverge: branches=%d tellers=%d accounts=%d, want equal", branches, tellers, accounts)
+	if branches != historyDelta || tellers != historyDelta || accounts != historyDelta {
+		t.Errorf(
+			"balance sums: branches=%d tellers=%d accounts=%d, want history delta %d",
+			branches, tellers, accounts, historyDelta,
+		)
 	}
 }
 
@@ -144,15 +150,21 @@ func assertTpcbProcsBalanceSumsMySQL(t *testing.T, db *sql.DB) {
 	t.Helper()
 
 	ctx := context.Background()
-	var branches, tellers, accounts int64
+	var branches, tellers, accounts, historyDelta int64
 	if err := db.QueryRowContext(ctx, `
 		SELECT
 			COALESCE((SELECT SUM(bbalance) FROM pgbench_branches), 0),
 			COALESCE((SELECT SUM(tbalance) FROM pgbench_tellers), 0),
-			COALESCE((SELECT SUM(abalance) FROM pgbench_accounts), 0)`).Scan(&branches, &tellers, &accounts); err != nil {
+			COALESCE((SELECT SUM(abalance) FROM pgbench_accounts), 0),
+			(SELECT delta FROM pgbench_history LIMIT 1)`).Scan(
+		&branches, &tellers, &accounts, &historyDelta,
+	); err != nil {
 		t.Fatalf("balance sums: %v", err)
 	}
-	if branches != tellers || tellers != accounts {
-		t.Errorf("balance sums diverge: branches=%d tellers=%d accounts=%d, want equal", branches, tellers, accounts)
+	if branches != historyDelta || tellers != historyDelta || accounts != historyDelta {
+		t.Errorf(
+			"balance sums: branches=%d tellers=%d accounts=%d, want history delta %d",
+			branches, tellers, accounts, historyDelta,
+		)
 	}
 }

--- a/test/integration/tpcb_procs_test.go
+++ b/test/integration/tpcb_procs_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// runTpcbProcsStroppy invokes the stroppy binary on the tpcb/procs workload
+// against the given driver, runs the full lifecycle (drop, create_schema,
+// create_procedures, load_data, indexes, FKs, analyze) plus the one default
+// iteration, and returns merged stdout+stderr.
+func runTpcbProcsStroppy(t *testing.T, driverType, url string, budget time.Duration) string {
+	t.Helper()
+
+	repoRoot := findRepoRoot(t)
+	binary := filepath.Join(repoRoot, "build", "stroppy")
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatalf("stroppy binary not found at %s (run `make build` first): %v", binary, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	cmd := exec.CommandContext(ctx, binary,
+		"run", "tpcb/procs",
+		"-D", "url="+url,
+		"-D", "driverType="+driverType,
+		"--scale-factor", "1",
+	)
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("stroppy run (tpcb/procs, %s) failed: %v\n--- stdout ---\n%s\n--- stderr ---\n%s",
+			driverType, err, stdout.String(), stderr.String())
+	}
+	elapsed := time.Since(start)
+	t.Logf("stroppy tpcb/procs run on %s completed in %s", driverType, elapsed)
+
+	if elapsed > budget {
+		t.Errorf("run on %s took %s, exceeds the %s budget", driverType, elapsed, budget)
+	}
+
+	return stdout.String() + stderr.String()
+}
+
+// TestTpcbProcsPostgres creates the tpcb_transaction procedure and runs it via
+// the tpcb/procs workload against tmpfs Postgres, asserting the procedure was
+// created and one iteration's server-side round-trip mutated balances and
+// inserted a single history row.
+func TestTpcbProcsPostgres(t *testing.T) {
+	if os.Getenv(envSkip) == "1" {
+		t.Skipf("skipping integration test: %s=1", envSkip)
+	}
+
+	pool := NewTmpfsPG(t)
+	ResetSchema(t, pool)
+
+	url := envOr(envTmpfsURL, defaultTmpfsURL)
+	runTpcbProcsStroppy(t, "postgres", url, 30*time.Second)
+
+	ctx := context.Background()
+
+	var procCount int64
+	if err := pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM pg_proc WHERE proname = 'tpcb_transaction'").Scan(&procCount); err != nil {
+		t.Fatalf("check tpcb_transaction: %v", err)
+	}
+	if procCount != 1 {
+		t.Errorf("tpcb_transaction procedure count = %d, want 1", procCount)
+	}
+
+	var history int64
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM pgbench_history").Scan(&history); err != nil {
+		t.Fatalf("history count: %v", err)
+	}
+	if history != 1 {
+		t.Errorf("pgbench_history rows = %d, want 1", history)
+	}
+
+	var branches, tellers, accounts int64
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			COALESCE((SELECT SUM(bbalance) FROM pgbench_branches), 0),
+			COALESCE((SELECT SUM(tbalance) FROM pgbench_tellers), 0),
+			COALESCE((SELECT SUM(abalance) FROM pgbench_accounts), 0)`).Scan(&branches, &tellers, &accounts); err != nil {
+		t.Fatalf("balance sums: %v", err)
+	}
+	if branches != tellers || tellers != accounts {
+		t.Errorf("balance sums diverge: branches=%d tellers=%d accounts=%d, want equal", branches, tellers, accounts)
+	}
+}
+
+// TestTpcbProcsMySQL creates the tpcb_transaction procedure and runs it via the
+// tpcb/procs workload against mysql, asserting routine creation and one
+// iteration's server-side execution. Requires the multi-DB tmpfs harness
+// (`make tmpfs-all-up`).
+func TestTpcbProcsMySQL(t *testing.T) {
+	if os.Getenv(envSkip) == "1" {
+		t.Skipf("skipping integration test: %s=1", envSkip)
+	}
+
+	db := NewMySQL(t)
+	ResetMySQL(t, db, tpcbTables)
+
+	url := envOr(envMySQLAllURL, defaultMySQLAllURL)
+	runTpcbProcsStroppy(t, "mysql", url, 30*time.Second)
+
+	ctx := context.Background()
+
+	var routineCount int64
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM information_schema.ROUTINES
+		WHERE ROUTINE_SCHEMA = DATABASE() AND ROUTINE_NAME = 'tpcb_transaction'`).Scan(&routineCount); err != nil {
+		t.Fatalf("check tpcb_transaction: %v", err)
+	}
+	if routineCount != 1 {
+		t.Errorf("tpcb_transaction routine count = %d, want 1", routineCount)
+	}
+
+	var history int64
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pgbench_history").Scan(&history); err != nil {
+		t.Fatalf("history count: %v", err)
+	}
+	if history != 1 {
+		t.Errorf("pgbench_history rows = %d, want 1", history)
+	}
+
+	assertTpcbProcsBalanceSumsMySQL(t, db)
+}
+
+func assertTpcbProcsBalanceSumsMySQL(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	ctx := context.Background()
+	var branches, tellers, accounts int64
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE((SELECT SUM(bbalance) FROM pgbench_branches), 0),
+			COALESCE((SELECT SUM(tbalance) FROM pgbench_tellers), 0),
+			COALESCE((SELECT SUM(abalance) FROM pgbench_accounts), 0)`).Scan(&branches, &tellers, &accounts); err != nil {
+		t.Fatalf("balance sums: %v", err)
+	}
+	if branches != tellers || tellers != accounts {
+		t.Errorf("balance sums diverge: branches=%d tellers=%d accounts=%d, want equal", branches, tellers, accounts)
+	}
+}


### PR DESCRIPTION
## What

Restores the `tpcb/procs` workload that the Go-native migration dropped (it
registered only `tpcb/tx`). `tpcb/procs` executes each TPC-B transaction as a
single server-side `tpcb_transaction` procedure call, useful for comparing
client-side transactions with server-side procedure execution on PostgreSQL and
MySQL. The implementation mirrors the existing `tpcc/tx` / `tpcc/procs`
dual-variant structure.

## Acceptance criteria

- **Register `tpcb/procs`** — `internal/workloads/tpcb/tpcb.go` registers both
  variants in `init()`; `Name()` returns `tpcb/<variant>`.
- **PostgreSQL + MySQL; reject unsupported drivers** — the procs variant runs
  the `create_procedures` step and resolves `workload_procs/tpcb_transaction`;
  `Setup` rejects picodata/ydb with a clear error
  (`tpcb/procs only supports postgres and mysql; use tpcb/tx for picodata/ydb`).
- **Share params/schema/retry/metrics/datagen** — one `workload` struct drives
  both variants: shared `Define`, shared `Setup` lifecycle (with a conditional
  `create_procedures` step), shared `TxRetryPolicy` + `tpcb_retry_attempts`
  metric, and a shared `vuState.txParams` draw. No copy-paste.
- **Existing SQL contract** — `create_procedures` / `workload_procs` were
  already present in `workloads/tpcb/pg.sql` and `mysql.sql`, so no SQL assets
  changed.
- **Probe/help/completion/docs** — discovery is registry-driven, so
  `stroppy probe`, `stroppy run tpcb/procs --help`, and completion pick it up
  automatically (verified locally).
- **Tests** — unit tests (`TestProcsRegistered`, `TestProcsSharesTxParams`,
  `TestProcsResolvesProcSection`, `TestProcsSupported`, `TestProcsNoopEndToEnd`)
  plus PostgreSQL/MySQL integration coverage in
  `test/integration/tpcb_procs_test.go`.

Closes #132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `tpcb/procs` workload option for running TPC-B transactions through database-side procedures.
  - Added support for PostgreSQL and MySQL procedure execution, including retries and setup validation.
  - Retained the existing `tpcb/tx` workload for client-side transaction execution.
- **Documentation**
  - Updated command help and the changelog to include the restored procedure workload.
- **Tests**
  - Added coverage validating workload behavior, driver support, procedure execution, and database results across PostgreSQL and MySQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->