### PR TITLE
Add per-query timeout and deadline support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ conditional transient retries.
 **Workload and run parameters:**
 - Registered workloads expose typed `--name VALUE` flags. Run
   `stroppy run <workload> --help` to see the selected workload's schema.
-- Shared run flags: `--executor`, `--vus`, `--iterations`, `--duration`.
+- Shared run flags: `--executor`, `--vus`, `--iterations`, `--duration`, `--query-timeout`.
 - Workload flags include `--scale-factor`, `--load-workers`, and other
   workload-specific declarations.
 - `-e KEY=VALUE` remains a compatibility input; keys are uppercased. Multiple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
-- `--query-timeout` (also `QUERY_TIMEOUT` and config `run.queryTimeout`) bounds each executed statement with a per-statement deadline; `0` (the default) disables it. Timed-out statements are reported distinctly from a canceled run, and MySQL adds a server-side `MAX_EXECUTION_TIME` hint so a timed-out query keeps its pooled connection.
+- `--query-timeout` (also `QUERY_TIMEOUT` and config `run.queryTimeout`) bounds each executed statement with a per-statement deadline; `0` (the default) disables it. Timed-out statements are reported distinctly from a canceled run, and MySQL adds a server-side `MAX_EXECUTION_TIME` hint so a timed-out query keeps its pooled connection. ([#153](https://github.com/stroppy-io/stroppy/pull/153))
 - All TPC-C runs now emit text and JSON reports with per-transaction count, mix, throughput, and p50/p90/p95/p99 response times; paced runs additionally receive §5.2.5 response-time and transaction-mix verdicts, statistical-validity status, and a steady-state assessment, while unpaced runs mark compliance not applicable. ([#147](https://github.com/stroppy-io/stroppy/pull/147))
 - Restored the `tpcb/procs` workload: TPC-B ships both `tx` and `procs` variants again, with `tpcb/procs` running each transaction as one server-side stored-procedure call (`tpcb_transaction`) on PostgreSQL and MySQL. ([#146](https://github.com/stroppy-io/stroppy/pull/146))
 - `stroppy probe` now lists registered workload parameter flags, and its JSON output includes each workload's typed schema for tooling and discovery. ([#128](https://github.com/stroppy-io/stroppy/pull/128))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Fixed
 
+- Query timeouts that surface while closing database result sets are reported once instead of repeating the same error. ([#153](https://github.com/stroppy-io/stroppy/pull/153))
 - Empty, whitespace-only, or comma-only step filters no longer conflict with a real opposite filter; `--steps=` still clears configured steps before `--no-steps` is applied. ([#149](https://github.com/stroppy-io/stroppy/pull/149))
 - The `workload` step is silent on the console again (no `Start`/`End` record per transaction), while setup/load/schema steps still log a single start/end and the `simple` workload now honors `--steps`/`--no-steps` like the other workloads. ([#149](https://github.com/stroppy-io/stroppy/pull/149))
 - `--steps` and `--no-steps` are rejected as mutually exclusive even when one is set in the config file and the other on the command line. ([#149](https://github.com/stroppy-io/stroppy/pull/149))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Added
 
+- `--query-timeout` (also `QUERY_TIMEOUT` and config `run.queryTimeout`) bounds each executed statement with a per-statement deadline; `0` (the default) disables it. Timed-out statements are reported distinctly from a canceled run, and MySQL adds a server-side `MAX_EXECUTION_TIME` hint so a timed-out query keeps its pooled connection.
 - All TPC-C runs now emit text and JSON reports with per-transaction count, mix, throughput, and p50/p90/p95/p99 response times; paced runs additionally receive §5.2.5 response-time and transaction-mix verdicts, statistical-validity status, and a steady-state assessment, while unpaced runs mark compliance not applicable. ([#147](https://github.com/stroppy-io/stroppy/pull/147))
 - Restored the `tpcb/procs` workload: TPC-B ships both `tx` and `procs` variants again, with `tpcb/procs` running each transaction as one server-side stored-procedure call (`tpcb_transaction`) on PostgreSQL and MySQL. ([#146](https://github.com/stroppy-io/stroppy/pull/146))
 - `stroppy probe` now lists registered workload parameter flags, and its JSON output includes each workload's typed schema for tooling and discovery. ([#128](https://github.com/stroppy-io/stroppy/pull/128))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Fixed
 
-- Query timeouts that surface while closing database result sets are reported once instead of repeating the same error. ([#153](https://github.com/stroppy-io/stroppy/pull/153))
+- Query helpers now return an empty result instead of panicking when a driver supplies no result set, and query timeouts that surface while closing result sets are reported once instead of repeating the same error. ([#153](https://github.com/stroppy-io/stroppy/pull/153))
 - Empty, whitespace-only, or comma-only step filters no longer conflict with a real opposite filter; `--steps=` still clears configured steps before `--no-steps` is applied. ([#149](https://github.com/stroppy-io/stroppy/pull/149))
 - The `workload` step is silent on the console again (no `Start`/`End` record per transaction), while setup/load/schema steps still log a single start/end and the `simple` workload now honors `--steps`/`--no-steps` like the other workloads. ([#149](https://github.com/stroppy-io/stroppy/pull/149))
 - `--steps` and `--no-steps` are rejected as mutually exclusive even when one is set in the config file and the other on the command line. ([#149](https://github.com/stroppy-io/stroppy/pull/149))

--- a/cmd/stroppy/commands/help/topic_config_file.go
+++ b/cmd/stroppy/commands/help/topic_config_file.go
@@ -46,7 +46,8 @@ Example stroppy-config.json:
     "run": {
       "executor": "constant-vus",
       "vus": 10,
-      "duration": "30s"
+      "duration": "30s",
+      "queryTimeout": "5s"
     },
     "params": {},
     "env": {
@@ -62,7 +63,8 @@ Example stroppy-config.json:
     sql      string            Explicit SQL file override (2nd positional)
     global   object            Logger and OTEL exporter config (no CLI equivalent)
     drivers  map[string]obj    Per-index driver configs (keys "0", "1", ...)
-    run      object            Typed scenario params: executor, vus, iterations, duration
+    run      object            Typed scenario params: executor, vus, iterations, duration,
+                              queryTimeout
     params   object            Typed parameters declared by the selected workload
     env      map[string]string Legacy workload env overrides (keys uppercased on load)
     steps    []string          Step allowlist (same as CLI --steps)
@@ -101,8 +103,9 @@ PRECEDENCE (highest to lowest)
     logger / OTEL exporter:      config file "global" only (no CLI equivalent)
 
   There is no "--" k6-args passthrough and no k6Args field in effect.
-  Use typed executor/vus/iterations/duration parameters; legacy
-  VUS/DURATION/ITER environment values remain compatible. Legacy DURATION
+  Use typed executor/vus/iterations/duration/queryTimeout parameters. The
+  VUS/DURATION/ITER/QUERY_TIMEOUT environment values remain compatible. A
+  queryTimeout of "0" disables the per-statement deadline. Legacy DURATION
   without an explicit executor infers constant-vus and emits a warning; prefer
   an explicit "run.executor" value.
 

--- a/cmd/stroppy/commands/help/topic_envs.go
+++ b/cmd/stroppy/commands/help/topic_envs.go
@@ -14,10 +14,11 @@ func init() {
 
   Scenario parameters are shared by every workload:
 
-    --executor     shared-iterations or constant-vus
-    --vus          Number of virtual users
-    --iterations   Total shared iterations
-    --duration     Run length as a Go duration, e.g. 60s or 10m
+    --executor       shared-iterations or constant-vus
+    --vus            Number of virtual users
+    --iterations     Total shared iterations
+    --duration       Run length as a Go duration, e.g. 60s or 10m
+    --query-timeout  Per-statement deadline as a Go duration; 0 disables it
 
   Select the executor explicitly. Examples:
 
@@ -74,7 +75,8 @@ CONFIG FILE
       "run": {
         "executor": "constant-vus",
         "vus": 10,
-        "duration": "60s"
+        "duration": "60s",
+        "queryTimeout": "5s"
       },
       "params": {
         "scaleFactor": 10,

--- a/cmd/stroppy/commands/help/topic_resolution.go
+++ b/cmd/stroppy/commands/help/topic_resolution.go
@@ -43,9 +43,9 @@ PARAMETER DISCOVERY AND RESOLUTION
     stroppy run tpcc/tx --help
     stroppy run tpcc/tx --scale-factor 10 --load-workers 8
 
-  Shared run parameters are --executor, --vus, --iterations, and --duration.
-  Select shared-iterations or constant-vus explicitly. Typed values resolve in
-  this order: CLI flag > process env > -e > matching "run"/"params" config >
+  Shared run parameters are --executor, --vus, --iterations, --duration, and
+  --query-timeout. Select shared-iterations or constant-vus explicitly. Typed values
+  resolve in this order: CLI flag > process env > -e > matching "run"/"params" config >
   config "env" > declared default. Legacy DURATION can still infer constant-vus,
   but emits a warning; prefer an explicit executor.
 

--- a/cmd/stroppy/commands/probe/probe_test.go
+++ b/cmd/stroppy/commands/probe/probe_test.go
@@ -35,7 +35,7 @@ func TestHumanCatalogIncludesGroupedWorkloads(t *testing.T) {
 		"PRESETS (embedded workloads)",
 		"WORKLOADS (typed parameters)",
 		"  tpcc/tx\n",
-		"    run:      --duration, --executor, --iterations, --vus",
+		"    run:      --duration, --executor, --iterations, --query-timeout, --vus",
 		"    workload: --load-items",
 		"stroppy run <workload> --help",
 		"DRIVERS (supported insert methods)",

--- a/docs/jsonschema/run.schema.json
+++ b/docs/jsonschema/run.schema.json
@@ -2019,6 +2019,10 @@
         },
         "duration": {
           "type": "string"
+        },
+        "queryTimeout": {
+          "type": "string",
+          "description": "Per-statement query deadline as a Go duration; 0 disables it."
         }
       },
       "type": "object",

--- a/internal/runner/config_file_test.go
+++ b/internal/runner/config_file_test.go
@@ -130,7 +130,7 @@ func TestLoadRunConfig_TypedParameterScopes(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{
 		"version": "1",
-		"run": {"executor":"constant-vus","vus":3,"duration":"2s","future":true},
+		"run": {"executor":"constant-vus","vus":3,"duration":"2s","queryTimeout":"250ms","future":true},
 		"params": {"scaleFactor":1.5,"enabled":false,"label":"sample"}
 	}`), 0o600))
 
@@ -139,6 +139,7 @@ func TestLoadRunConfig_TypedParameterScopes(t *testing.T) {
 	assert.True(t, loaded)
 	assert.JSONEq(t, `"constant-vus"`, string(cfg.Run["executor"]))
 	assert.JSONEq(t, `3`, string(cfg.Run["vus"]))
+	assert.JSONEq(t, `"250ms"`, string(cfg.Run["queryTimeout"]))
 	assert.JSONEq(t, `true`, string(cfg.Run["future"]))
 	assert.JSONEq(t, `1.5`, string(cfg.Params["scaleFactor"]))
 	assert.JSONEq(t, `false`, string(cfg.Params["enabled"]))

--- a/pkg/bench/param_test.go
+++ b/pkg/bench/param_test.go
@@ -573,6 +573,21 @@ func TestScenarioQueryTimeoutResolution(t *testing.T) {
 
 	clearParamEnv(t, "QUERY_TIMEOUT")
 
+	params, _, err = defineWorkload(&paramTestWorkload{name: "test/query-timeout"}, ParamInputs{
+		RunConfig: map[string]json.RawMessage{"queryTimeout": json.RawMessage(`"250ms"`)},
+	}, false)
+	if err != nil {
+		t.Fatalf("defineWorkload() config error = %v", err)
+	}
+
+	if got := params.queryTimeout.Value(); got != 250*time.Millisecond {
+		t.Fatalf("queryTimeout = %v, want 250ms", got)
+	}
+
+	if params.queryTimeout.Source() != ParamSourceConfig {
+		t.Fatalf("queryTimeout source = %q, want %q", params.queryTimeout.Source(), ParamSourceConfig)
+	}
+
 	params, _, err = defineWorkload(&paramTestWorkload{name: "test/query-timeout"}, ParamInputs{}, false)
 	if err != nil {
 		t.Fatalf("defineWorkload() default error = %v", err)

--- a/pkg/bench/param_test.go
+++ b/pkg/bench/param_test.go
@@ -433,7 +433,7 @@ func TestDescribeUsesDefaultsAndCopiesSchema(t *testing.T) {
 		t.Fatalf("Setup calls = %d, want 0", setupCalls.Load())
 	}
 
-	if description.Name != "test/describe-params" || len(description.Params) != 5 {
+	if description.Name != "test/describe-params" || len(description.Params) != 6 {
 		t.Fatalf("description = %#v", description)
 	}
 
@@ -448,19 +448,19 @@ func TestDescribeUsesDefaultsAndCopiesSchema(t *testing.T) {
 		LegacyEnvAliases: []string{"OLD_BATCH_SIZE"},
 		Config:           "batchSize",
 	}
-	if !reflect.DeepEqual(description.Params[4], want) {
-		t.Fatalf("workload schema = %#v, want %#v", description.Params[4], want)
+	if !reflect.DeepEqual(description.Params[5], want) {
+		t.Fatalf("workload schema = %#v, want %#v", description.Params[5], want)
 	}
 
-	description.Params[4].LegacyEnvAliases[0] = "MUTATED"
+	description.Params[5].LegacyEnvAliases[0] = "MUTATED"
 
 	again, err := Describe("test/describe-params")
 	if err != nil {
 		t.Fatalf("Describe() again error = %v", err)
 	}
 
-	if again.Params[4].LegacyEnvAliases[0] != "OLD_BATCH_SIZE" {
-		t.Fatalf("schema alias was mutated: %#v", again.Params[4])
+	if again.Params[5].LegacyEnvAliases[0] != "OLD_BATCH_SIZE" {
+		t.Fatalf("schema alias was mutated: %#v", again.Params[5])
 	}
 }
 
@@ -535,6 +535,55 @@ func TestDescribeAllIsSorted(t *testing.T) {
 		if descriptions[idx-1].Name > descriptions[idx].Name {
 			t.Fatalf("descriptions are not sorted at %d: %q > %q", idx, descriptions[idx-1].Name, descriptions[idx].Name)
 		}
+	}
+}
+
+func TestScenarioQueryTimeoutResolution(t *testing.T) {
+	clearScenarioEnv(t)
+	clearParamEnv(t, "QUERY_TIMEOUT")
+
+	params, _, err := defineWorkload(&paramTestWorkload{name: "test/query-timeout"},
+		ParamInputs{CLI: map[string]string{"query-timeout": "5s"}}, false)
+	if err != nil {
+		t.Fatalf("defineWorkload() error = %v", err)
+	}
+
+	if got := params.queryTimeout.Value(); got != 5*time.Second {
+		t.Fatalf("queryTimeout = %v, want 5s", got)
+	}
+
+	if params.queryTimeout.Source() != ParamSourceCLI {
+		t.Fatalf("queryTimeout source = %q, want %q", params.queryTimeout.Source(), ParamSourceCLI)
+	}
+
+	t.Setenv("QUERY_TIMEOUT", "2s")
+
+	params, _, err = defineWorkload(&paramTestWorkload{name: "test/query-timeout"}, ParamInputs{}, false)
+	if err != nil {
+		t.Fatalf("defineWorkload() env error = %v", err)
+	}
+
+	if got := params.queryTimeout.Value(); got != 2*time.Second {
+		t.Fatalf("queryTimeout = %v, want 2s", got)
+	}
+
+	if params.queryTimeout.Source() != ParamSourceProcessEnv {
+		t.Fatalf("queryTimeout source = %q, want %q", params.queryTimeout.Source(), ParamSourceProcessEnv)
+	}
+
+	clearParamEnv(t, "QUERY_TIMEOUT")
+
+	params, _, err = defineWorkload(&paramTestWorkload{name: "test/query-timeout"}, ParamInputs{}, false)
+	if err != nil {
+		t.Fatalf("defineWorkload() default error = %v", err)
+	}
+
+	if got := params.queryTimeout.Value(); got != 0 {
+		t.Fatalf("queryTimeout = %v, want disabled default 0", got)
+	}
+
+	if params.queryTimeout.Source() != ParamSourceDefault {
+		t.Fatalf("queryTimeout source = %q, want %q", params.queryTimeout.Source(), ParamSourceDefault)
 	}
 }
 

--- a/pkg/bench/query.go
+++ b/pkg/bench/query.go
@@ -39,18 +39,26 @@ func (b *Bench) QueryValue(ctx context.Context, sql string, args map[string]any)
 	}
 	defer res.Rows.Close()
 
-	if !res.Rows.Next() {
-		//nolint:nilnil // no-row sentinel: callers (validate.go, simple, tpcc) branch on `v == nil` after `err == nil`
+	return firstQueryValue(res.Rows)
+}
+
+func firstQueryValue(rows driver.Rows) (any, error) {
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+
+		//nolint:nilnil // no-row sentinel: workloads branch on `v == nil` after `err == nil`
 		return nil, nil
 	}
 
-	vals := res.Rows.Values()
+	vals := rows.Values()
 	if len(vals) == 0 {
 		//nolint:nilnil // no-row sentinel: empty row means "no value"; same caller contract as above
 		return nil, nil
 	}
 
-	return vals[0], res.Rows.Err()
+	return vals[0], rows.Err()
 }
 
 // QueryRow returns the first row (or nil if no rows).
@@ -256,18 +264,7 @@ func (t *TxX) QueryValue(ctx context.Context, sql string, args map[string]any) (
 	}
 	defer res.Rows.Close()
 
-	if !res.Rows.Next() {
-		//nolint:nilnil // no-row sentinel: tpcc tx workloads branch on `v == nil` after `err == nil`
-		return nil, nil
-	}
-
-	vals := res.Rows.Values()
-	if len(vals) == 0 {
-		//nolint:nilnil // no-row sentinel: empty row means "no value"; same caller contract as above
-		return nil, nil
-	}
-
-	return vals[0], res.Rows.Err()
+	return firstQueryValue(res.Rows)
 }
 
 func (t *TxX) QueryRow(ctx context.Context, sql string, args map[string]any) ([]any, error) {

--- a/pkg/bench/query.go
+++ b/pkg/bench/query.go
@@ -41,6 +41,11 @@ func (b *Bench) QueryValue(ctx context.Context, sql string, args map[string]any)
 }
 
 func firstQueryValue(rows driver.Rows) (any, error) {
+	if rows == nil {
+		//nolint:nilnil // no-row sentinel: a driver may report no result set
+		return nil, nil
+	}
+
 	if !rows.Next() {
 		if err := rows.Err(); err != nil {
 			return nil, err
@@ -59,6 +64,28 @@ func firstQueryValue(rows driver.Rows) (any, error) {
 	return vals[0], rows.Err()
 }
 
+func firstQueryRow(rows driver.Rows) ([]any, error) {
+	if rows == nil {
+		//nolint:nilnil // no-row sentinel: a driver may report no result set
+		return nil, nil
+	}
+
+	if !rows.Next() {
+		return nil, rows.Err()
+	}
+
+	return rows.Values(), rows.Err()
+}
+
+func readQueryRows(rows driver.Rows) ([][]any, error) {
+	if rows == nil {
+		//nolint:nilnil // no-row sentinel: a driver may report no result set
+		return nil, nil
+	}
+
+	return rows.ReadAll(0), rows.Err()
+}
+
 // QueryRow returns the first row (or nil if no rows).
 func (b *Bench) QueryRow(ctx context.Context, sql string, args map[string]any) (_ []any, err error) {
 	res, err := b.runQuery(ctx, sql, args)
@@ -68,11 +95,7 @@ func (b *Bench) QueryRow(ctx context.Context, sql string, args map[string]any) (
 		return nil, err
 	}
 
-	if !res.Rows.Next() {
-		return nil, res.Rows.Err()
-	}
-
-	return res.Rows.Values(), res.Rows.Err()
+	return firstQueryRow(res.Rows)
 }
 
 // QueryRows returns all rows (up to a large cap).
@@ -84,7 +107,7 @@ func (b *Bench) QueryRows(ctx context.Context, sql string, args map[string]any) 
 		return nil, err
 	}
 
-	return res.Rows.ReadAll(0), res.Rows.Err()
+	return readQueryRows(res.Rows)
 }
 
 func (b *Bench) runQuery(ctx context.Context, sql string, args map[string]any) (*driver.QueryResult, error) {
@@ -281,11 +304,7 @@ func (t *TxX) QueryRow(ctx context.Context, sql string, args map[string]any) (_ 
 		return nil, err
 	}
 
-	if !res.Rows.Next() {
-		return nil, res.Rows.Err()
-	}
-
-	return res.Rows.Values(), res.Rows.Err()
+	return firstQueryRow(res.Rows)
 }
 
 func (t *TxX) QueryRows(ctx context.Context, sql string, args map[string]any) (_ [][]any, err error) {
@@ -296,7 +315,7 @@ func (t *TxX) QueryRows(ctx context.Context, sql string, args map[string]any) (_
 		return nil, err
 	}
 
-	return res.Rows.ReadAll(0), res.Rows.Err()
+	return readQueryRows(res.Rows)
 }
 
 func (t *TxX) runQuery(ctx context.Context, sql string, args map[string]any) (*driver.QueryResult, error) {

--- a/pkg/bench/query.go
+++ b/pkg/bench/query.go
@@ -2,7 +2,6 @@ package bench
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -100,7 +99,7 @@ func (b *Bench) runQuery(ctx context.Context, sql string, args map[string]any) (
 func (b *Bench) finishQuery(res *driver.QueryResult, queryErr error) error {
 	if res != nil && res.Rows != nil {
 		closeErr := res.Rows.Close()
-		queryErr = errors.Join(queryErr, res.Rows.Err(), closeErr)
+		queryErr = driver.JoinErrors(queryErr, res.Rows.Err(), closeErr)
 	}
 
 	var elapsed time.Duration

--- a/pkg/bench/query.go
+++ b/pkg/bench/query.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -24,20 +25,18 @@ type BeginOpts struct {
 // Exec runs a statement that returns no rows.
 func (b *Bench) Exec(ctx context.Context, sql string, args map[string]any) error {
 	res, err := b.runQuery(ctx, sql, args)
-	if res != nil {
-		res.Rows.Close()
-	}
 
-	return err
+	return b.finishQuery(res, err)
 }
 
 // QueryValue returns the first column of the first row (or nil if no rows).
-func (b *Bench) QueryValue(ctx context.Context, sql string, args map[string]any) (any, error) {
+func (b *Bench) QueryValue(ctx context.Context, sql string, args map[string]any) (_ any, err error) {
 	res, err := b.runQuery(ctx, sql, args)
+	defer func() { err = b.finishQuery(res, err) }()
+
 	if err != nil {
 		return nil, err
 	}
-	defer res.Rows.Close()
 
 	return firstQueryValue(res.Rows)
 }
@@ -62,12 +61,13 @@ func firstQueryValue(rows driver.Rows) (any, error) {
 }
 
 // QueryRow returns the first row (or nil if no rows).
-func (b *Bench) QueryRow(ctx context.Context, sql string, args map[string]any) ([]any, error) {
+func (b *Bench) QueryRow(ctx context.Context, sql string, args map[string]any) (_ []any, err error) {
 	res, err := b.runQuery(ctx, sql, args)
+	defer func() { err = b.finishQuery(res, err) }()
+
 	if err != nil {
 		return nil, err
 	}
-	defer res.Rows.Close()
 
 	if !res.Rows.Next() {
 		return nil, res.Rows.Err()
@@ -77,31 +77,40 @@ func (b *Bench) QueryRow(ctx context.Context, sql string, args map[string]any) (
 }
 
 // QueryRows returns all rows (up to a large cap).
-func (b *Bench) QueryRows(ctx context.Context, sql string, args map[string]any) ([][]any, error) {
+func (b *Bench) QueryRows(ctx context.Context, sql string, args map[string]any) (_ [][]any, err error) {
 	res, err := b.runQuery(ctx, sql, args)
+	defer func() { err = b.finishQuery(res, err) }()
+
 	if err != nil {
 		return nil, err
 	}
-	defer res.Rows.Close()
 
 	return res.Rows.ReadAll(0), res.Rows.Err()
 }
 
 func (b *Bench) runQuery(ctx context.Context, sql string, args map[string]any) (*driver.QueryResult, error) {
 	res, err := b.drv.RunQuery(ctx, sql, args)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+
+	return res, nil
+}
+
+func (b *Bench) finishQuery(res *driver.QueryResult, queryErr error) error {
+	if res != nil && res.Rows != nil {
+		closeErr := res.Rows.Close()
+		queryErr = errors.Join(queryErr, res.Rows.Err(), closeErr)
+	}
 
 	var elapsed time.Duration
 	if res != nil && res.Stats != nil {
 		elapsed = res.Stats.Elapsed
 	}
 
-	b.root.txMetrics.recordQueryResult(b.vu, elapsed, err)
+	b.root.txMetrics.recordQueryResult(b.vu, elapsed, queryErr)
 
-	if err != nil {
-		return nil, fmt.Errorf("query: %w", err)
-	}
-
-	return res, nil
+	return queryErr
 }
 
 // Insert runs a typed [driver.InsertRequest] through the benchmark driver,
@@ -250,29 +259,28 @@ type TxX struct {
 
 func (t *TxX) Exec(ctx context.Context, sql string, args map[string]any) error {
 	res, err := t.runQuery(ctx, sql, args)
-	if res != nil {
-		res.Rows.Close()
-	}
 
-	return err
+	return t.b.finishQuery(res, err)
 }
 
-func (t *TxX) QueryValue(ctx context.Context, sql string, args map[string]any) (any, error) {
+func (t *TxX) QueryValue(ctx context.Context, sql string, args map[string]any) (_ any, err error) {
 	res, err := t.runQuery(ctx, sql, args)
+	defer func() { err = t.b.finishQuery(res, err) }()
+
 	if err != nil {
 		return nil, err
 	}
-	defer res.Rows.Close()
 
 	return firstQueryValue(res.Rows)
 }
 
-func (t *TxX) QueryRow(ctx context.Context, sql string, args map[string]any) ([]any, error) {
+func (t *TxX) QueryRow(ctx context.Context, sql string, args map[string]any) (_ []any, err error) {
 	res, err := t.runQuery(ctx, sql, args)
+	defer func() { err = t.b.finishQuery(res, err) }()
+
 	if err != nil {
 		return nil, err
 	}
-	defer res.Rows.Close()
 
 	if !res.Rows.Next() {
 		return nil, res.Rows.Err()
@@ -281,12 +289,13 @@ func (t *TxX) QueryRow(ctx context.Context, sql string, args map[string]any) ([]
 	return res.Rows.Values(), res.Rows.Err()
 }
 
-func (t *TxX) QueryRows(ctx context.Context, sql string, args map[string]any) ([][]any, error) {
+func (t *TxX) QueryRows(ctx context.Context, sql string, args map[string]any) (_ [][]any, err error) {
 	res, err := t.runQuery(ctx, sql, args)
+	defer func() { err = t.b.finishQuery(res, err) }()
+
 	if err != nil {
 		return nil, err
 	}
-	defer res.Rows.Close()
 
 	return res.Rows.ReadAll(0), res.Rows.Err()
 }
@@ -296,14 +305,6 @@ func (t *TxX) runQuery(ctx context.Context, sql string, args map[string]any) (*d
 	if t.tx == nil {
 		// NONE mode: delegate to the parent driver.
 		res, err := t.b.drv.RunQuery(ctx, sql, args)
-
-		var elapsed time.Duration
-		if res != nil && res.Stats != nil {
-			elapsed = res.Stats.Elapsed
-		}
-
-		t.b.root.txMetrics.recordQueryResult(t.b.vu, elapsed, err)
-
 		if err != nil {
 			return nil, fmt.Errorf("query: %w", err)
 		}
@@ -312,14 +313,6 @@ func (t *TxX) runQuery(ctx context.Context, sql string, args map[string]any) (*d
 	}
 
 	res, err := t.tx.RunQuery(ctx, sql, args)
-
-	var elapsed time.Duration
-	if res != nil && res.Stats != nil {
-		elapsed = res.Stats.Elapsed
-	}
-
-	t.b.root.txMetrics.recordQueryResult(t.b.vu, elapsed, err)
-
 	if err != nil {
 		return nil, fmt.Errorf("tx query: %w", err)
 	}

--- a/pkg/bench/query_test.go
+++ b/pkg/bench/query_test.go
@@ -2,14 +2,21 @@ package bench
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/zap"
 
 	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
 	"github.com/stroppy-io/stroppy/pkg/driver"
+	"github.com/stroppy-io/stroppy/pkg/driver/mysql"
 )
 
 func TestInsertRejectsNilRequest(t *testing.T) {
@@ -166,7 +173,8 @@ func newQueryTestTarget(
 
 func TestQueryTerminalErrorsAndMetrics(t *testing.T) {
 	rowErr := context.DeadlineExceeded
-	closeErr := errors.New("close rows")
+	closeFailure := errors.New("close rows")
+	closeErr := errors.Join(closeFailure, fmt.Errorf("close: %w", rowErr))
 	runErr := errors.New("run query")
 
 	paths := []struct {
@@ -237,7 +245,8 @@ func TestQueryTerminalErrorsAndMetrics(t *testing.T) {
 
 				err := operation.run(target)
 				require.ErrorIs(t, err, context.DeadlineExceeded)
-				require.ErrorIs(t, err, closeErr)
+				require.ErrorIs(t, err, closeFailure)
+				require.Equal(t, 1, strings.Count(err.Error(), context.DeadlineExceeded.Error()))
 				require.False(t, metricsRecordedBeforeClose)
 				require.Equal(t, 1, rows.closeCalls)
 
@@ -319,4 +328,100 @@ func queryMetricCount(t *testing.T, data metricdata.ResourceMetrics, name string
 	}
 
 	return 0
+}
+
+type closeCountingDriver struct {
+	driver.Driver
+	closeCalls int
+}
+
+func (d *closeCountingDriver) RunQuery(
+	ctx context.Context,
+	sql string,
+	args map[string]any,
+) (*driver.QueryResult, error) {
+	res, err := d.Driver.RunQuery(ctx, sql, args)
+	if res != nil && res.Rows != nil {
+		res.Rows = &closeCountingRows{Rows: res.Rows, closeCalls: &d.closeCalls}
+	}
+
+	return res, err
+}
+
+type closeCountingRows struct {
+	driver.Rows
+	closeCalls *int
+}
+
+func (r *closeCountingRows) Close() error {
+	*r.closeCalls++
+
+	return r.Rows.Close()
+}
+
+func TestMySQLCallTimeoutIsReportedOnce(t *testing.T) {
+	const (
+		procedure = "stroppy_bench_result_cleanup_timeout"
+		timeout   = 100 * time.Millisecond
+	)
+
+	dsn := os.Getenv("STROPPY_MYSQL_DSN")
+	if dsn == "" {
+		t.Skip("STROPPY_MYSQL_DSN not set; skipping real-MySQL timeout test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	mysqlDriver, err := mysql.NewDriver(ctx, driver.Options{
+		Logger: zap.NewNop(),
+		Config: &stroppy.DriverConfig{
+			Url:        dsn,
+			DriverType: stroppy.DriverConfig_DRIVER_TYPE_MYSQL,
+		},
+		QueryTimeout: timeout,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		teardownCtx, teardownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer teardownCancel()
+
+		require.NoError(t, mysqlDriver.Teardown(teardownCtx))
+	})
+
+	fixtureDB, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, fixtureDB.Close()) })
+
+	execFixture := func(query string) {
+		fixtureCtx, fixtureCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer fixtureCancel()
+
+		_, err := fixtureDB.ExecContext(fixtureCtx, query)
+		require.NoError(t, err)
+	}
+	execFixture("DROP PROCEDURE IF EXISTS " + procedure)
+	execFixture("CREATE PROCEDURE " + procedure + "() BEGIN SELECT 1; DO SLEEP(2); END")
+	t.Cleanup(func() { execFixture("DROP PROCEDURE IF EXISTS " + procedure) })
+
+	fx := newTestBenchFixture(t)
+	previousRoot := root
+	root = fx.rootState
+
+	t.Cleanup(func() { root = previousRoot })
+
+	countingDriver := &closeCountingDriver{Driver: mysqlDriver}
+	fx.b.drv = countingDriver
+
+	err = fx.b.Exec(context.Background(), "CALL "+procedure+"()", nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, strings.Count(err.Error(), context.DeadlineExceeded.Error()))
+	require.Equal(t, 1, countingDriver.closeCalls)
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, fx.reader.Collect(context.Background(), &data))
+	require.Equal(t, queryMetricCounts{
+		operations: 1,
+		errors:     1,
+	}, collectQueryMetricCounts(t, data, fx.prefix))
 }

--- a/pkg/bench/query_test.go
+++ b/pkg/bench/query_test.go
@@ -16,3 +16,29 @@ func TestInsertRejectsNilRequest(t *testing.T) {
 		t.Fatalf("Insert error = %v, want ErrNilInsertRequest", err)
 	}
 }
+
+type errorRows struct {
+	err error
+}
+
+func (*errorRows) Columns() []string   { return nil }
+func (*errorRows) Next() bool          { return false }
+func (*errorRows) Values() []any       { return nil }
+func (*errorRows) ReadAll(int) [][]any { return nil }
+func (r *errorRows) Err() error        { return r.err }
+func (*errorRows) Close() error        { return nil }
+
+func TestFirstQueryValueReturnsRowError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("rows")
+
+	value, err := firstQueryValue(&errorRows{err: sentinel})
+	if value != nil {
+		t.Fatalf("firstQueryValue() value = %v, want nil", value)
+	}
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("firstQueryValue() error = %v, want sentinel", err)
+	}
+}

--- a/pkg/bench/query_test.go
+++ b/pkg/bench/query_test.go
@@ -5,6 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
 	"github.com/stroppy-io/stroppy/pkg/driver"
 )
 
@@ -41,4 +45,278 @@ func TestFirstQueryValueReturnsRowError(t *testing.T) {
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("firstQueryValue() error = %v, want sentinel", err)
 	}
+}
+
+type queryAPI interface {
+	Exec(ctx context.Context, sql string, args map[string]any) error
+	QueryValue(ctx context.Context, sql string, args map[string]any) (any, error)
+	QueryRow(ctx context.Context, sql string, args map[string]any) ([]any, error)
+	QueryRows(ctx context.Context, sql string, args map[string]any) ([][]any, error)
+}
+
+type queryTestDriver struct {
+	driver.Driver
+	result *driver.QueryResult
+	runErr error
+}
+
+func (d *queryTestDriver) RunQuery(context.Context, string, map[string]any) (*driver.QueryResult, error) {
+	return d.result, d.runErr
+}
+
+func (d *queryTestDriver) Begin(
+	context.Context,
+	stroppy.TxIsolationLevel,
+) (driver.Tx, error) {
+	return &queryTestTx{result: d.result, runErr: d.runErr}, nil
+}
+
+type queryTestTx struct {
+	driver.Tx
+	result *driver.QueryResult
+	runErr error
+}
+
+func (tx *queryTestTx) RunQuery(context.Context, string, map[string]any) (*driver.QueryResult, error) {
+	return tx.result, tx.runErr
+}
+
+type lazyCloseErrorRows struct {
+	rowErr     error
+	closeErr   error
+	onClose    func()
+	yielded    bool
+	exhausted  bool
+	closed     bool
+	closeCalls int
+}
+
+func (*lazyCloseErrorRows) Columns() []string { return []string{"value"} }
+
+func (r *lazyCloseErrorRows) Next() bool {
+	if r.closed || r.exhausted {
+		return false
+	}
+
+	if !r.yielded {
+		r.yielded = true
+
+		return true
+	}
+
+	r.exhausted = true
+
+	return false
+}
+
+func (*lazyCloseErrorRows) Values() []any { return []any{"value"} }
+
+func (r *lazyCloseErrorRows) ReadAll(limit int) [][]any {
+	var values [][]any
+	for r.Next() && (limit <= 0 || len(values) < limit) {
+		values = append(values, r.Values())
+	}
+
+	return values
+}
+
+func (r *lazyCloseErrorRows) Err() error {
+	if r.closed || r.exhausted {
+		return r.rowErr
+	}
+
+	return nil
+}
+
+func (r *lazyCloseErrorRows) Close() error {
+	r.closeCalls++
+	if r.onClose != nil {
+		r.onClose()
+	}
+
+	r.closed = true
+
+	return r.closeErr
+}
+
+type queryMetricCounts struct {
+	operations uint64
+	errors     uint64
+	durations  uint64
+}
+
+func newQueryTestTarget(
+	t *testing.T,
+	b *Bench,
+	drv *queryTestDriver,
+	isolation TxIsolationName,
+) queryAPI {
+	t.Helper()
+
+	b.drv = drv
+	if isolation == "" {
+		return b
+	}
+
+	tx, err := b.Begin(context.Background(), BeginOpts{Isolation: isolation})
+	require.NoError(t, err)
+
+	return tx
+}
+
+func TestQueryTerminalErrorsAndMetrics(t *testing.T) {
+	rowErr := context.DeadlineExceeded
+	closeErr := errors.New("close rows")
+	runErr := errors.New("run query")
+
+	paths := []struct {
+		name        string
+		isolation   TxIsolationName
+		errorPrefix string
+	}{
+		{name: "bench", errorPrefix: "query:"},
+		{name: "tx_none", isolation: IsoNone, errorPrefix: "query:"},
+		{name: "tx_real", isolation: IsoReadCommitted, errorPrefix: "tx query:"},
+	}
+
+	operations := []struct {
+		name string
+		run  func(queryAPI) error
+	}{
+		{
+			name: "exec",
+			run: func(q queryAPI) error {
+				return q.Exec(context.Background(), "SELECT 1", nil)
+			},
+		},
+		{
+			name: "query_value",
+			run: func(q queryAPI) error {
+				_, err := q.QueryValue(context.Background(), "SELECT 1", nil)
+
+				return err
+			},
+		},
+		{
+			name: "query_row",
+			run: func(q queryAPI) error {
+				_, err := q.QueryRow(context.Background(), "SELECT 1", nil)
+
+				return err
+			},
+		},
+		{
+			name: "query_rows",
+			run: func(q queryAPI) error {
+				_, err := q.QueryRows(context.Background(), "SELECT 1", nil)
+
+				return err
+			},
+		},
+	}
+
+	for _, path := range paths {
+		for _, operation := range operations {
+			t.Run(path.name+"/"+operation.name+"/terminal", func(t *testing.T) {
+				fx := newTestBenchFixture(t)
+				previousRoot := root
+				root = fx.rootState
+
+				t.Cleanup(func() { root = previousRoot })
+
+				metricsRecordedBeforeClose := false
+				rows := &lazyCloseErrorRows{
+					rowErr:   rowErr,
+					closeErr: closeErr,
+					onClose: func() {
+						metricsRecordedBeforeClose = fx.rootState.txMetrics.queryOperations != nil
+					},
+				}
+				drv := &queryTestDriver{result: &driver.QueryResult{Rows: rows}}
+				target := newQueryTestTarget(t, fx.b, drv, path.isolation)
+
+				err := operation.run(target)
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+				require.ErrorIs(t, err, closeErr)
+				require.False(t, metricsRecordedBeforeClose)
+				require.Equal(t, 1, rows.closeCalls)
+
+				var data metricdata.ResourceMetrics
+				require.NoError(t, fx.reader.Collect(context.Background(), &data))
+				require.Equal(t, queryMetricCounts{
+					operations: 1,
+					errors:     1,
+				}, collectQueryMetricCounts(t, data, fx.prefix))
+			})
+
+			t.Run(path.name+"/"+operation.name+"/early", func(t *testing.T) {
+				fx := newTestBenchFixture(t)
+				previousRoot := root
+				root = fx.rootState
+
+				t.Cleanup(func() { root = previousRoot })
+
+				drv := &queryTestDriver{runErr: runErr}
+				target := newQueryTestTarget(t, fx.b, drv, path.isolation)
+
+				err := operation.run(target)
+				require.ErrorIs(t, err, runErr)
+				require.ErrorContains(t, err, path.errorPrefix)
+
+				var data metricdata.ResourceMetrics
+				require.NoError(t, fx.reader.Collect(context.Background(), &data))
+				require.Equal(t, queryMetricCounts{
+					operations: 1,
+					errors:     1,
+				}, collectQueryMetricCounts(t, data, fx.prefix))
+			})
+		}
+	}
+}
+
+func collectQueryMetricCounts(
+	t *testing.T,
+	data metricdata.ResourceMetrics,
+	prefix string,
+) queryMetricCounts {
+	t.Helper()
+
+	return queryMetricCounts{
+		operations: queryMetricCount(t, data, prefix+"run_query_operations_total"),
+		errors:     queryMetricCount(t, data, prefix+"run_query_errors_total"),
+		durations:  queryMetricCount(t, data, prefix+"run_query_duration"),
+	}
+}
+
+func queryMetricCount(t *testing.T, data metricdata.ResourceMetrics, name string) uint64 {
+	t.Helper()
+
+	for _, scope := range data.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+
+			switch points := metric.Data.(type) {
+			case metricdata.Sum[float64]:
+				var count uint64
+				for _, point := range points.DataPoints {
+					count += uint64(point.Value)
+				}
+
+				return count
+			case metricdata.Histogram[float64]:
+				var count uint64
+				for _, point := range points.DataPoints {
+					count += point.Count
+				}
+
+				return count
+			default:
+				t.Fatalf("metric %q has unexpected type %T", name, metric.Data)
+			}
+		}
+	}
+
+	return 0
 }

--- a/pkg/bench/query_test.go
+++ b/pkg/bench/query_test.go
@@ -171,6 +171,67 @@ func newQueryTestTarget(
 	return tx
 }
 
+func TestQueryNilRowsUseNoRowSemantics(t *testing.T) {
+	paths := []struct {
+		name      string
+		isolation TxIsolationName
+	}{
+		{name: "bench"},
+		{name: "tx_none", isolation: IsoNone},
+		{name: "tx_real", isolation: IsoReadCommitted},
+	}
+
+	operations := []struct {
+		name string
+		run  func(queryAPI) (any, error)
+	}{
+		{
+			name: "query_value",
+			run: func(q queryAPI) (any, error) {
+				return q.QueryValue(context.Background(), "SELECT 1", nil)
+			},
+		},
+		{
+			name: "query_row",
+			run: func(q queryAPI) (any, error) {
+				return q.QueryRow(context.Background(), "SELECT 1", nil)
+			},
+		},
+		{
+			name: "query_rows",
+			run: func(q queryAPI) (any, error) {
+				return q.QueryRows(context.Background(), "SELECT 1", nil)
+			},
+		},
+	}
+
+	for _, path := range paths {
+		for _, operation := range operations {
+			t.Run(path.name+"/"+operation.name, func(t *testing.T) {
+				fx := newTestBenchFixture(t)
+				previousRoot := root
+				root = fx.rootState
+
+				t.Cleanup(func() { root = previousRoot })
+
+				drv := &queryTestDriver{result: &driver.QueryResult{}}
+				target := newQueryTestTarget(t, fx.b, drv, path.isolation)
+
+				got, err := operation.run(target)
+				require.NoError(t, err)
+				require.Nil(t, got)
+
+				var data metricdata.ResourceMetrics
+				require.NoError(t, fx.reader.Collect(context.Background(), &data))
+				require.Equal(t, queryMetricCounts{
+					operations: 1,
+					durations:  1,
+				}, collectQueryMetricCounts(t, data, fx.prefix))
+			})
+		}
+	}
+}
+
 func TestQueryTerminalErrorsAndMetrics(t *testing.T) {
 	rowErr := context.DeadlineExceeded
 	closeFailure := errors.New("close rows")

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -74,6 +74,7 @@ var (
 	errDurationNeedsExecutor     = errors.New("duration requires an explicit constant-vus executor")
 	errDurationWithWrongExecutor = errors.New("duration is only valid with the constant-vus executor")
 	errConstantVUsNeedsDuration  = errors.New("constant-vus requires duration")
+	errNegativeQueryTimeout      = errors.New("query-timeout must not be negative")
 )
 
 // Register adds a workload factory. Workload packages call it during init.
@@ -225,7 +226,17 @@ func Run(
 		return errDriverIndexMissing
 	}
 
-	drv, err := driver.Dispatch(ctx, driver.Options{Config: cfg, Logger: lg, DialFunc: root.dialer.DialContext})
+	queryTimeout := scenarioParams.queryTimeout.Value()
+	if queryTimeout < 0 {
+		return fmt.Errorf("%w, got %s", errNegativeQueryTimeout, queryTimeout)
+	}
+
+	drv, err := driver.Dispatch(ctx, driver.Options{
+		Config:       cfg,
+		Logger:       lg,
+		DialFunc:     root.dialer.DialContext,
+		QueryTimeout: queryTimeout,
+	})
 	if err != nil {
 		return fmt.Errorf("driver dispatch: %w", err)
 	}
@@ -283,6 +294,8 @@ type scenarioParams struct {
 	vus        Param[int]
 	iterations Param[int64]
 	duration   Param[time.Duration]
+
+	queryTimeout Param[time.Duration]
 }
 
 func defineWorkload(
@@ -306,6 +319,10 @@ func defineWorkload(
 			"iterations", 1, "Total shared iterations.", iterationOptions...,
 		),
 		duration: def.Param.Duration("duration", 0, "Duration of a constant-vus scenario."),
+		queryTimeout: def.Param.Duration(
+			"query-timeout", 0,
+			"Per-statement query deadline (e.g. 30s, 5s, 500ms); 0 disables it.",
+		),
 	}
 
 	def.scope = ParamScopeWorkload

--- a/pkg/bench/runtime_test.go
+++ b/pkg/bench/runtime_test.go
@@ -3,6 +3,7 @@ package bench
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -55,6 +56,25 @@ func TestRunScenarioKeepsOrdinaryErrorsPerWorker(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("runScenario() error = %v, want nil", err)
+	}
+}
+
+func TestRunRejectsNegativeQueryTimeout(t *testing.T) {
+	installRuntimeTestRoot(t)
+
+	Register(func() Workload { return &paramTestWorkload{name: "test/query-timeout-negative"} })
+
+	err := Run(
+		context.Background(),
+		"test/query-timeout-negative",
+		map[int]*stroppy.DriverConfig{0: {DriverType: stroppy.DriverConfig_DRIVER_TYPE_NOOP}},
+		nil,
+		ParamInputs{CLI: map[string]string{"query-timeout": "-5s"}},
+		zap.NewNop(),
+		&MetricsConfig{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "query-timeout must not be negative") {
+		t.Fatalf("Run() error = %v, want negative query-timeout", err)
 	}
 }
 

--- a/pkg/driver/dispatcher.go
+++ b/pkg/driver/dispatcher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -18,6 +19,9 @@ type (
 		DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 		Logger   *zap.Logger
 		Config   *stroppy.DriverConfig
+
+		// QueryTimeout bounds each statement; <= 0 disables the deadline.
+		QueryTimeout time.Duration
 	}
 
 	// Rows provides cursor-style iteration over query result rows.

--- a/pkg/driver/errors.go
+++ b/pkg/driver/errors.go
@@ -72,15 +72,5 @@ func appendDistinctError(unique *[]error, err error) {
 }
 
 func sameErrorCause(left, right error) bool {
-	for left != nil {
-		for candidate := right; candidate != nil; candidate = errors.Unwrap(candidate) {
-			if errors.Is(left, candidate) || errors.Is(candidate, left) {
-				return true
-			}
-		}
-
-		left = errors.Unwrap(left)
-	}
-
-	return false
+	return errors.Is(left, right) || errors.Is(right, left)
 }

--- a/pkg/driver/errors.go
+++ b/pkg/driver/errors.go
@@ -38,3 +38,49 @@ func DefaultErrorFacts(err error) ErrorFacts {
 		return ErrorFacts{Kind: ErrorKindUnknown}
 	}
 }
+
+// JoinErrors combines distinct error causes while preserving errors.Is behavior.
+func JoinErrors(errs ...error) error {
+	unique := make([]error, 0, len(errs))
+	for _, err := range errs {
+		appendDistinctError(&unique, err)
+	}
+
+	return errors.Join(unique...)
+}
+
+func appendDistinctError(unique *[]error, err error) {
+	if err == nil {
+		return
+	}
+
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, cause := range joined.Unwrap() {
+			appendDistinctError(unique, cause)
+		}
+
+		return
+	}
+
+	for _, candidate := range *unique {
+		if sameErrorCause(candidate, err) {
+			return
+		}
+	}
+
+	*unique = append(*unique, err)
+}
+
+func sameErrorCause(left, right error) bool {
+	for left != nil {
+		for candidate := right; candidate != nil; candidate = errors.Unwrap(candidate) {
+			if errors.Is(left, candidate) || errors.Is(candidate, left) {
+				return true
+			}
+		}
+
+		left = errors.Unwrap(left)
+	}
+
+	return false
+}

--- a/pkg/driver/errors_test.go
+++ b/pkg/driver/errors_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultErrorFacts(t *testing.T) {
@@ -28,5 +31,84 @@ func TestDefaultErrorFacts(t *testing.T) {
 				t.Fatalf("DefaultErrorFacts().Kind = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestJoinErrorsDeduplicatesOnlyTopLevelCauses(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("shared cause")
+	left := fmt.Errorf("left: %w", sentinel)
+	right := fmt.Errorf("right: %w", sentinel)
+
+	tests := []struct {
+		name        string
+		errs        []error
+		wantCauses  []error
+		wantMessage string
+	}{
+		{
+			name:        "wrapper_then_sentinel",
+			errs:        []error{left, sentinel},
+			wantCauses:  []error{left},
+			wantMessage: left.Error(),
+		},
+		{
+			name:        "sentinel_then_wrapper",
+			errs:        []error{sentinel, left},
+			wantCauses:  []error{sentinel},
+			wantMessage: sentinel.Error(),
+		},
+		{
+			name:        "sibling_wrappers",
+			errs:        []error{left, right},
+			wantCauses:  []error{left, right},
+			wantMessage: left.Error() + "\n" + right.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := JoinErrors(tt.errs...)
+			if got.Error() != tt.wantMessage {
+				t.Fatalf("JoinErrors message = %q, want %q", got.Error(), tt.wantMessage)
+			}
+
+			joined, ok := got.(interface{ Unwrap() []error })
+			if !ok {
+				t.Fatalf("JoinErrors result type %T has no multi-error unwrap", got)
+			}
+
+			causes := joined.Unwrap()
+			if len(causes) != len(tt.wantCauses) {
+				t.Fatalf("JoinErrors causes = %v, want %v", causes, tt.wantCauses)
+			}
+
+			for i := range causes {
+				require.Same(t, tt.wantCauses[i], causes[i], "cause %d", i)
+			}
+		})
+	}
+}
+
+func TestJoinErrorsReportsTimeoutOnce(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close rows")
+	wrappedTimeout := fmt.Errorf("close: %w", context.DeadlineExceeded)
+	got := JoinErrors(context.DeadlineExceeded, errors.Join(closeErr, wrappedTimeout))
+
+	if !errors.Is(got, context.DeadlineExceeded) {
+		t.Fatalf("JoinErrors error = %v, want context deadline exceeded", got)
+	}
+
+	if !errors.Is(got, closeErr) {
+		t.Fatalf("JoinErrors error = %v, want close error", got)
+	}
+
+	if count := strings.Count(got.Error(), context.DeadlineExceeded.Error()); count != 1 {
+		t.Fatalf("deadline message count = %d, want 1: %v", count, got)
 	}
 }

--- a/pkg/driver/mysql/dialect.go
+++ b/pkg/driver/mysql/dialect.go
@@ -21,12 +21,22 @@ type mysqlDialect struct{}
 func (mysqlDialect) Placeholder(_ int) string { return "?" }
 func (mysqlDialect) Deduplicate() bool        { return false }
 
+// statementTimeoutGrace pads the client-side deadline past the server-side
+// MAX_EXECUTION_TIME hint. Without it the client context timer fires one
+// round-trip earlier than the server hint, so go-sql-driver/mysql cancels and
+// discards the connection instead of letting the hint return its own 3024
+// error. The hint fires at `timeout` (server-side); the padded client deadline
+// is only a backstop.
+const statementTimeoutGrace = time.Second
+
 // StatementTimeoutHint bounds SELECT statements server-side with the
 // MAX_EXECUTION_TIME optimizer hint so a timed-out query aborts cleanly and
 // keeps its pooled connection, unlike client-side cancellation which forces
-// go-sql-driver/mysql to discard the connection. The hint is ignored by
-// non-SELECT statements, so inserting it after the SELECT keyword only is
-// safe for the DDL and DML that also flow through this dialect.
+// go-sql-driver/mysql to discard the connection. The hint is recognized only
+// when the statement's first token is SELECT: WITH/EXPLAIN-prefixed or
+// comment-prefixed statements rely on the client deadline backstop, and
+// non-SELECT statements (including INSERT ... SELECT) are intentionally left
+// untouched because the hint does not bind them.
 func (mysqlDialect) StatementTimeoutHint(sql string, timeout time.Duration) string {
 	if timeout <= 0 {
 		return sql
@@ -55,6 +65,16 @@ func (mysqlDialect) StatementTimeoutHint(sql string, timeout time.Duration) stri
 
 	return lead + trimmed[:len(keyword)] + " " +
 		fmt.Sprintf("/*+ MAX_EXECUTION_TIME(%d) */", ms) + trimmed[len(keyword):]
+}
+
+// StatementDeadline returns the client-side deadline padded past the
+// server-side hint so the hint's 3024 timeout wins over client cancellation.
+func (mysqlDialect) StatementDeadline(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return timeout
+	}
+
+	return timeout + statementTimeoutGrace
 }
 
 func isSQLWhitespace(c byte) bool {

--- a/pkg/driver/mysql/dialect.go
+++ b/pkg/driver/mysql/dialect.go
@@ -74,6 +74,7 @@ func (mysqlDialect) StatementDeadline(timeout time.Duration) time.Duration {
 	if timeout <= 0 {
 		return timeout
 	}
+
 	if timeout > time.Duration(math.MaxInt64)-statementTimeoutGrace {
 		return time.Duration(math.MaxInt64)
 	}

--- a/pkg/driver/mysql/dialect.go
+++ b/pkg/driver/mysql/dialect.go
@@ -45,15 +45,15 @@ var maxExecutionTimeHintPattern = regexp.MustCompile(
 // kept in the single hint block MySQL recognizes after SELECT. WITH/EXPLAIN-
 // prefixed, comment-prefixed, non-SELECT, and top-level SELECT SLEEP statements
 // rely on the client deadline backstop.
-func (mysqlDialect) StatementTimeoutHint(sql string, timeout time.Duration) string {
+func (mysqlDialect) StatementTimeoutHint(sql string, timeout time.Duration) (string, bool) {
 	milliseconds, ok := mysqlTimeoutMilliseconds(timeout)
 	if !ok {
-		return sql
+		return sql, false
 	}
 
 	selectEnd, ok := selectKeywordEnd(sql)
 	if !ok {
-		return sql
+		return sql, false
 	}
 
 	hintStart, hintEnd, hasHint := optimizerHintBounds(sql, selectEnd)
@@ -64,12 +64,12 @@ func (mysqlDialect) StatementTimeoutHint(sql string, timeout time.Duration) stri
 	}
 
 	if isTopLevelSleep(sql[expressionStart:]) {
-		return sql
+		return sql, false
 	}
 
 	timeoutHint := fmt.Sprintf("MAX_EXECUTION_TIME(%d)", milliseconds)
 	if !hasHint {
-		return sql[:selectEnd] + " /*+ " + timeoutHint + " */" + sql[selectEnd:]
+		return sql[:selectEnd] + " /*+ " + timeoutHint + " */" + sql[selectEnd:], true
 	}
 
 	contentStart := hintStart + len("/*+")
@@ -83,7 +83,7 @@ func (mysqlDialect) StatementTimeoutHint(sql string, timeout time.Duration) stri
 		content = insertOptimizerHint(content, timeoutHint)
 	}
 
-	return sql[:contentStart] + content + sql[contentEnd:]
+	return sql[:contentStart] + content + sql[contentEnd:], true
 }
 
 func replaceMaxExecutionTimeHints(content, hint string) (string, bool) {
@@ -177,37 +177,171 @@ func insertOptimizerHint(content, hint string) string {
 }
 
 func isTopLevelSleep(sql string) bool {
-	start := skipLeadingBlockComments(sql)
+	offset, ok := skipSQLTrivia(sql, 0)
+	if !ok {
+		return false
+	}
+
+	wrappers := 0
+	for offset < len(sql) && sql[offset] == '(' {
+		wrappers++
+
+		offset, ok = skipSQLTrivia(sql, offset+1)
+		if !ok {
+			return false
+		}
+	}
 
 	const function = "SLEEP"
 
-	end := start + len(function)
-	if end > len(sql) || !strings.EqualFold(sql[start:end], function) {
+	functionEnd := offset + len(function)
+	if functionEnd > len(sql) || !strings.EqualFold(sql[offset:functionEnd], function) {
 		return false
 	}
 
-	if end < len(sql) && isSQLIdentifierByte(sql[end]) {
+	if functionEnd < len(sql) && isSQLIdentifierByte(sql[functionEnd]) {
 		return false
 	}
 
-	end = skipSQLWhitespace(sql, end)
+	offset, ok = skipSQLTrivia(sql, functionEnd)
+	if !ok || offset >= len(sql) || sql[offset] != '(' {
+		return false
+	}
 
-	return end < len(sql) && sql[end] == '('
+	offset, ok = parenthesizedEnd(sql, offset)
+	if !ok {
+		return false
+	}
+
+	for range wrappers {
+		offset, ok = skipSQLTrivia(sql, offset)
+		if !ok || offset >= len(sql) || sql[offset] != ')' {
+			return false
+		}
+
+		offset++
+	}
+
+	offset, ok = skipSQLTrivia(sql, offset)
+	if !ok {
+		return false
+	}
+
+	return isTopLevelSleepSuffix(sql, offset)
 }
 
-func skipLeadingBlockComments(sql string) int {
-	offset := skipSQLWhitespace(sql, 0)
-	for strings.HasPrefix(sql[offset:], "/*") {
+func skipSQLTrivia(sql string, offset int) (int, bool) {
+	for {
+		offset = skipSQLWhitespace(sql, offset)
+		if !strings.HasPrefix(sql[offset:], "/*") {
+			return offset, true
+		}
+
 		closeOffset := strings.Index(sql[offset+len("/*"):], "*/")
 		if closeOffset < 0 {
-			return offset
+			return offset, false
 		}
 
 		offset += len("/*") + closeOffset + len("*/")
-		offset = skipSQLWhitespace(sql, offset)
+	}
+}
+
+func parenthesizedEnd(sql string, start int) (int, bool) {
+	depth := 0
+
+	for offset := start; offset < len(sql); {
+		if strings.HasPrefix(sql[offset:], "/*") {
+			closeOffset := strings.Index(sql[offset+len("/*"):], "*/")
+			if closeOffset < 0 {
+				return 0, false
+			}
+
+			offset += len("/*") + closeOffset + len("*/")
+
+			continue
+		}
+
+		switch sql[offset] {
+		case '\'', '"', '`':
+			var ok bool
+
+			offset, ok = quotedSQLEnd(sql, offset)
+			if !ok {
+				return 0, false
+			}
+		case '(':
+			depth++
+			offset++
+		case ')':
+			depth--
+			offset++
+
+			if depth == 0 {
+				return offset, true
+			}
+		default:
+			offset++
+		}
 	}
 
-	return offset
+	return 0, false
+}
+
+func quotedSQLEnd(sql string, start int) (int, bool) {
+	quote := sql[start]
+
+	for offset := start + 1; offset < len(sql); offset++ {
+		if sql[offset] == '\\' {
+			offset++
+
+			continue
+		}
+
+		if sql[offset] != quote {
+			continue
+		}
+
+		if offset+1 < len(sql) && sql[offset+1] == quote {
+			offset++
+
+			continue
+		}
+
+		return offset + 1, true
+	}
+
+	return 0, false
+}
+
+func isTopLevelSleepSuffix(sql string, offset int) bool {
+	if offset == len(sql) {
+		return true
+	}
+
+	if sql[offset] == ',' || sql[offset] == ';' {
+		return true
+	}
+
+	return hasSQLKeyword(sql, offset, "AS") ||
+		hasSQLKeyword(sql, offset, "FROM") ||
+		hasSQLKeyword(sql, offset, "INTO") ||
+		hasSQLKeyword(sql, offset, "WHERE") ||
+		hasSQLKeyword(sql, offset, "GROUP") ||
+		hasSQLKeyword(sql, offset, "HAVING") ||
+		hasSQLKeyword(sql, offset, "ORDER") ||
+		hasSQLKeyword(sql, offset, "LIMIT") ||
+		hasSQLKeyword(sql, offset, "FOR") ||
+		hasSQLKeyword(sql, offset, "LOCK") ||
+		hasSQLKeyword(sql, offset, "UNION")
+}
+
+func hasSQLKeyword(sql string, offset int, keyword string) bool {
+	end := offset + len(keyword)
+	if end > len(sql) || !strings.EqualFold(sql[offset:end], keyword) {
+		return false
+	}
+
+	return end == len(sql) || !isSQLIdentifierByte(sql[end])
 }
 
 func skipSQLWhitespace(sql string, offset int) int {

--- a/pkg/driver/mysql/dialect.go
+++ b/pkg/driver/mysql/dialect.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -72,6 +73,9 @@ func (mysqlDialect) StatementTimeoutHint(sql string, timeout time.Duration) stri
 func (mysqlDialect) StatementDeadline(timeout time.Duration) time.Duration {
 	if timeout <= 0 {
 		return timeout
+	}
+	if timeout > time.Duration(math.MaxInt64)-statementTimeoutGrace {
+		return time.Duration(math.MaxInt64)
 	}
 
 	return timeout + statementTimeoutGrace

--- a/pkg/driver/mysql/dialect.go
+++ b/pkg/driver/mysql/dialect.go
@@ -2,6 +2,8 @@ package mysql
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,6 +20,51 @@ type mysqlDialect struct{}
 
 func (mysqlDialect) Placeholder(_ int) string { return "?" }
 func (mysqlDialect) Deduplicate() bool        { return false }
+
+// StatementTimeoutHint bounds SELECT statements server-side with the
+// MAX_EXECUTION_TIME optimizer hint so a timed-out query aborts cleanly and
+// keeps its pooled connection, unlike client-side cancellation which forces
+// go-sql-driver/mysql to discard the connection. The hint is ignored by
+// non-SELECT statements, so inserting it after the SELECT keyword only is
+// safe for the DDL and DML that also flow through this dialect.
+func (mysqlDialect) StatementTimeoutHint(sql string, timeout time.Duration) string {
+	if timeout <= 0 {
+		return sql
+	}
+
+	const keyword = "SELECT"
+
+	trimmed := strings.TrimLeft(sql, " \t\r\n")
+
+	upper := strings.ToUpper(trimmed)
+	if !strings.HasPrefix(upper, keyword) {
+		return sql
+	}
+
+	// Only inject when "SELECT" is a whole keyword, not a longer identifier.
+	if rest := upper[len(keyword):]; rest != "" && !isSQLWhitespace(rest[0]) {
+		return sql
+	}
+
+	ms := timeout.Milliseconds()
+	if ms < 1 {
+		ms = 1
+	}
+
+	lead := sql[:len(sql)-len(trimmed)]
+
+	return lead + trimmed[:len(keyword)] + " " +
+		fmt.Sprintf("/*+ MAX_EXECUTION_TIME(%d) */", ms) + trimmed[len(keyword):]
+}
+
+func isSQLWhitespace(c byte) bool {
+	switch c {
+	case ' ', '\t', '\r', '\n':
+		return true
+	default:
+		return false
+	}
+}
 
 func (mysqlDialect) Convert(val any) (any, error) {
 	switch v := val.(type) { //nolint:varnamelen // switch type assertion idiom

--- a/pkg/driver/mysql/dialect.go
+++ b/pkg/driver/mysql/dialect.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 	"time"
 
@@ -28,58 +29,200 @@ func (mysqlDialect) Deduplicate() bool        { return false }
 // discards the connection instead of letting the hint return its own 3024
 // error. The hint fires at `timeout` (server-side); the padded client deadline
 // is only a backstop.
-const statementTimeoutGrace = time.Second
+const (
+	statementTimeoutGrace = time.Second
+	maxStatementTimeout   = time.Duration(math.MaxUint32) * time.Millisecond
+)
 
-// StatementTimeoutHint bounds SELECT statements server-side with the
+var maxExecutionTimeHintPattern = regexp.MustCompile(
+	`(?i)\bMAX_EXECUTION_TIME[ \t\r\n]*\([ \t\r\n]*[0-9]+[ \t\r\n]*\)`,
+)
+
+// StatementTimeoutHint bounds eligible SELECT statements server-side with the
 // MAX_EXECUTION_TIME optimizer hint so a timed-out query aborts cleanly and
 // keeps its pooled connection, unlike client-side cancellation which forces
-// go-sql-driver/mysql to discard the connection. The hint is recognized only
-// when the statement's first token is SELECT: WITH/EXPLAIN-prefixed or
-// comment-prefixed statements rely on the client deadline backstop, and
-// non-SELECT statements (including INSERT ... SELECT) are intentionally left
-// untouched because the hint does not bind them.
+// go-sql-driver/mysql to discard the connection. Existing optimizer hints are
+// kept in the single hint block MySQL recognizes after SELECT. WITH/EXPLAIN-
+// prefixed, comment-prefixed, non-SELECT, and top-level SELECT SLEEP statements
+// rely on the client deadline backstop.
 func (mysqlDialect) StatementTimeoutHint(sql string, timeout time.Duration) string {
-	if timeout <= 0 {
+	milliseconds, ok := mysqlTimeoutMilliseconds(timeout)
+	if !ok {
 		return sql
 	}
 
-	const keyword = "SELECT"
-
-	trimmed := strings.TrimLeft(sql, " \t\r\n")
-
-	upper := strings.ToUpper(trimmed)
-	if !strings.HasPrefix(upper, keyword) {
+	selectEnd, ok := selectKeywordEnd(sql)
+	if !ok {
 		return sql
 	}
 
-	// Only inject when "SELECT" is a whole keyword, not a longer identifier.
-	if rest := upper[len(keyword):]; rest != "" && !isSQLWhitespace(rest[0]) {
+	hintStart, hintEnd, hasHint := optimizerHintBounds(sql, selectEnd)
+
+	expressionStart := selectEnd
+	if hasHint {
+		expressionStart = hintEnd
+	}
+
+	if isTopLevelSleep(sql[expressionStart:]) {
 		return sql
 	}
 
-	ms := timeout.Milliseconds()
-	if ms < 1 {
-		ms = 1
+	timeoutHint := fmt.Sprintf("MAX_EXECUTION_TIME(%d)", milliseconds)
+	if !hasHint {
+		return sql[:selectEnd] + " /*+ " + timeoutHint + " */" + sql[selectEnd:]
 	}
 
-	lead := sql[:len(sql)-len(trimmed)]
+	contentStart := hintStart + len("/*+")
+	contentEnd := hintEnd - len("*/")
+	content := sql[contentStart:contentEnd]
 
-	return lead + trimmed[:len(keyword)] + " " +
-		fmt.Sprintf("/*+ MAX_EXECUTION_TIME(%d) */", ms) + trimmed[len(keyword):]
+	replaced, found := replaceMaxExecutionTimeHints(content, timeoutHint)
+	if found {
+		content = replaced
+	} else {
+		content = insertOptimizerHint(content, timeoutHint)
+	}
+
+	return sql[:contentStart] + content + sql[contentEnd:]
 }
 
-// StatementDeadline returns the client-side deadline padded past the
-// server-side hint so the hint's 3024 timeout wins over client cancellation.
+func replaceMaxExecutionTimeHints(content, hint string) (string, bool) {
+	matches := maxExecutionTimeHintPattern.FindAllStringIndex(content, -1)
+	if len(matches) == 0 {
+		return content, false
+	}
+
+	var replaced strings.Builder
+	replaced.Grow(len(content) - matches[0][1] + matches[0][0] + len(hint))
+
+	last := 0
+	for index, match := range matches {
+		replaced.WriteString(content[last:match[0]])
+
+		if index == 0 {
+			replaced.WriteString(hint)
+		}
+
+		last = match[1]
+	}
+
+	replaced.WriteString(content[last:])
+
+	return replaced.String(), true
+}
+
+// StatementDeadline pads the client-side deadline only for durations that can
+// be represented by a MAX_EXECUTION_TIME hint.
 func (mysqlDialect) StatementDeadline(timeout time.Duration) time.Duration {
-	if timeout <= 0 {
+	if _, ok := mysqlTimeoutMilliseconds(timeout); !ok {
 		return timeout
 	}
 
-	if timeout > time.Duration(math.MaxInt64)-statementTimeoutGrace {
-		return time.Duration(math.MaxInt64)
+	return timeout + statementTimeoutGrace
+}
+
+func mysqlTimeoutMilliseconds(timeout time.Duration) (uint32, bool) {
+	if timeout < time.Millisecond || timeout > maxStatementTimeout {
+		return 0, false
 	}
 
-	return timeout + statementTimeoutGrace
+	return uint32(timeout / time.Millisecond), true
+}
+
+func selectKeywordEnd(sql string) (int, bool) {
+	const keyword = "SELECT"
+
+	start := skipSQLWhitespace(sql, 0)
+	end := start + len(keyword)
+
+	if end > len(sql) || !strings.EqualFold(sql[start:end], keyword) {
+		return 0, false
+	}
+
+	if end < len(sql) && isSQLIdentifierByte(sql[end]) {
+		return 0, false
+	}
+
+	return end, true
+}
+
+func optimizerHintBounds(sql string, offset int) (hintStart, hintEnd int, found bool) {
+	start := skipSQLWhitespace(sql, offset)
+	if !strings.HasPrefix(sql[start:], "/*+") {
+		return 0, 0, false
+	}
+
+	closeOffset := strings.Index(sql[start+len("/*+"):], "*/")
+	if closeOffset < 0 {
+		return 0, 0, false
+	}
+
+	end := start + len("/*+") + closeOffset + len("*/")
+
+	return start, end, true
+}
+
+func insertOptimizerHint(content, hint string) string {
+	insertAt := len(content)
+	for insertAt > 0 && isSQLWhitespace(content[insertAt-1]) {
+		insertAt--
+	}
+
+	separator := ""
+	if insertAt > 0 {
+		separator = " "
+	}
+
+	return content[:insertAt] + separator + hint + content[insertAt:]
+}
+
+func isTopLevelSleep(sql string) bool {
+	start := skipLeadingBlockComments(sql)
+
+	const function = "SLEEP"
+
+	end := start + len(function)
+	if end > len(sql) || !strings.EqualFold(sql[start:end], function) {
+		return false
+	}
+
+	if end < len(sql) && isSQLIdentifierByte(sql[end]) {
+		return false
+	}
+
+	end = skipSQLWhitespace(sql, end)
+
+	return end < len(sql) && sql[end] == '('
+}
+
+func skipLeadingBlockComments(sql string) int {
+	offset := skipSQLWhitespace(sql, 0)
+	for strings.HasPrefix(sql[offset:], "/*") {
+		closeOffset := strings.Index(sql[offset+len("/*"):], "*/")
+		if closeOffset < 0 {
+			return offset
+		}
+
+		offset += len("/*") + closeOffset + len("*/")
+		offset = skipSQLWhitespace(sql, offset)
+	}
+
+	return offset
+}
+
+func skipSQLWhitespace(sql string, offset int) int {
+	for offset < len(sql) && isSQLWhitespace(sql[offset]) {
+		offset++
+	}
+
+	return offset
+}
+
+func isSQLIdentifierByte(char byte) bool {
+	return char >= 'a' && char <= 'z' ||
+		char >= 'A' && char <= 'Z' ||
+		char >= '0' && char <= '9' ||
+		char == '_' || char == '$' || char >= 0x80
 }
 
 func isSQLWhitespace(c byte) bool {

--- a/pkg/driver/mysql/dialect_test.go
+++ b/pkg/driver/mysql/dialect_test.go
@@ -111,6 +111,7 @@ func TestStatementDeadline(t *testing.T) {
 	if got := dynamic.StatementDeadline(maxDuration); got != maxDuration {
 		t.Fatalf("StatementDeadline(max duration) = %v, want saturated %v", got, maxDuration)
 	}
+
 	if got := dynamic.StatementDeadline(maxDuration - statementTimeoutGrace); got != maxDuration {
 		t.Fatalf("StatementDeadline(max duration - grace) = %v, want %v", got, maxDuration)
 	}

--- a/pkg/driver/mysql/dialect_test.go
+++ b/pkg/driver/mysql/dialect_test.go
@@ -47,6 +47,24 @@ func TestStatementTimeoutHint(t *testing.T) {
 			want:    "SELECTION x",
 		},
 		{
+			name:    "WITH-prefixed select relies on client backstop",
+			sql:     "WITH cte AS (SELECT 1) SELECT * FROM cte",
+			timeout: time.Second,
+			want:    "WITH cte AS (SELECT 1) SELECT * FROM cte",
+		},
+		{
+			name:    "EXPLAIN-prefixed select relies on client backstop",
+			sql:     "EXPLAIN SELECT 1",
+			timeout: time.Second,
+			want:    "EXPLAIN SELECT 1",
+		},
+		{
+			name:    "comment-prefixed select relies on client backstop",
+			sql:     "/* probe */ SELECT 1",
+			timeout: time.Second,
+			want:    "/* probe */ SELECT 1",
+		},
+		{
 			name:    "disabled timeout unchanged",
 			sql:     "SELECT 1",
 			timeout: 0,
@@ -62,5 +80,23 @@ func TestStatementTimeoutHint(t *testing.T) {
 				t.Fatalf("StatementTimeoutHint() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStatementDeadline(t *testing.T) {
+	t.Parallel()
+
+	dynamic := mysqlDialect{}
+
+	if got := dynamic.StatementDeadline(150 * time.Millisecond); got != 150*time.Millisecond+statementTimeoutGrace {
+		t.Fatalf("StatementDeadline(150ms) = %v, want 150ms + grace", got)
+	}
+
+	if got := dynamic.StatementDeadline(0); got != 0 {
+		t.Fatalf("StatementDeadline(0) = %v, want 0 (disabled)", got)
+	}
+
+	if got := dynamic.StatementDeadline(-time.Second); got != -time.Second {
+		t.Fatalf("StatementDeadline(-1s) = %v, want -1s (disabled)", got)
 	}
 }

--- a/pkg/driver/mysql/dialect_test.go
+++ b/pkg/driver/mysql/dialect_test.go
@@ -1,0 +1,66 @@
+package mysql
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStatementTimeoutHint(t *testing.T) {
+	t.Parallel()
+
+	dynamic := mysqlDialect{}
+
+	tests := []struct {
+		name    string
+		sql     string
+		timeout time.Duration
+		want    string
+	}{
+		{
+			name:    "select gets hint after keyword",
+			sql:     "SELECT 1",
+			timeout: time.Second,
+			want:    "SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1",
+		},
+		{
+			name:    "lowercase select preserves its keyword case",
+			sql:     "select * from t",
+			timeout: 2 * time.Second,
+			want:    "select /*+ MAX_EXECUTION_TIME(2000) */ * from t",
+		},
+		{
+			name:    "leading whitespace preserved",
+			sql:     "  SELECT x",
+			timeout: time.Second,
+			want:    "  SELECT /*+ MAX_EXECUTION_TIME(1000) */ x",
+		},
+		{
+			name:    "non-select unchanged",
+			sql:     "INSERT INTO t VALUES (1)",
+			timeout: time.Second,
+			want:    "INSERT INTO t VALUES (1)",
+		},
+		{
+			name:    "select as identifier prefix unchanged",
+			sql:     "SELECTION x",
+			timeout: time.Second,
+			want:    "SELECTION x",
+		},
+		{
+			name:    "disabled timeout unchanged",
+			sql:     "SELECT 1",
+			timeout: 0,
+			want:    "SELECT 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := dynamic.StatementTimeoutHint(tt.sql, tt.timeout); got != tt.want {
+				t.Fatalf("StatementTimeoutHint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/driver/mysql/dialect_test.go
+++ b/pkg/driver/mysql/dialect_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -39,6 +40,12 @@ func TestStatementTimeoutHint(t *testing.T) {
 			sql:     "INSERT INTO t VALUES (1)",
 			timeout: time.Second,
 			want:    "INSERT INTO t VALUES (1)",
+		},
+		{
+			name:    "do unchanged",
+			sql:     "DO SLEEP(10)",
+			timeout: time.Second,
+			want:    "DO SLEEP(10)",
 		},
 		{
 			name:    "select as identifier prefix unchanged",
@@ -98,5 +105,13 @@ func TestStatementDeadline(t *testing.T) {
 
 	if got := dynamic.StatementDeadline(-time.Second); got != -time.Second {
 		t.Fatalf("StatementDeadline(-1s) = %v, want -1s (disabled)", got)
+	}
+
+	maxDuration := time.Duration(math.MaxInt64)
+	if got := dynamic.StatementDeadline(maxDuration); got != maxDuration {
+		t.Fatalf("StatementDeadline(max duration) = %v, want saturated %v", got, maxDuration)
+	}
+	if got := dynamic.StatementDeadline(maxDuration - statementTimeoutGrace); got != maxDuration {
+		t.Fatalf("StatementDeadline(max duration - grace) = %v, want %v", got, maxDuration)
 	}
 }

--- a/pkg/driver/mysql/dialect_test.go
+++ b/pkg/driver/mysql/dialect_test.go
@@ -9,7 +9,8 @@ import (
 func TestStatementTimeoutHint(t *testing.T) {
 	t.Parallel()
 
-	dynamic := mysqlDialect{}
+	dialect := mysqlDialect{}
+	maxTimeout := time.Duration(math.MaxUint32) * time.Millisecond
 
 	tests := []struct {
 		name    string
@@ -34,6 +35,66 @@ func TestStatementTimeoutHint(t *testing.T) {
 			sql:     "  SELECT x",
 			timeout: time.Second,
 			want:    "  SELECT /*+ MAX_EXECUTION_TIME(1000) */ x",
+		},
+		{
+			name:    "existing optimizer hints share one block",
+			sql:     "SeLeCt\t/*+ SET_VAR(sort_buffer_size=32768) BKA(t) */\n1",
+			timeout: 1500 * time.Millisecond,
+			want:    "SeLeCt\t/*+ SET_VAR(sort_buffer_size=32768) BKA(t) MAX_EXECUTION_TIME(1500) */\n1",
+		},
+		{
+			name:    "adjacent optimizer hint block is merged",
+			sql:     "SELECT/*+SET_VAR(sort_buffer_size=32768)*/1",
+			timeout: time.Second,
+			want:    "SELECT/*+SET_VAR(sort_buffer_size=32768) MAX_EXECUTION_TIME(1000)*/1",
+		},
+		{
+			name:    "existing timeout spacing and case are replaced",
+			sql:     "SELECT /*+ set_var(sort_buffer_size=32768) mAx_ExEcUtIoN_tImE \n ( \t5000 ) BKA(t) */ 1",
+			timeout: 250 * time.Millisecond,
+			want:    "SELECT /*+ set_var(sort_buffer_size=32768) MAX_EXECUTION_TIME(250) BKA(t) */ 1",
+		},
+		{
+			name:    "all duplicate timeouts collapse to configured timeout",
+			sql:     "SELECT /*+ MAX_EXECUTION_TIME(1) SET_VAR(sort_buffer_size=32768) max_execution_time (2) */ 1",
+			timeout: 250 * time.Millisecond,
+			want:    "SELECT /*+ MAX_EXECUTION_TIME(250) SET_VAR(sort_buffer_size=32768)  */ 1",
+		},
+		{
+			name:    "select sleep remains on exact client deadline",
+			sql:     "SELECT SLEEP(10) AS slept",
+			timeout: time.Second,
+			want:    "SELECT SLEEP(10) AS slept",
+		},
+		{
+			name:    "select sleep accepts keyword spacing and case",
+			sql:     "select\nSlEeP \t (10)",
+			timeout: time.Second,
+			want:    "select\nSlEeP \t (10)",
+		},
+		{
+			name:    "select sleep after optimizer hints remains unchanged",
+			sql:     "SELECT /*+ SET_VAR(sort_buffer_size=32768) */ SLEEP(10)",
+			timeout: time.Second,
+			want:    "SELECT /*+ SET_VAR(sort_buffer_size=32768) */ SLEEP(10)",
+		},
+		{
+			name:    "select sleep after ordinary block comment remains unchanged",
+			sql:     "SELECT /* probe */ SLEEP(10)",
+			timeout: time.Second,
+			want:    "SELECT /* probe */ SLEEP(10)",
+		},
+		{
+			name:    "sleep identifier prefix remains eligible",
+			sql:     "SELECT SLEEPING(10)",
+			timeout: time.Second,
+			want:    "SELECT /*+ MAX_EXECUTION_TIME(1000) */ SLEEPING(10)",
+		},
+		{
+			name:    "select expression without whitespace is eligible",
+			sql:     "SELECT(1)",
+			timeout: time.Second,
+			want:    "SELECT /*+ MAX_EXECUTION_TIME(1000) */(1)",
 		},
 		{
 			name:    "non-select unchanged",
@@ -77,13 +138,49 @@ func TestStatementTimeoutHint(t *testing.T) {
 			timeout: 0,
 			want:    "SELECT 1",
 		},
+		{
+			name:    "negative timeout unchanged",
+			sql:     "SELECT 1",
+			timeout: -time.Second,
+			want:    "SELECT 1",
+		},
+		{
+			name:    "sub-millisecond timeout unchanged",
+			sql:     "SELECT 1",
+			timeout: time.Millisecond - time.Nanosecond,
+			want:    "SELECT 1",
+		},
+		{
+			name:    "one millisecond is representable",
+			sql:     "SELECT 1",
+			timeout: time.Millisecond,
+			want:    "SELECT /*+ MAX_EXECUTION_TIME(1) */ 1",
+		},
+		{
+			name:    "fractional milliseconds use representable integer part",
+			sql:     "SELECT 1",
+			timeout: time.Millisecond + 500*time.Microsecond,
+			want:    "SELECT /*+ MAX_EXECUTION_TIME(1) */ 1",
+		},
+		{
+			name:    "uint32 maximum milliseconds is representable",
+			sql:     "SELECT 1",
+			timeout: maxTimeout,
+			want:    "SELECT /*+ MAX_EXECUTION_TIME(4294967295) */ 1",
+		},
+		{
+			name:    "duration above uint32 maximum unchanged",
+			sql:     "SELECT 1",
+			timeout: maxTimeout + time.Nanosecond,
+			want:    "SELECT 1",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := dynamic.StatementTimeoutHint(tt.sql, tt.timeout); got != tt.want {
+			if got := dialect.StatementTimeoutHint(tt.sql, tt.timeout); got != tt.want {
 				t.Fatalf("StatementTimeoutHint() = %q, want %q", got, tt.want)
 			}
 		})
@@ -93,26 +190,55 @@ func TestStatementTimeoutHint(t *testing.T) {
 func TestStatementDeadline(t *testing.T) {
 	t.Parallel()
 
-	dynamic := mysqlDialect{}
+	dialect := mysqlDialect{}
+	maxTimeout := time.Duration(math.MaxUint32) * time.Millisecond
 
-	if got := dynamic.StatementDeadline(150 * time.Millisecond); got != 150*time.Millisecond+statementTimeoutGrace {
-		t.Fatalf("StatementDeadline(150ms) = %v, want 150ms + grace", got)
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{name: "disabled", timeout: 0, want: 0},
+		{name: "negative", timeout: -time.Second, want: -time.Second},
+		{
+			name:    "sub-millisecond remains exact",
+			timeout: time.Millisecond - time.Nanosecond,
+			want:    time.Millisecond - time.Nanosecond,
+		},
+		{
+			name:    "minimum hint gets grace",
+			timeout: time.Millisecond,
+			want:    time.Millisecond + statementTimeoutGrace,
+		},
+		{
+			name:    "fractional milliseconds get grace",
+			timeout: time.Millisecond + 500*time.Microsecond,
+			want:    time.Millisecond + 500*time.Microsecond + statementTimeoutGrace,
+		},
+		{
+			name:    "maximum hint gets grace",
+			timeout: maxTimeout,
+			want:    maxTimeout + statementTimeoutGrace,
+		},
+		{
+			name:    "above maximum remains exact",
+			timeout: maxTimeout + time.Nanosecond,
+			want:    maxTimeout + time.Nanosecond,
+		},
+		{
+			name:    "maximum duration remains exact",
+			timeout: time.Duration(math.MaxInt64),
+			want:    time.Duration(math.MaxInt64),
+		},
 	}
 
-	if got := dynamic.StatementDeadline(0); got != 0 {
-		t.Fatalf("StatementDeadline(0) = %v, want 0 (disabled)", got)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if got := dynamic.StatementDeadline(-time.Second); got != -time.Second {
-		t.Fatalf("StatementDeadline(-1s) = %v, want -1s (disabled)", got)
-	}
-
-	maxDuration := time.Duration(math.MaxInt64)
-	if got := dynamic.StatementDeadline(maxDuration); got != maxDuration {
-		t.Fatalf("StatementDeadline(max duration) = %v, want saturated %v", got, maxDuration)
-	}
-
-	if got := dynamic.StatementDeadline(maxDuration - statementTimeoutGrace); got != maxDuration {
-		t.Fatalf("StatementDeadline(max duration - grace) = %v, want %v", got, maxDuration)
+			if got := dialect.StatementDeadline(tt.timeout); got != tt.want {
+				t.Fatalf("StatementDeadline(%v) = %v, want %v", tt.timeout, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/driver/mysql/dialect_test.go
+++ b/pkg/driver/mysql/dialect_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"math"
+	"strings"
 	"testing"
 	"time"
 )
@@ -13,52 +14,67 @@ func TestStatementTimeoutHint(t *testing.T) {
 	maxTimeout := time.Duration(math.MaxUint32) * time.Millisecond
 
 	tests := []struct {
-		name    string
-		sql     string
-		timeout time.Duration
-		want    string
+		name       string
+		sql        string
+		timeout    time.Duration
+		want       string
+		wantActive bool
 	}{
 		{
-			name:    "select gets hint after keyword",
-			sql:     "SELECT 1",
-			timeout: time.Second,
-			want:    "SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1",
+			name:       "select gets hint after keyword",
+			sql:        "SELECT 1",
+			timeout:    time.Second,
+			want:       "SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1",
+			wantActive: true,
 		},
 		{
-			name:    "lowercase select preserves its keyword case",
-			sql:     "select * from t",
-			timeout: 2 * time.Second,
-			want:    "select /*+ MAX_EXECUTION_TIME(2000) */ * from t",
+			name:       "lowercase select preserves its keyword case",
+			sql:        "select * from t",
+			timeout:    2 * time.Second,
+			want:       "select /*+ MAX_EXECUTION_TIME(2000) */ * from t",
+			wantActive: true,
 		},
 		{
-			name:    "leading whitespace preserved",
-			sql:     "  SELECT x",
-			timeout: time.Second,
-			want:    "  SELECT /*+ MAX_EXECUTION_TIME(1000) */ x",
+			name:       "leading whitespace preserved",
+			sql:        "  SELECT x",
+			timeout:    time.Second,
+			want:       "  SELECT /*+ MAX_EXECUTION_TIME(1000) */ x",
+			wantActive: true,
 		},
 		{
-			name:    "existing optimizer hints share one block",
-			sql:     "SeLeCt\t/*+ SET_VAR(sort_buffer_size=32768) BKA(t) */\n1",
-			timeout: 1500 * time.Millisecond,
-			want:    "SeLeCt\t/*+ SET_VAR(sort_buffer_size=32768) BKA(t) MAX_EXECUTION_TIME(1500) */\n1",
+			name:       "existing optimizer hints share one block",
+			sql:        "SeLeCt\t/*+ SET_VAR(sort_buffer_size=32768) BKA(t) */\n1",
+			timeout:    1500 * time.Millisecond,
+			want:       "SeLeCt\t/*+ SET_VAR(sort_buffer_size=32768) BKA(t) MAX_EXECUTION_TIME(1500) */\n1",
+			wantActive: true,
 		},
 		{
-			name:    "adjacent optimizer hint block is merged",
-			sql:     "SELECT/*+SET_VAR(sort_buffer_size=32768)*/1",
-			timeout: time.Second,
-			want:    "SELECT/*+SET_VAR(sort_buffer_size=32768) MAX_EXECUTION_TIME(1000)*/1",
+			name:       "adjacent optimizer hint block is merged",
+			sql:        "SELECT/*+SET_VAR(sort_buffer_size=32768)*/1",
+			timeout:    time.Second,
+			want:       "SELECT/*+SET_VAR(sort_buffer_size=32768) MAX_EXECUTION_TIME(1000)*/1",
+			wantActive: true,
 		},
 		{
-			name:    "existing timeout spacing and case are replaced",
-			sql:     "SELECT /*+ set_var(sort_buffer_size=32768) mAx_ExEcUtIoN_tImE \n ( \t5000 ) BKA(t) */ 1",
-			timeout: 250 * time.Millisecond,
-			want:    "SELECT /*+ set_var(sort_buffer_size=32768) MAX_EXECUTION_TIME(250) BKA(t) */ 1",
+			name:       "existing timeout spacing and case are replaced",
+			sql:        "SELECT /*+ set_var(sort_buffer_size=32768) mAx_ExEcUtIoN_tImE \n ( \t5000 ) BKA(t) */ 1",
+			timeout:    250 * time.Millisecond,
+			want:       "SELECT /*+ set_var(sort_buffer_size=32768) MAX_EXECUTION_TIME(250) BKA(t) */ 1",
+			wantActive: true,
 		},
 		{
-			name:    "all duplicate timeouts collapse to configured timeout",
-			sql:     "SELECT /*+ MAX_EXECUTION_TIME(1) SET_VAR(sort_buffer_size=32768) max_execution_time (2) */ 1",
-			timeout: 250 * time.Millisecond,
-			want:    "SELECT /*+ MAX_EXECUTION_TIME(250) SET_VAR(sort_buffer_size=32768)  */ 1",
+			name:       "all duplicate timeouts collapse to configured timeout",
+			sql:        "SELECT /*+ MAX_EXECUTION_TIME(1) SET_VAR(sort_buffer_size=32768) max_execution_time (2) */ 1",
+			timeout:    250 * time.Millisecond,
+			want:       "SELECT /*+ MAX_EXECUTION_TIME(250) SET_VAR(sort_buffer_size=32768)  */ 1",
+			wantActive: true,
+		},
+		{
+			name:       "canonical timeout remains active without a rewrite",
+			sql:        "SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1",
+			timeout:    time.Second,
+			want:       "SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1",
+			wantActive: true,
 		},
 		{
 			name:    "select sleep remains on exact client deadline",
@@ -85,16 +101,18 @@ func TestStatementTimeoutHint(t *testing.T) {
 			want:    "SELECT /* probe */ SLEEP(10)",
 		},
 		{
-			name:    "sleep identifier prefix remains eligible",
-			sql:     "SELECT SLEEPING(10)",
-			timeout: time.Second,
-			want:    "SELECT /*+ MAX_EXECUTION_TIME(1000) */ SLEEPING(10)",
+			name:       "sleep identifier prefix remains eligible",
+			sql:        "SELECT SLEEPING(10)",
+			timeout:    time.Second,
+			want:       "SELECT /*+ MAX_EXECUTION_TIME(1000) */ SLEEPING(10)",
+			wantActive: true,
 		},
 		{
-			name:    "select expression without whitespace is eligible",
-			sql:     "SELECT(1)",
-			timeout: time.Second,
-			want:    "SELECT /*+ MAX_EXECUTION_TIME(1000) */(1)",
+			name:       "select expression without whitespace is eligible",
+			sql:        "SELECT(1)",
+			timeout:    time.Second,
+			want:       "SELECT /*+ MAX_EXECUTION_TIME(1000) */(1)",
+			wantActive: true,
 		},
 		{
 			name:    "non-select unchanged",
@@ -151,22 +169,25 @@ func TestStatementTimeoutHint(t *testing.T) {
 			want:    "SELECT 1",
 		},
 		{
-			name:    "one millisecond is representable",
-			sql:     "SELECT 1",
-			timeout: time.Millisecond,
-			want:    "SELECT /*+ MAX_EXECUTION_TIME(1) */ 1",
+			name:       "one millisecond is representable",
+			sql:        "SELECT 1",
+			timeout:    time.Millisecond,
+			want:       "SELECT /*+ MAX_EXECUTION_TIME(1) */ 1",
+			wantActive: true,
 		},
 		{
-			name:    "fractional milliseconds use representable integer part",
-			sql:     "SELECT 1",
-			timeout: time.Millisecond + 500*time.Microsecond,
-			want:    "SELECT /*+ MAX_EXECUTION_TIME(1) */ 1",
+			name:       "fractional milliseconds use representable integer part",
+			sql:        "SELECT 1",
+			timeout:    time.Millisecond + 500*time.Microsecond,
+			want:       "SELECT /*+ MAX_EXECUTION_TIME(1) */ 1",
+			wantActive: true,
 		},
 		{
-			name:    "uint32 maximum milliseconds is representable",
-			sql:     "SELECT 1",
-			timeout: maxTimeout,
-			want:    "SELECT /*+ MAX_EXECUTION_TIME(4294967295) */ 1",
+			name:       "uint32 maximum milliseconds is representable",
+			sql:        "SELECT 1",
+			timeout:    maxTimeout,
+			want:       "SELECT /*+ MAX_EXECUTION_TIME(4294967295) */ 1",
+			wantActive: true,
 		},
 		{
 			name:    "duration above uint32 maximum unchanged",
@@ -180,10 +201,85 @@ func TestStatementTimeoutHint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := dialect.StatementTimeoutHint(tt.sql, tt.timeout); got != tt.want {
-				t.Fatalf("StatementTimeoutHint() = %q, want %q", got, tt.want)
+			hintedSQL, active := dialect.StatementTimeoutHint(tt.sql, tt.timeout)
+			if hintedSQL != tt.want || active != tt.wantActive {
+				t.Fatalf(
+					"StatementTimeoutHint() = (%q, %t), want (%q, %t)",
+					hintedSQL,
+					active,
+					tt.want,
+					tt.wantActive,
+				)
 			}
 		})
+	}
+}
+
+func TestStatementTimeoutHintTopLevelSleepWrappers(t *testing.T) {
+	t.Parallel()
+
+	dialect := mysqlDialect{}
+	selectPrefixes := []string{
+		"SELECT /* expression */ ",
+		"SELECT /*+ SET_VAR(sort_buffer_size=32768) */ /* expression */ ",
+	}
+	calls := []string{
+		"SLEEP(10)",
+		"sleep /* call */ (10)",
+		"SlEeP(IF(1, 10, 0))",
+	}
+
+	for depth := range 5 {
+		opening := strings.Repeat("( /* open */ ", depth)
+		closing := strings.Repeat(" /* close */ )", depth)
+
+		for _, prefix := range selectPrefixes {
+			for _, call := range calls {
+				sql := prefix + opening + "/* before */ " + call + " /* after */" + closing + " AS slept"
+				hintedSQL, active := dialect.StatementTimeoutHint(sql, time.Second)
+
+				if hintedSQL != sql || active {
+					t.Errorf(
+						"depth %d StatementTimeoutHint(%q) = (%q, %t), want (%q, false)",
+						depth,
+						sql,
+						hintedSQL,
+						active,
+						sql,
+					)
+				}
+			}
+		}
+	}
+}
+
+func TestStatementTimeoutHintDoesNotPromoteNestedSleep(t *testing.T) {
+	t.Parallel()
+
+	dialect := mysqlDialect{}
+	expressions := []string{
+		"ABS(SLEEP(10))",
+		"(ABS(SLEEP(10)))",
+		"SLEEP(10) + 1",
+		"(SLEEP(10) + 1)",
+		"(SLEEP(10)) + 1",
+		"(SELECT SLEEP(10))",
+	}
+
+	for _, expression := range expressions {
+		sql := "SELECT " + expression
+		want := "SELECT /*+ MAX_EXECUTION_TIME(1000) */ " + expression
+		hintedSQL, active := dialect.StatementTimeoutHint(sql, time.Second)
+
+		if hintedSQL != want || !active {
+			t.Errorf(
+				"StatementTimeoutHint(%q) = (%q, %t), want (%q, true)",
+				sql,
+				hintedSQL,
+				active,
+				want,
+			)
+		}
 	}
 }
 

--- a/pkg/driver/mysql/driver.go
+++ b/pkg/driver/mysql/driver.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	gomysql "github.com/go-sql-driver/mysql"
 	"go.uber.org/zap"
@@ -30,11 +31,12 @@ func init() {
 }
 
 type Driver struct {
-	db       *sql.DB
-	dialect  queries.Dialect
-	logger   *zap.Logger
-	sqlCfg   *stroppy.DriverConfig_SqlConfig
-	bulkSize int
+	db           *sql.DB
+	dialect      queries.Dialect
+	logger       *zap.Logger
+	sqlCfg       *stroppy.DriverConfig_SqlConfig
+	bulkSize     int
+	queryTimeout time.Duration
 }
 
 var _ driver.Driver = (*Driver)(nil)
@@ -80,11 +82,12 @@ func NewDriver(
 	}
 
 	return &Driver{
-		db:       db,
-		dialect:  mysqlDialect{},
-		logger:   lg,
-		sqlCfg:   sqlCfg,
-		bulkSize: bulkSize,
+		db:           db,
+		dialect:      mysqlDialect{},
+		logger:       lg,
+		sqlCfg:       sqlCfg,
+		bulkSize:     bulkSize,
+		queryTimeout: opts.QueryTimeout,
 	}, nil
 }
 
@@ -192,7 +195,7 @@ func (d *Driver) Begin(ctx context.Context, isolation stroppy.TxIsolationLevel) 
 			return nil, err
 		}
 
-		return sqldriver.NewConnOnlyTx(conn, sqldriver.NewRows, d.dialect, d.logger, conn.Close), nil
+		return sqldriver.NewConnOnlyTx(conn, sqldriver.NewRows, d.dialect, d.logger, d.queryTimeout, conn.Close), nil
 	}
 
 	sqlTx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sqldriver.IsolationToSQL(isolation)})
@@ -206,6 +209,7 @@ func (d *Driver) Begin(ctx context.Context, isolation stroppy.TxIsolationLevel) 
 		isolation,
 		d.dialect,
 		d.logger,
+		d.queryTimeout,
 	), nil
 }
 
@@ -214,7 +218,7 @@ func (d *Driver) RunQuery(
 	sqlStr string,
 	args map[string]any,
 ) (*driver.QueryResult, error) {
-	return sqldriver.RunQuery(ctx, d.db, sqldriver.NewRows, d.dialect, d.logger, sqlStr, args)
+	return sqldriver.RunQuery(ctx, d.db, sqldriver.NewRows, d.dialect, d.logger, sqlStr, args, d.queryTimeout)
 }
 
 func (d *Driver) Teardown(ctx context.Context) error {

--- a/pkg/driver/mysql/errors.go
+++ b/pkg/driver/mysql/errors.go
@@ -11,6 +11,7 @@ import (
 const (
 	errLockDeadlock    = 1213 // ER_LOCK_DEADLOCK
 	errLockWaitTimeout = 1205 // ER_LOCK_WAIT_TIMEOUT
+	errQueryTimeout    = 3024 // ER_QUERY_TIMEOUT (MAX_EXECUTION_TIME) — aborted with max_execution_time exceeded
 )
 
 func (*Driver) ClassifyError(err error) driver.ErrorFacts {
@@ -20,6 +21,8 @@ func (*Driver) ClassifyError(err error) driver.ErrorFacts {
 			return driver.ErrorFacts{Kind: driver.ErrorKindDeadlock}
 		case errLockWaitTimeout:
 			return driver.ErrorFacts{Kind: driver.ErrorKindLockTimeout}
+		case errQueryTimeout:
+			return driver.ErrorFacts{Kind: driver.ErrorKindTimeout}
 		}
 	}
 

--- a/pkg/driver/mysql/errors_test.go
+++ b/pkg/driver/mysql/errors_test.go
@@ -24,6 +24,7 @@ func TestClassifyError(t *testing.T) {
 			err:  fmt.Errorf("query: %w", &gomysql.MySQLError{Number: errLockWaitTimeout}),
 			want: driver.ErrorKindLockTimeout,
 		},
+		{name: "query timeout", err: &gomysql.MySQLError{Number: errQueryTimeout}, want: driver.ErrorKindTimeout},
 		{name: "other mysql", err: &gomysql.MySQLError{Number: 1062}, want: driver.ErrorKindUnknown},
 		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
 	}

--- a/pkg/driver/mysql/insert_spec.go
+++ b/pkg/driver/mysql/insert_spec.go
@@ -74,9 +74,9 @@ func (d *Driver) runInsertChunk(
 ) error {
 	switch method {
 	case driver.InsertNative, driver.InsertPlainBulk:
-		return sqldriver.RunBulkInsert(ctx, d.db, table, src, d.dialect, d.bulkSize)
+		return sqldriver.RunBulkInsert(ctx, d.db, table, src, d.dialect, d.bulkSize, d.queryTimeout)
 	case driver.InsertPlainQuery:
-		return sqldriver.RunBulkInsert(ctx, d.db, table, src, d.dialect, 1)
+		return sqldriver.RunBulkInsert(ctx, d.db, table, src, d.dialect, 1, d.queryTimeout)
 	default:
 		return fmt.Errorf("%w: %s", driver.ErrInsertMethodNotSupported, method)
 	}

--- a/pkg/driver/mysql/timeout_integration_test.go
+++ b/pkg/driver/mysql/timeout_integration_test.go
@@ -1,0 +1,170 @@
+package mysql
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+const realMySQLDSNEnv = "STROPPY_MYSQL_DSN"
+
+func realMySQLTimeoutDriver(t *testing.T, timeout time.Duration) *Driver {
+	t.Helper()
+
+	dsn := os.Getenv(realMySQLDSNEnv)
+	if dsn == "" {
+		t.Skip(realMySQLDSNEnv + " not set; skipping real-MySQL timeout test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	d, err := NewDriver(ctx, driver.Options{
+		Logger: zap.NewNop(),
+		Config: &stroppy.DriverConfig{
+			Url:        dsn,
+			DriverType: stroppy.DriverConfig_DRIVER_TYPE_MYSQL,
+		},
+		QueryTimeout: timeout,
+	})
+	if err != nil {
+		t.Fatalf("create MySQL driver: %v", err)
+	}
+
+	d.db.SetMaxOpenConns(1)
+	d.db.SetMaxIdleConns(1)
+
+	t.Cleanup(func() {
+		teardownCtx, teardownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer teardownCancel()
+
+		if err := d.Teardown(teardownCtx); err != nil {
+			t.Errorf("tear down MySQL driver: %v", err)
+		}
+	})
+
+	return d
+}
+
+func execRealMySQL(t *testing.T, d *Driver, query string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := d.db.ExecContext(ctx, query); err != nil {
+		t.Fatalf("execute MySQL fixture query: %v", err)
+	}
+}
+
+func finishMySQLQuery(res *driver.QueryResult, queryErr error) error {
+	if res == nil || res.Rows == nil {
+		return queryErr
+	}
+
+	closeErr := res.Rows.Close()
+
+	return errors.Join(queryErr, res.Rows.Err(), closeErr)
+}
+
+func runMySQLExec(ctx context.Context, d *Driver, query string) (err error) {
+	res, err := d.RunQuery(ctx, query, nil)
+	defer func() { err = finishMySQLQuery(res, err) }()
+
+	return err
+}
+
+func runMySQLFirstValue(ctx context.Context, d *Driver, query string) (_ any, err error) {
+	res, err := d.RunQuery(ctx, query, nil)
+	defer func() { err = finishMySQLQuery(res, err) }()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !res.Rows.Next() {
+		return nil, res.Rows.Err()
+	}
+
+	values := res.Rows.Values()
+	if len(values) == 0 {
+		return nil, res.Rows.Err()
+	}
+
+	return values[0], res.Rows.Err()
+}
+
+func TestProcedureResultCleanupHonorsQueryTimeout(t *testing.T) {
+	const (
+		procedure = "stroppy_result_cleanup_timeout"
+		timeout   = 100 * time.Millisecond
+	)
+
+	d := realMySQLTimeoutDriver(t, timeout)
+	execRealMySQL(t, d, "DROP PROCEDURE IF EXISTS "+procedure)
+	execRealMySQL(t, d, "CREATE PROCEDURE "+procedure+"() BEGIN SELECT 1; DO SLEEP(2); END")
+	t.Cleanup(func() { execRealMySQL(t, d, "DROP PROCEDURE IF EXISTS "+procedure) })
+
+	tests := []struct {
+		name     string
+		firstRow bool
+		run      func(context.Context) (any, error)
+	}{
+		{
+			name: "exec",
+			run: func(ctx context.Context) (any, error) {
+				return nil, runMySQLExec(ctx, d, "CALL "+procedure+"()")
+			},
+		},
+		{
+			name:     "first_row",
+			firstRow: true,
+			run: func(ctx context.Context) (any, error) {
+				return runMySQLFirstValue(ctx, d, "CALL "+procedure+"()")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := time.Now()
+			value, err := tt.run(context.Background())
+			elapsed := time.Since(start)
+
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("procedure error = %v, want context.DeadlineExceeded", err)
+			}
+
+			if facts := d.ClassifyError(err); facts.Kind != driver.ErrorKindTimeout {
+				t.Fatalf("error kind = %s, want %s", facts.Kind, driver.ErrorKindTimeout)
+			}
+
+			if elapsed >= time.Second {
+				t.Fatalf("procedure cleanup took %s, want less than 1s", elapsed)
+			}
+
+			if tt.firstRow && value != "1" && value != int64(1) {
+				t.Fatalf("first value = %#v, want 1", value)
+			}
+
+			followupCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			value, err = runMySQLFirstValue(followupCtx, d, "SELECT 1")
+			if err != nil {
+				t.Fatalf("follow-up query error = %v", err)
+			}
+
+			if value != "1" && value != int64(1) {
+				t.Fatalf("follow-up value = %#v, want 1", value)
+			}
+		})
+	}
+}

--- a/pkg/driver/mysql/timeout_integration_test.go
+++ b/pkg/driver/mysql/timeout_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	gomysql "github.com/go-sql-driver/mysql"
 	"go.uber.org/zap"
 
 	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
@@ -99,6 +100,139 @@ func runMySQLFirstValue(ctx context.Context, d *Driver, query string) (_ any, er
 	}
 
 	return values[0], res.Rows.Err()
+}
+
+func realMySQLConnectionID(t *testing.T, d *Driver) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	value, err := runMySQLFirstValue(ctx, d, "SELECT CAST(CONNECTION_ID() AS CHAR)")
+	if err != nil {
+		t.Fatalf("read MySQL connection ID: %v", err)
+	}
+
+	id, ok := value.(string)
+	if !ok {
+		t.Fatalf("MySQL connection ID = %#v (%T), want string", value, value)
+	}
+
+	return id
+}
+
+func assertRealMySQLTimeoutElapsed(t *testing.T, elapsed, timeout time.Duration) {
+	t.Helper()
+
+	if minimum := timeout / 2; elapsed < minimum {
+		t.Fatalf("query timed out after %s, want at least %s", elapsed, minimum)
+	}
+
+	if maximum := timeout + 500*time.Millisecond; elapsed > maximum {
+		t.Fatalf("query timed out after %s, want at most %s", elapsed, maximum)
+	}
+}
+
+func assertRealMySQLServerTimeout(t *testing.T, d *Driver, query string, timeout time.Duration) {
+	t.Helper()
+
+	connectionID := realMySQLConnectionID(t, d)
+	start := time.Now()
+	err := runMySQLExec(context.Background(), d, query)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("query %q returned nil error, want MySQL timeout", query)
+	}
+
+	var mysqlErr *gomysql.MySQLError
+	if !errors.As(err, &mysqlErr) || mysqlErr.Number != 3024 {
+		t.Fatalf("query %q error = %v, want MySQL error 3024", query, err)
+	}
+
+	if facts := d.ClassifyError(err); facts.Kind != driver.ErrorKindTimeout {
+		t.Fatalf("error kind = %s, want %s", facts.Kind, driver.ErrorKindTimeout)
+	}
+
+	if nextID := realMySQLConnectionID(t, d); nextID != connectionID {
+		t.Fatalf("connection ID after timeout = %s, want original %s", nextID, connectionID)
+	}
+
+	assertRealMySQLTimeoutElapsed(t, elapsed, timeout)
+}
+
+func assertRealMySQLClientTimeout(t *testing.T, d *Driver, query string, timeout time.Duration) {
+	t.Helper()
+
+	start := time.Now()
+	err := runMySQLExec(context.Background(), d, query)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("query %q error = %v, want context.DeadlineExceeded", query, err)
+	}
+
+	if facts := d.ClassifyError(err); facts.Kind != driver.ErrorKindTimeout {
+		t.Fatalf("error kind = %s, want %s", facts.Kind, driver.ErrorKindTimeout)
+	}
+
+	assertRealMySQLTimeoutElapsed(t, elapsed, timeout)
+}
+
+func TestStatementTimeoutHintLiveMySQLEligiblePaths(t *testing.T) {
+	const timeout = 100 * time.Millisecond
+
+	const expensiveSelect = "COUNT(*) FROM information_schema.columns a " +
+		"CROSS JOIN information_schema.columns b CROSS JOIN information_schema.columns c"
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "inserted",
+			query: "SELECT " + expensiveSelect,
+		},
+		{
+			name:  "replaced",
+			query: "SELECT /*+ MAX_EXECUTION_TIME(5000) */ " + expensiveSelect,
+		},
+		{
+			name:  "canonical unchanged",
+			query: "SELECT /*+ MAX_EXECUTION_TIME(100) */ " + expensiveSelect,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := realMySQLTimeoutDriver(t, timeout)
+			assertRealMySQLServerTimeout(t, d, tt.query, timeout)
+		})
+	}
+}
+
+func TestStatementTimeoutHintLiveMySQLSleepForms(t *testing.T) {
+	const timeout = 100 * time.Millisecond
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "direct", query: "SELECT SLEEP(0.3)"},
+		{name: "parenthesized", query: "SELECT (SLEEP(0.3))"},
+		{name: "comment prefixed", query: "SELECT /* before */ SLEEP(0.3) /* after */"},
+		{
+			name:  "comment wrapped parentheses",
+			query: "SELECT /* before */ (/* inner */ SLEEP /* call */ (0.3) /* after */)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := realMySQLTimeoutDriver(t, timeout)
+			assertRealMySQLClientTimeout(t, d, tt.query, timeout)
+		})
+	}
 }
 
 func TestProcedureResultCleanupHonorsQueryTimeout(t *testing.T) {

--- a/pkg/driver/noop/driver.go
+++ b/pkg/driver/noop/driver.go
@@ -39,10 +39,11 @@ func init() {
 // Every method runs the full stroppy framework stack (data generation,
 // argument processing, transaction bookkeeping) but discards the final I/O.
 type Driver struct {
-	conn     *noopConn
-	dialect  queries.Dialect
-	logger   *zap.Logger
-	bulkSize int
+	conn         *noopConn
+	dialect      queries.Dialect
+	logger       *zap.Logger
+	bulkSize     int
+	queryTimeout time.Duration
 }
 
 var _ driver.Driver = (*Driver)(nil)
@@ -59,10 +60,11 @@ func NewDriver(opts driver.Options) *Driver {
 	}
 
 	return &Driver{
-		conn:     &noopConn{},
-		dialect:  noopDialect{},
-		logger:   lg,
-		bulkSize: bulkSize,
+		conn:         &noopConn{},
+		dialect:      noopDialect{},
+		logger:       lg,
+		bulkSize:     bulkSize,
+		queryTimeout: opts.QueryTimeout,
 	}
 }
 
@@ -144,7 +146,7 @@ func (d *Driver) RunQuery(
 	sqlStr string,
 	args map[string]any,
 ) (*driver.QueryResult, error) {
-	return sqldriver.RunQuery(ctx, d.conn, wrapRows, d.dialect, d.logger, sqlStr, args)
+	return sqldriver.RunQuery(ctx, d.conn, wrapRows, d.dialect, d.logger, sqlStr, args, d.queryTimeout)
 }
 
 func (d *Driver) Begin(
@@ -153,12 +155,12 @@ func (d *Driver) Begin(
 ) (driver.Tx, error) {
 	if isolation == stroppy.TxIsolationLevel_CONNECTION_ONLY {
 		return sqldriver.NewConnOnlyTx(
-			d.conn, wrapRows, d.dialect, d.logger,
+			d.conn, wrapRows, d.dialect, d.logger, d.queryTimeout,
 			func() error { return nil },
 		), nil
 	}
 
-	return sqldriver.NewTx(d.conn, wrapRows, isolation, d.dialect, d.logger), nil
+	return sqldriver.NewTx(d.conn, wrapRows, isolation, d.dialect, d.logger, d.queryTimeout), nil
 }
 
 func (d *Driver) Teardown(_ context.Context) error {
@@ -249,6 +251,9 @@ var _ queries.Dialect = noopDialect{}
 
 func (noopDialect) Placeholder(_ int) string { return "?" }
 func (noopDialect) Deduplicate() bool        { return false }
+
+// StatementTimeoutHint returns sql unchanged; noop performs no I/O to bound.
+func (noopDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
 
 func (noopDialect) Convert(v any) (any, error) {
 	return v, nil

--- a/pkg/driver/noop/driver.go
+++ b/pkg/driver/noop/driver.go
@@ -255,6 +255,9 @@ func (noopDialect) Deduplicate() bool        { return false }
 // StatementTimeoutHint returns sql unchanged; noop performs no I/O to bound.
 func (noopDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
 
+// StatementDeadline returns timeout unchanged; noop has no server-side hint.
+func (noopDialect) StatementDeadline(timeout time.Duration) time.Duration { return timeout }
+
 func (noopDialect) Convert(v any) (any, error) {
 	return v, nil
 }

--- a/pkg/driver/noop/driver.go
+++ b/pkg/driver/noop/driver.go
@@ -253,7 +253,9 @@ func (noopDialect) Placeholder(_ int) string { return "?" }
 func (noopDialect) Deduplicate() bool        { return false }
 
 // StatementTimeoutHint returns sql unchanged; noop performs no I/O to bound.
-func (noopDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
+func (noopDialect) StatementTimeoutHint(sql string, _ time.Duration) (string, bool) {
+	return sql, false
+}
 
 // StatementDeadline returns timeout unchanged; noop has no server-side hint.
 func (noopDialect) StatementDeadline(timeout time.Duration) time.Duration { return timeout }

--- a/pkg/driver/picodata/dialect.go
+++ b/pkg/driver/picodata/dialect.go
@@ -75,3 +75,7 @@ func (PicoDialect) Convert(val any) (any, error) {
 }
 
 func (PicoDialect) Deduplicate() bool { return true }
+
+// StatementTimeoutHint returns sql unchanged; picodata honors context
+// cancellation for its per-statement deadline.
+func (PicoDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }

--- a/pkg/driver/picodata/dialect.go
+++ b/pkg/driver/picodata/dialect.go
@@ -78,7 +78,9 @@ func (PicoDialect) Deduplicate() bool { return true }
 
 // StatementTimeoutHint returns sql unchanged; picodata honors context
 // cancellation for its per-statement deadline.
-func (PicoDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
+func (PicoDialect) StatementTimeoutHint(sql string, _ time.Duration) (string, bool) {
+	return sql, false
+}
 
 // StatementDeadline returns timeout unchanged; there is no server-side hint
 // to outlast.

--- a/pkg/driver/picodata/dialect.go
+++ b/pkg/driver/picodata/dialect.go
@@ -79,3 +79,7 @@ func (PicoDialect) Deduplicate() bool { return true }
 // StatementTimeoutHint returns sql unchanged; picodata honors context
 // cancellation for its per-statement deadline.
 func (PicoDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
+
+// StatementDeadline returns timeout unchanged; there is no server-side hint
+// to outlast.
+func (PicoDialect) StatementDeadline(timeout time.Duration) time.Duration { return timeout }

--- a/pkg/driver/picodata/driver.go
+++ b/pkg/driver/picodata/driver.go
@@ -63,9 +63,10 @@ func (p *PoolX) QueryContext(ctx context.Context, sql string, args ...any) (pgx.
 
 // Driver implements the driver.Driver interface for Picodata DB.
 type Driver struct {
-	logger   *zap.Logger
-	pool     Executor
-	bulkSize int
+	logger       *zap.Logger
+	pool         Executor
+	bulkSize     int
+	queryTimeout time.Duration
 }
 
 // NewDriver creates a new Picodata driver instance.
@@ -85,8 +86,9 @@ func NewDriver(
 	cfg := opts.Config
 
 	d = &Driver{
-		logger:   lg,
-		bulkSize: defaultBulkSize,
+		logger:       lg,
+		bulkSize:     defaultBulkSize,
+		queryTimeout: opts.QueryTimeout,
 	}
 
 	if cfg.BulkSize != nil {
@@ -166,6 +168,7 @@ func (d *Driver) RunQuery(
 		d.logger,
 		sql,
 		args,
+		d.queryTimeout,
 	)
 }
 

--- a/pkg/driver/picodata/insert_spec.go
+++ b/pkg/driver/picodata/insert_spec.go
@@ -73,9 +73,9 @@ func (d *Driver) runInsertChunk(
 ) error {
 	switch method {
 	case driver.InsertNative, driver.InsertPlainBulk:
-		return sqldriver.RunBulkInsert(ctx, d.pool, table, src, PicoDialect{}, d.bulkSize)
+		return sqldriver.RunBulkInsert(ctx, d.pool, table, src, PicoDialect{}, d.bulkSize, d.queryTimeout)
 	case driver.InsertPlainQuery:
-		return sqldriver.RunBulkInsert(ctx, d.pool, table, src, PicoDialect{}, 1)
+		return sqldriver.RunBulkInsert(ctx, d.pool, table, src, PicoDialect{}, 1, d.queryTimeout)
 	default:
 		return fmt.Errorf("%w: %s", driver.ErrInsertMethodNotSupported, method)
 	}

--- a/pkg/driver/postgres/columnar_realpg_test.go
+++ b/pkg/driver/postgres/columnar_realpg_test.go
@@ -96,27 +96,34 @@ func TestColumnarDescribeStatementContext(t *testing.T) {
 
 	parent := context.Background()
 	zeroDriver := &Driver{}
+
 	ctx, cancel := zeroDriver.statementCtx(parent)
 	defer cancel()
+
 	if ctx != parent {
 		t.Fatal("zero query timeout should preserve the parent context")
 	}
 
-	cancelledParent, cancelParent := context.WithCancel(parent)
+	canceledParent, cancelParent := context.WithCancel(parent)
 	cancelParent()
+
 	timedDriver := &Driver{queryTimeout: time.Minute}
-	ctx, cancel = timedDriver.statementCtx(cancelledParent)
+
+	ctx, cancel = timedDriver.statementCtx(canceledParent)
 	defer cancel()
+
 	if !errors.Is(ctx.Err(), context.Canceled) {
-		t.Fatalf("cancelled parent error = %v, want context.Canceled", ctx.Err())
+		t.Fatalf("canceled parent error = %v, want context.Canceled", ctx.Err())
 	}
 
 	ctx, cancel = timedDriver.statementCtx(parent)
 	defer cancel()
+
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		t.Fatal("positive query timeout should set a deadline")
 	}
+
 	if remaining := time.Until(deadline); remaining <= 0 || remaining > time.Minute {
 		t.Fatalf("deadline remaining = %s, want (0, %s]", remaining, time.Minute)
 	}
@@ -231,12 +238,14 @@ func TestColumnarDescribeTimeoutReleasesConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect lock holder: %v", err)
 	}
+
 	t.Cleanup(func() { _ = locker.Close(context.Background()) })
 
 	lockTx, err := locker.Begin(context.Background())
 	if err != nil {
 		t.Fatalf("begin lock holder: %v", err)
 	}
+
 	t.Cleanup(func() { _ = lockTx.Rollback(context.Background()) })
 
 	if _, err := lockTx.Exec(context.Background(), "LOCK TABLE "+table+" IN ACCESS EXCLUSIVE MODE"); err != nil {
@@ -246,9 +255,11 @@ func TestColumnarDescribeTimeoutReleasesConnection(t *testing.T) {
 	start := time.Now()
 	_, err = d.describeColumnCastTypes(context.Background(), table, []string{"id"})
 	elapsed := time.Since(start)
+
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("describeColumnCastTypes error = %v, want context.DeadlineExceeded", err)
 	}
+
 	if elapsed < timeout/2 || elapsed > timeout*5 {
 		t.Fatalf("describeColumnCastTypes took %s, want near %s", elapsed, timeout)
 	}

--- a/pkg/driver/postgres/columnar_realpg_test.go
+++ b/pkg/driver/postgres/columnar_realpg_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -43,6 +44,12 @@ func (f *fakeSource) Next() ([]any, error) {
 func realPGDriver(t *testing.T, bulkSize int) *Driver {
 	t.Helper()
 
+	return realPGDriverWithTimeout(t, bulkSize, 0)
+}
+
+func realPGDriverWithTimeout(t *testing.T, bulkSize int, queryTimeout time.Duration) *Driver {
+	t.Helper()
+
 	dsn := os.Getenv("STROPPY_PG_DSN")
 	if dsn == "" {
 		t.Skip("STROPPY_PG_DSN not set; skipping real-postgres columnar test")
@@ -59,6 +66,9 @@ func realPGDriver(t *testing.T, bulkSize int) *Driver {
 	// override to a describe-based mode per Exec — and this mode is also where
 	// the 65535 bind-parameter limit that the columnar path exists to beat bites.
 	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
+	if queryTimeout > 0 {
+		cfg.MaxConns = 1
+	}
 
 	cfg.AfterConnect = func(_ context.Context, conn *pgx.Conn) error {
 		pgxdecimal.Register(conn.TypeMap())
@@ -74,9 +84,41 @@ func realPGDriver(t *testing.T, bulkSize int) *Driver {
 	t.Cleanup(pgxPool.Close)
 
 	return &Driver{
-		logger:   logger.Global(),
-		pool:     &pool.PoolX{Pool: pgxPool},
-		bulkSize: bulkSize,
+		logger:       logger.Global(),
+		pool:         &pool.PoolX{Pool: pgxPool},
+		bulkSize:     bulkSize,
+		queryTimeout: queryTimeout,
+	}
+}
+
+func TestColumnarDescribeStatementContext(t *testing.T) {
+	t.Parallel()
+
+	parent := context.Background()
+	zeroDriver := &Driver{}
+	ctx, cancel := zeroDriver.statementCtx(parent)
+	defer cancel()
+	if ctx != parent {
+		t.Fatal("zero query timeout should preserve the parent context")
+	}
+
+	cancelledParent, cancelParent := context.WithCancel(parent)
+	cancelParent()
+	timedDriver := &Driver{queryTimeout: time.Minute}
+	ctx, cancel = timedDriver.statementCtx(cancelledParent)
+	defer cancel()
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("cancelled parent error = %v, want context.Canceled", ctx.Err())
+	}
+
+	ctx, cancel = timedDriver.statementCtx(parent)
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("positive query timeout should set a deadline")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > time.Minute {
+		t.Fatalf("deadline remaining = %s, want (0, %s]", remaining, time.Minute)
 	}
 }
 
@@ -171,6 +213,52 @@ func TestColumnarInsertRoundTrip(t *testing.T) {
 
 	if string(payload) != "\x00\x01" {
 		t.Errorf("payload = %x, want 0001", payload)
+	}
+}
+
+func TestColumnarDescribeTimeoutReleasesConnection(t *testing.T) {
+	const (
+		table   = "columnar_describe_timeout_test"
+		timeout = 200 * time.Millisecond
+	)
+
+	d := realPGDriverWithTimeout(t, 1, timeout)
+	execSQL(t, d, "DROP TABLE IF EXISTS "+table)
+	execSQL(t, d, "CREATE TABLE "+table+" (id bigint)")
+	t.Cleanup(func() { execSQL(t, d, "DROP TABLE IF EXISTS "+table) })
+
+	locker, err := pgx.Connect(context.Background(), os.Getenv("STROPPY_PG_DSN"))
+	if err != nil {
+		t.Fatalf("connect lock holder: %v", err)
+	}
+	t.Cleanup(func() { _ = locker.Close(context.Background()) })
+
+	lockTx, err := locker.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin lock holder: %v", err)
+	}
+	t.Cleanup(func() { _ = lockTx.Rollback(context.Background()) })
+
+	if _, err := lockTx.Exec(context.Background(), "LOCK TABLE "+table+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+		t.Fatalf("lock table: %v", err)
+	}
+
+	start := time.Now()
+	_, err = d.describeColumnCastTypes(context.Background(), table, []string{"id"})
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("describeColumnCastTypes error = %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed < timeout/2 || elapsed > timeout*5 {
+		t.Fatalf("describeColumnCastTypes took %s, want near %s", elapsed, timeout)
+	}
+
+	if err := lockTx.Rollback(context.Background()); err != nil {
+		t.Fatalf("release table lock: %v", err)
+	}
+
+	if _, err := d.describeColumnCastTypes(context.Background(), table, []string{"id"}); err != nil {
+		t.Fatalf("describeColumnCastTypes after lock release: %v", err)
 	}
 }
 

--- a/pkg/driver/postgres/columnar_realpg_test.go
+++ b/pkg/driver/postgres/columnar_realpg_test.go
@@ -10,12 +10,14 @@ import (
 	"testing"
 	"time"
 
-	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
 
 	"github.com/stroppy-io/stroppy/pkg/common/logger"
+	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
+	"github.com/stroppy-io/stroppy/pkg/driver"
 	"github.com/stroppy-io/stroppy/pkg/driver/postgres/pool"
 )
 
@@ -55,26 +57,12 @@ func realPGDriverWithTimeout(t *testing.T, bulkSize int, queryTimeout time.Durat
 		t.Skip("STROPPY_PG_DSN not set; skipping real-postgres columnar test")
 	}
 
-	cfg, err := pgxpool.ParseConfig(dsn)
+	cfg, err := pool.ParseConfig(&stroppy.DriverConfig{Url: dsn}, logger.Global())
 	if err != nil {
 		t.Fatalf("parse dsn: %v", err)
 	}
 
-	// Match the production pool default (QueryExecModeExec): extended protocol
-	// but no server-side parameter Describe, so pgx infers param OIDs from the Go
-	// values. A []any array has no inferable OID there, so the columnar path must
-	// override to a describe-based mode per Exec — and this mode is also where
-	// the 65535 bind-parameter limit that the columnar path exists to beat bites.
-	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
-	if queryTimeout > 0 {
-		cfg.MaxConns = 1
-	}
-
-	cfg.AfterConnect = func(_ context.Context, conn *pgx.Conn) error {
-		pgxdecimal.Register(conn.TypeMap())
-
-		return nil
-	}
+	cfg.MaxConns = 1
 
 	pgxPool, err := pgxpool.NewWithConfig(context.Background(), cfg)
 	if err != nil {
@@ -155,6 +143,113 @@ func queryOneRow(t *testing.T, d *Driver, sql string, dest ...any) {
 	if err := rows.Scan(dest...); err != nil {
 		t.Fatalf("scan %q: %v", sql, err)
 	}
+}
+
+func sleepingQueryError(d *Driver, ctx context.Context) error {
+	result, err := d.RunQuery(ctx, "SELECT pg_sleep(10)", nil)
+	if err != nil {
+		return err
+	}
+
+	_ = result.Rows.ReadAll(0)
+
+	return result.Rows.Err()
+}
+
+func backendPID(t *testing.T, d *Driver) int {
+	t.Helper()
+
+	var pid int
+	queryOneRow(t, d, "SELECT pg_backend_pid()", &pid)
+
+	return pid
+}
+
+func requireServerCancellation(t *testing.T, err error) {
+	t.Helper()
+
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "57014" {
+		t.Fatalf("error = %v, want PostgreSQL SQLSTATE 57014", err)
+	}
+}
+
+func requireReusableBackend(t *testing.T, d *Driver, wantPID int) {
+	t.Helper()
+
+	var (
+		gotPID int
+		value  int
+	)
+	queryOneRow(t, d, "SELECT pg_backend_pid(), 42", &gotPID, &value)
+
+	if gotPID != wantPID {
+		t.Fatalf("follow-up backend PID = %d, want %d", gotPID, wantPID)
+	}
+
+	if value != 42 {
+		t.Fatalf("follow-up query value = %d, want 42", value)
+	}
+}
+
+func TestRunQueryParentCancellationPreservesConnection(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		queryTimeout time.Duration
+	}{
+		{name: "timeout disabled"},
+		{name: "timeout enabled", queryTimeout: 5 * time.Second},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			d := realPGDriverWithTimeout(t, 1, tt.queryTimeout)
+			pid := backendPID(t, d)
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			timer := time.AfterFunc(200*time.Millisecond, cancel)
+			defer timer.Stop()
+			defer cancel()
+
+			err := sleepingQueryError(d, ctx)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("query error = %v, want context.Canceled", err)
+			}
+
+			if errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("query error = %v, do not want context.DeadlineExceeded", err)
+			}
+
+			if got := d.ClassifyError(err).Kind; got != driver.ErrorKindCanceled {
+				t.Fatalf("error kind = %q, want %q", got, driver.ErrorKindCanceled)
+			}
+
+			requireServerCancellation(t, err)
+			requireReusableBackend(t, d, pid)
+		})
+	}
+}
+
+func TestRunQueryDeadlinePreservesConnection(t *testing.T) {
+	const timeout = 200 * time.Millisecond
+
+	d := realPGDriverWithTimeout(t, 1, timeout)
+	pid := backendPID(t, d)
+
+	err := sleepingQueryError(d, context.Background())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("query error = %v, want context.DeadlineExceeded", err)
+	}
+
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("query error = %v, do not want context.Canceled", err)
+	}
+
+	if got := d.ClassifyError(err).Kind; got != driver.ErrorKindTimeout {
+		t.Fatalf("error kind = %q, want %q", got, driver.ErrorKindTimeout)
+	}
+
+	requireServerCancellation(t, err)
+	requireReusableBackend(t, d, pid)
 }
 
 // TestColumnarInsertRoundTrip drives the unnest path against a real Postgres for

--- a/pkg/driver/postgres/dialect.go
+++ b/pkg/driver/postgres/dialect.go
@@ -75,3 +75,8 @@ func (PgxDialect) Convert(val any) (any, error) {
 }
 
 func (PgxDialect) Deduplicate() bool { return true }
+
+// StatementTimeoutHint returns sql unchanged: pgx already turns a deadline
+// into a PostgreSQL CancelRequest, so no session-level statement_timeout (and
+// no pooled-connection state to leak) is needed.
+func (PgxDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }

--- a/pkg/driver/postgres/dialect.go
+++ b/pkg/driver/postgres/dialect.go
@@ -80,3 +80,7 @@ func (PgxDialect) Deduplicate() bool { return true }
 // into a PostgreSQL CancelRequest, so no session-level statement_timeout (and
 // no pooled-connection state to leak) is needed.
 func (PgxDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
+
+// StatementDeadline returns timeout unchanged; there is no server-side hint
+// to outlast, so the client deadline is the timeout itself.
+func (PgxDialect) StatementDeadline(timeout time.Duration) time.Duration { return timeout }

--- a/pkg/driver/postgres/dialect.go
+++ b/pkg/driver/postgres/dialect.go
@@ -79,7 +79,9 @@ func (PgxDialect) Deduplicate() bool { return true }
 // StatementTimeoutHint returns sql unchanged: pgx already turns a deadline
 // into a PostgreSQL CancelRequest, so no session-level statement_timeout (and
 // no pooled-connection state to leak) is needed.
-func (PgxDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
+func (PgxDialect) StatementTimeoutHint(sql string, _ time.Duration) (string, bool) {
+	return sql, false
+}
 
 // StatementDeadline returns timeout unchanged; there is no server-side hint
 // to outlast, so the client deadline is the timeout itself.

--- a/pkg/driver/postgres/driver.go
+++ b/pkg/driver/postgres/driver.go
@@ -47,9 +47,10 @@ type Executor interface {
 }
 
 type Driver struct {
-	logger   *zap.Logger
-	pool     Executor
-	bulkSize int
+	logger       *zap.Logger
+	pool         Executor
+	bulkSize     int
+	queryTimeout time.Duration
 }
 
 var _ driver.Driver = new(Driver)
@@ -68,8 +69,9 @@ func NewDriver(
 	const defaultBulkSize = 2500
 
 	d = &Driver{
-		logger:   lg,
-		bulkSize: defaultBulkSize,
+		logger:       lg,
+		bulkSize:     defaultBulkSize,
+		queryTimeout: opts.QueryTimeout,
 	}
 
 	cfg := opts.Config
@@ -114,7 +116,7 @@ func (d *Driver) Begin(ctx context.Context, isolation stroppy.TxIsolationLevel) 
 			return nil, err
 		}
 
-		return NewConnOnlyTx(conn, d.logger), nil
+		return NewConnOnlyTx(conn, d.logger, d.queryTimeout), nil
 	}
 
 	pgxTx, err := d.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: toTxIsoLevel(isolation)})
@@ -139,5 +141,5 @@ func (d *Driver) RunQuery(
 	sql string,
 	args map[string]any,
 ) (*driver.QueryResult, error) {
-	return sqldriver.RunQuery(ctx, d.pool, NewRows, PgxDialect{}, d.logger, sql, args)
+	return sqldriver.RunQuery(ctx, d.pool, NewRows, PgxDialect{}, d.logger, sql, args, d.queryTimeout)
 }

--- a/pkg/driver/postgres/driver.go
+++ b/pkg/driver/postgres/driver.go
@@ -141,5 +141,7 @@ func (d *Driver) RunQuery(
 	sql string,
 	args map[string]any,
 ) (*driver.QueryResult, error) {
-	return sqldriver.RunQuery(ctx, d.pool, NewRows, PgxDialect{}, d.logger, sql, args, d.queryTimeout)
+	query := statementQuery{query: d.pool.QueryContext}
+
+	return sqldriver.RunQuery(ctx, query, NewRows, PgxDialect{}, d.logger, sql, args, d.queryTimeout)
 }

--- a/pkg/driver/postgres/errors.go
+++ b/pkg/driver/postgres/errors.go
@@ -17,6 +17,8 @@ func (*Driver) ClassifyError(err error) driver.ErrorFacts {
 			return driver.ErrorFacts{Kind: driver.ErrorKindDeadlock}
 		case "55P03":
 			return driver.ErrorFacts{Kind: driver.ErrorKindLockTimeout}
+		case "57014":
+			return driver.ErrorFacts{Kind: driver.ErrorKindTimeout}
 		}
 	}
 

--- a/pkg/driver/postgres/errors.go
+++ b/pkg/driver/postgres/errors.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"errors"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -8,7 +9,24 @@ import (
 	"github.com/stroppy-io/stroppy/pkg/driver"
 )
 
+func statementContextError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	ctxErr := ctx.Err()
+	if ctxErr == nil || errors.Is(err, ctxErr) {
+		return err
+	}
+
+	return errors.Join(ctxErr, err)
+}
+
 func (*Driver) ClassifyError(err error) driver.ErrorFacts {
+	if errors.Is(err, context.Canceled) {
+		return driver.ErrorFacts{Kind: driver.ErrorKindCanceled}
+	}
+
 	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		switch pgErr.Code {
 		case "40001":

--- a/pkg/driver/postgres/errors_test.go
+++ b/pkg/driver/postgres/errors_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -26,6 +27,16 @@ func TestClassifyError(t *testing.T) {
 		},
 		{name: "lock timeout", err: &pgconn.PgError{Code: "55P03"}, want: driver.ErrorKindLockTimeout},
 		{name: "query canceled", err: &pgconn.PgError{Code: "57014"}, want: driver.ErrorKindTimeout},
+		{
+			name: "parent cancellation wins over server cancellation",
+			err:  errors.Join(context.Canceled, &pgconn.PgError{Code: "57014"}),
+			want: driver.ErrorKindCanceled,
+		},
+		{
+			name: "deadline remains timeout",
+			err:  errors.Join(context.DeadlineExceeded, &pgconn.PgError{Code: "57014"}),
+			want: driver.ErrorKindTimeout,
+		},
 		{name: "other postgres", err: &pgconn.PgError{Code: "23505"}, want: driver.ErrorKindUnknown},
 		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
 	}

--- a/pkg/driver/postgres/errors_test.go
+++ b/pkg/driver/postgres/errors_test.go
@@ -25,6 +25,7 @@ func TestClassifyError(t *testing.T) {
 			want: driver.ErrorKindDeadlock,
 		},
 		{name: "lock timeout", err: &pgconn.PgError{Code: "55P03"}, want: driver.ErrorKindLockTimeout},
+		{name: "query canceled", err: &pgconn.PgError{Code: "57014"}, want: driver.ErrorKindTimeout},
 		{name: "other postgres", err: &pgconn.PgError{Code: "23505"}, want: driver.ErrorKindUnknown},
 		{name: "other", err: errors.New("boom"), want: driver.ErrorKindUnknown},
 	}

--- a/pkg/driver/postgres/insert_spec.go
+++ b/pkg/driver/postgres/insert_spec.go
@@ -123,7 +123,7 @@ func (d *Driver) copyFromRuntime(
 	copySrc.progress.Flush()
 
 	if err != nil {
-		return fmt.Errorf("postgres: CopyFrom %q: %w", table, err)
+		return fmt.Errorf("postgres: CopyFrom %q: %w", table, statementContextError(stmtCtx, err))
 	}
 
 	insertprogress.AddConfirmed(ctx, rowsCopied)
@@ -239,7 +239,7 @@ func (d *Driver) execBulkBatch(
 	defer cancel()
 
 	if _, err := d.pool.Exec(stmtCtx, query, args...); err != nil {
-		return fmt.Errorf("postgres: bulk INSERT %q: %w", table, err)
+		return fmt.Errorf("postgres: bulk INSERT %q: %w", table, statementContextError(stmtCtx, err))
 	}
 
 	return nil
@@ -440,7 +440,7 @@ func (d *Driver) execProgressColumnarBatch(
 	defer cancel()
 
 	if _, err := d.pool.Exec(stmtCtx, query, args...); err != nil {
-		return fmt.Errorf("postgres: columnar INSERT %q: %w", table, err)
+		return fmt.Errorf("postgres: columnar INSERT %q: %w", table, statementContextError(stmtCtx, err))
 	}
 
 	insertprogress.AddConfirmed(ctx, rows)
@@ -465,7 +465,11 @@ func (d *Driver) describeColumnCastTypes(
 
 	conn, err := d.pool.Acquire(stmtCtx)
 	if err != nil {
-		return nil, fmt.Errorf("postgres: acquire conn for describe %q: %w", table, err)
+		return nil, fmt.Errorf(
+			"postgres: acquire conn for describe %q: %w",
+			table,
+			statementContextError(stmtCtx, err),
+		)
 	}
 	defer conn.Release()
 
@@ -486,7 +490,11 @@ func (d *Driver) describeColumnCastTypes(
 
 	sd, err := conn.Conn().Prepare(stmtCtx, "", sb.String())
 	if err != nil {
-		return nil, fmt.Errorf("postgres: describe columns of %q: %w", table, err)
+		return nil, fmt.Errorf(
+			"postgres: describe columns of %q: %w",
+			table,
+			statementContextError(stmtCtx, err),
+		)
 	}
 
 	if len(sd.Fields) != len(columns) {

--- a/pkg/driver/postgres/insert_spec.go
+++ b/pkg/driver/postgres/insert_spec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stroppy-io/stroppy/pkg/driver"
 	"github.com/stroppy-io/stroppy/pkg/driver/common"
 	"github.com/stroppy-io/stroppy/pkg/driver/insertprogress"
+	"github.com/stroppy-io/stroppy/pkg/driver/sqldriver"
 	"github.com/stroppy-io/stroppy/pkg/driver/stats"
 	"github.com/stroppy-io/stroppy/pkg/gen"
 )
@@ -96,6 +97,11 @@ func (d *Driver) runInsertChunk(
 	}
 }
 
+// statementCtx derives the per-statement deadline for a single COPY/INSERT.
+func (d *Driver) statementCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	return sqldriver.StatementTimeout(ctx, d.queryTimeout)
+}
+
 // copyFromRuntime streams source rows into pgx.CopyFrom without buffering
 // the full result set. The adapter drains src to EOF.
 func (d *Driver) copyFromRuntime(
@@ -109,8 +115,11 @@ func (d *Driver) copyFromRuntime(
 		progress: insertprogress.NewGeneratedRowCounter(ctx),
 	}
 
+	stmtCtx, cancel := d.statementCtx(ctx)
+	defer cancel()
+
 	start := time.Now()
-	rowsCopied, err := d.pool.CopyFrom(ctx, pgx.Identifier{table}, src.Columns(), copySrc)
+	rowsCopied, err := d.pool.CopyFrom(stmtCtx, pgx.Identifier{table}, src.Columns(), copySrc)
 	copySrc.progress.Flush()
 
 	if err != nil {
@@ -226,7 +235,10 @@ func (d *Driver) execBulkBatch(
 ) error {
 	query, args := buildBulkInsert(table, columns, rows)
 
-	if _, err := d.pool.Exec(ctx, query, args...); err != nil {
+	stmtCtx, cancel := d.statementCtx(ctx)
+	defer cancel()
+
+	if _, err := d.pool.Exec(stmtCtx, query, args...); err != nil {
 		return fmt.Errorf("postgres: bulk INSERT %q: %w", table, err)
 	}
 
@@ -424,7 +436,10 @@ func (d *Driver) execProgressColumnarBatch(
 		args[i+1] = col
 	}
 
-	if _, err := d.pool.Exec(ctx, query, args...); err != nil {
+	stmtCtx, cancel := d.statementCtx(ctx)
+	defer cancel()
+
+	if _, err := d.pool.Exec(stmtCtx, query, args...); err != nil {
 		return fmt.Errorf("postgres: columnar INSERT %q: %w", table, err)
 	}
 

--- a/pkg/driver/postgres/insert_spec.go
+++ b/pkg/driver/postgres/insert_spec.go
@@ -502,9 +502,11 @@ func (d *Driver) describeColumnCastTypes(
 	for i, field := range sd.Fields {
 		pgType, ok := typeMap.TypeForOID(field.DataTypeOID)
 		if !ok {
+			column := columns[i] //nolint:gosec // field and column counts are checked above
+
 			return nil, fmt.Errorf(
 				"%w: table %q column %q OID %d",
-				ErrUnregisteredColumnType, table, columns[i], field.DataTypeOID,
+				ErrUnregisteredColumnType, table, column, field.DataTypeOID,
 			)
 		}
 

--- a/pkg/driver/postgres/insert_spec.go
+++ b/pkg/driver/postgres/insert_spec.go
@@ -460,7 +460,10 @@ func (d *Driver) describeColumnCastTypes(
 	table string,
 	columns []string,
 ) ([]string, error) {
-	conn, err := d.pool.Acquire(ctx)
+	stmtCtx, cancel := d.statementCtx(ctx)
+	defer cancel()
+
+	conn, err := d.pool.Acquire(stmtCtx)
 	if err != nil {
 		return nil, fmt.Errorf("postgres: acquire conn for describe %q: %w", table, err)
 	}
@@ -481,7 +484,7 @@ func (d *Driver) describeColumnCastTypes(
 	sb.WriteString(" FROM ")
 	sb.WriteString(pgx.Identifier{table}.Sanitize())
 
-	sd, err := conn.Conn().Prepare(ctx, "", sb.String())
+	sd, err := conn.Conn().Prepare(stmtCtx, "", sb.String())
 	if err != nil {
 		return nil, fmt.Errorf("postgres: describe columns of %q: %w", table, err)
 	}

--- a/pkg/driver/postgres/pool/pool.go
+++ b/pkg/driver/postgres/pool/pool.go
@@ -15,6 +15,7 @@ import (
 	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgconn/ctxwatch"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.uber.org/zap"
 
@@ -22,8 +23,9 @@ import (
 )
 
 const (
-	LoggerName       = "pgx-pool"
-	DriverLoggerName = "postgres-driver"
+	LoggerName                    = "pgx-pool"
+	DriverLoggerName              = "postgres-driver"
+	cancelRequestFallbackDeadline = 5 * time.Second
 )
 
 var (
@@ -80,6 +82,14 @@ func ParseConfig(
 	cfg, err := pgxpool.ParseConfig(config.GetUrl())
 	if err != nil {
 		return nil, err
+	}
+
+	cfg.ConnConfig.BuildContextWatcherHandler = func(conn *pgconn.PgConn) ctxwatch.Handler {
+		return &pgconn.CancelRequestContextWatcherHandler{
+			Conn:               conn,
+			CancelRequestDelay: 0,
+			DeadlineDelay:      cancelRequestFallbackDeadline,
+		}
 	}
 
 	// Disable connection lifetime limits

--- a/pkg/driver/postgres/pool/pool_test.go
+++ b/pkg/driver/postgres/pool/pool_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stroppy-io/stroppy/pkg/common/logger"
@@ -37,6 +38,12 @@ func TestParseConfig_Success(t *testing.T) {
 		require.Equal(t, int32(2), cfg.MinIdleConns)
 		require.Equal(t, time.Hour, cfg.MaxConnLifetime)
 		require.Equal(t, 10*time.Minute, cfg.MaxConnIdleTime)
+
+		handler := cfg.ConnConfig.BuildContextWatcherHandler(new(pgconn.PgConn))
+		watcher, ok := handler.(*pgconn.CancelRequestContextWatcherHandler)
+		require.True(t, ok)
+		require.Zero(t, watcher.CancelRequestDelay)
+		require.Equal(t, cancelRequestFallbackDeadline, watcher.DeadlineDelay)
 	})
 
 	t.Run("statementCache", func(t *testing.T) {

--- a/pkg/driver/postgres/rows.go
+++ b/pkg/driver/postgres/rows.go
@@ -1,12 +1,56 @@
 package postgres
 
 import (
+	"context"
+
 	"github.com/jackc/pgx/v5"
 
 	"github.com/stroppy-io/stroppy/pkg/driver"
 )
 
 var _ driver.Rows = (*Rows)(nil)
+
+type statementQuery struct {
+	query func(context.Context, string, ...any) (pgx.Rows, error)
+}
+
+func (q statementQuery) QueryContext(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	rows, err := q.query(ctx, sql, args...)
+	if rows != nil {
+		rows = &statementRows{
+			Rows: rows,
+			preserveError: func(err error) error {
+				return statementContextError(ctx, err)
+			},
+		}
+	}
+
+	return rows, statementContextError(ctx, err)
+}
+
+type statementRows struct {
+	pgx.Rows
+	preserveError func(error) error
+	err           error
+}
+
+func (r *statementRows) Next() bool {
+	if r.Rows.Next() {
+		return true
+	}
+
+	r.err = r.preserveError(r.Rows.Err())
+
+	return false
+}
+
+func (r *statementRows) Err() error {
+	if r.err == nil {
+		r.err = r.preserveError(r.Rows.Err())
+	}
+
+	return r.err
+}
 
 type Rows struct {
 	pgxRows pgx.Rows

--- a/pkg/driver/postgres/rows_test.go
+++ b/pkg/driver/postgres/rows_test.go
@@ -3,10 +3,93 @@ package postgres
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
 )
+
+func TestStatementQueryPreservesImmediateContextError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	pgErr := &pgconn.PgError{Code: "57014"}
+	query := statementQuery{query: func(context.Context, string, ...any) (pgx.Rows, error) {
+		return nil, pgErr
+	}}
+
+	rows, err := query.QueryContext(ctx, "SELECT pg_sleep(10)")
+	if rows != nil {
+		rows.Close()
+	}
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorIs(t, err, pgErr)
+}
+
+type terminalErrorRows struct {
+	pgx.Rows
+	err error
+}
+
+func (*terminalErrorRows) Next() bool { return false }
+func (r *terminalErrorRows) Err() error {
+	return r.err
+}
+
+func TestStatementRowsPreserveParentCancellationBeforeCleanup(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name         string
+		queryTimeout time.Duration
+	}{
+		{name: "timeout disabled"},
+		{name: "timeout enabled", queryTimeout: time.Minute},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			parentCtx, cancelParent := context.WithCancel(context.Background())
+			statementCtx := parentCtx
+			cancelStatement := func() {}
+
+			if tt.queryTimeout > 0 {
+				statementCtx, cancelStatement = context.WithTimeout(parentCtx, tt.queryTimeout)
+			}
+
+			defer cancelStatement()
+
+			pgErr := &pgconn.PgError{Code: "57014"}
+			baseRows := pgxmock.NewRows([]string{"value"}).Kind()
+			query := statementQuery{query: func(context.Context, string, ...any) (pgx.Rows, error) {
+				return &terminalErrorRows{Rows: baseRows, err: pgErr}, nil
+			}}
+
+			rawRows, err := query.QueryContext(statementCtx, "SELECT value")
+			require.NoError(t, err)
+
+			rows := NewRows(rawRows)
+
+			cancelParent()
+			require.False(t, rows.Next())
+			cancelStatement()
+
+			err = rows.Err()
+			require.ErrorIs(t, err, context.Canceled)
+			require.NotErrorIs(t, err, context.DeadlineExceeded)
+			require.ErrorIs(t, err, pgErr)
+			require.Equal(t, driver.ErrorKindCanceled, (*Driver)(nil).ClassifyError(err).Kind)
+		})
+	}
+}
 
 func TestRunQuery_ReturnsRows(t *testing.T) {
 	mock, err := pgxmock.NewPool()

--- a/pkg/driver/postgres/tx.go
+++ b/pkg/driver/postgres/tx.go
@@ -22,7 +22,7 @@ func (a *pgxTxAdapter) QueryContext(
 	sql string,
 	args ...any,
 ) (pgx.Rows, error) {
-	return a.Query(ctx, sql, args...)
+	return statementQuery{query: a.Query}.QueryContext(ctx, sql, args...)
 }
 
 func toTxIsoLevel(level stroppy.TxIsolationLevel) pgx.TxIsoLevel {
@@ -59,7 +59,7 @@ func (a *pgxConnAdapter) QueryContext(
 	sql string,
 	args ...any,
 ) (pgx.Rows, error) {
-	return a.conn.Query(ctx, sql, args...)
+	return statementQuery{query: a.conn.Query}.QueryContext(ctx, sql, args...)
 }
 
 func NewConnOnlyTx(conn *pgxpool.Conn, lg *zap.Logger, timeout time.Duration) *sqldriver.ConnOnlyTx[pgx.Rows] {

--- a/pkg/driver/postgres/tx.go
+++ b/pkg/driver/postgres/tx.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -46,6 +47,7 @@ func newTx(pgxTx pgx.Tx, isolation stroppy.TxIsolationLevel, d *Driver) *sqldriv
 		isolation,
 		PgxDialect{},
 		d.logger,
+		d.queryTimeout,
 	)
 }
 
@@ -60,12 +62,13 @@ func (a *pgxConnAdapter) QueryContext(
 	return a.conn.Query(ctx, sql, args...)
 }
 
-func NewConnOnlyTx(conn *pgxpool.Conn, lg *zap.Logger) *sqldriver.ConnOnlyTx[pgx.Rows] {
+func NewConnOnlyTx(conn *pgxpool.Conn, lg *zap.Logger, timeout time.Duration) *sqldriver.ConnOnlyTx[pgx.Rows] {
 	return sqldriver.NewConnOnlyTx(
 		&pgxConnAdapter{conn},
 		NewRows,
 		PgxDialect{},
 		lg,
+		timeout,
 		func() error {
 			conn.Release()
 

--- a/pkg/driver/sqldriver/bulk_test_helpers_test.go
+++ b/pkg/driver/sqldriver/bulk_test_helpers_test.go
@@ -2,6 +2,7 @@ package sqldriver
 
 import (
 	"context"
+	"time"
 
 	"github.com/stroppy-io/stroppy/pkg/driver/sqldriver/queries"
 )
@@ -37,5 +38,7 @@ type qmark struct{}
 func (qmark) Placeholder(_ int) string   { return "?" }
 func (qmark) Convert(v any) (any, error) { return v, nil } //nolint:nilnil // pass-through
 func (qmark) Deduplicate() bool          { return false }
+
+func (qmark) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
 
 var _ queries.Dialect = qmark{}

--- a/pkg/driver/sqldriver/bulk_test_helpers_test.go
+++ b/pkg/driver/sqldriver/bulk_test_helpers_test.go
@@ -39,7 +39,9 @@ func (qmark) Placeholder(_ int) string   { return "?" }
 func (qmark) Convert(v any) (any, error) { return v, nil } //nolint:nilnil // pass-through
 func (qmark) Deduplicate() bool          { return false }
 
-func (qmark) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
-func (qmark) StatementDeadline(timeout time.Duration) time.Duration   { return timeout }
+func (qmark) StatementTimeoutHint(sql string, _ time.Duration) (string, bool) {
+	return sql, false
+}
+func (qmark) StatementDeadline(timeout time.Duration) time.Duration { return timeout }
 
 var _ queries.Dialect = qmark{}

--- a/pkg/driver/sqldriver/bulk_test_helpers_test.go
+++ b/pkg/driver/sqldriver/bulk_test_helpers_test.go
@@ -40,5 +40,6 @@ func (qmark) Convert(v any) (any, error) { return v, nil } //nolint:nilnil // pa
 func (qmark) Deduplicate() bool          { return false }
 
 func (qmark) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
+func (qmark) StatementDeadline(timeout time.Duration) time.Duration   { return timeout }
 
 var _ queries.Dialect = qmark{}

--- a/pkg/driver/sqldriver/cancel_test.go
+++ b/pkg/driver/sqldriver/cancel_test.go
@@ -57,6 +57,7 @@ func TestRunQueryCancelsBlockedQuery(t *testing.T) {
 		zap.NewNop(),
 		"SELECT 1",
 		nil,
+		0,
 	)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("RunQuery() error = %v, want context.Canceled", err)

--- a/pkg/driver/sqldriver/insert_spec.go
+++ b/pkg/driver/sqldriver/insert_spec.go
@@ -64,6 +64,7 @@ func RunBulkInsert[T any](
 	src source.RowSource,
 	dialect queries.Dialect,
 	batchSize int,
+	timeout time.Duration,
 ) error {
 	columns := src.Columns()
 
@@ -127,7 +128,7 @@ func RunBulkInsert[T any](
 			var err error
 
 			args, err = flushBulkInsertBatch(
-				ctx, db, table, columns, batch[:filled], dialect, args, &fullBatchQuery)
+				ctx, db, table, columns, batch[:filled], dialect, args, &fullBatchQuery, timeout)
 			if err != nil {
 				return err
 			}
@@ -137,7 +138,7 @@ func RunBulkInsert[T any](
 	}
 
 	return flushBulkInsertRemainder(
-		ctx, db, table, columns, batch[:filled], dialect, args, &fullBatchQuery, generatedProgress)
+		ctx, db, table, columns, batch[:filled], dialect, args, &fullBatchQuery, generatedProgress, timeout)
 }
 
 func flushBulkInsertRemainder[T any](
@@ -150,6 +151,7 @@ func flushBulkInsertRemainder[T any](
 	args []any,
 	fullBatchQuery *string,
 	generatedProgress insertprogress.RowCounter,
+	timeout time.Duration,
 ) error {
 	if len(rows) == 0 {
 		return nil
@@ -157,7 +159,7 @@ func flushBulkInsertRemainder[T any](
 
 	generatedProgress.Flush()
 
-	_, err := flushBulkInsertBatch(ctx, db, table, columns, rows, dialect, args, fullBatchQuery)
+	_, err := flushBulkInsertBatch(ctx, db, table, columns, rows, dialect, args, fullBatchQuery, timeout)
 
 	return err
 }
@@ -171,7 +173,13 @@ func flushBulkInsertBatch[T any](
 	dialect queries.Dialect,
 	args []any,
 	fullBatchQuery *string,
+	timeout time.Duration,
 ) ([]any, error) {
+	// Bound each batch (one multi-row INSERT statement) independently so the
+	// per-statement deadline does not accumulate over the whole load.
+	batchCtx, cancel := StatementTimeout(ctx, timeout)
+	defer cancel()
+
 	rowCount := len(rows)
 
 	query := buildBulkInsertQuery(dialect, table, columns, rowCount)
@@ -184,7 +192,7 @@ func flushBulkInsertBatch[T any](
 	}
 
 	args = appendFlatArgs(args, rows)
-	if err := execProgressBulkBatch(ctx, db, table, query, args, int64(rowCount)); err != nil {
+	if err := execProgressBulkBatch(batchCtx, db, table, query, args, int64(rowCount)); err != nil {
 		return args, err
 	}
 

--- a/pkg/driver/sqldriver/insert_typed_test.go
+++ b/pkg/driver/sqldriver/insert_typed_test.go
@@ -2,9 +2,11 @@ package sqldriver
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stroppy-io/stroppy/pkg/driver/common"
 	"github.com/stroppy-io/stroppy/pkg/gen"
@@ -41,6 +43,56 @@ func typedRowSource(t *testing.T, src *gen.IndexedSource, cols []string) *common
 	}
 
 	return common.NewBatchRowSource(cur, cols, len(cols))
+}
+
+type blockingExecer struct {
+	calls int
+}
+
+func (e *blockingExecer) ExecContext(ctx context.Context, _ string, _ ...any) (int64, error) {
+	e.calls++
+
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-time.After(time.Second):
+		return 0, errors.New("statement context was not canceled")
+	}
+}
+
+var _ ExecContext[int64] = (*blockingExecer)(nil)
+
+func TestRunBulkInsertTypedStatementTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		total     int64
+		batchSize int
+	}{
+		{name: "full_batch", total: 2, batchSize: 2},
+		{name: "final_remainder", total: 1, batchSize: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			src, cols := typedIntSource(tt.total)
+			exec := &blockingExecer{}
+
+			err := RunBulkInsert[int64](
+				context.Background(), exec, "t_timeout", typedRowSource(t, src, cols), qmark{}, tt.batchSize, 10*time.Millisecond,
+			)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("RunBulkInsert error = %v, want context deadline exceeded", err)
+			}
+
+			if exec.calls != 1 {
+				t.Fatalf("got %d exec calls, want 1", exec.calls)
+			}
+		})
+	}
 }
 
 // TestRunBulkInsertTypedPlainBulk proves the shared SQL bulk helper

--- a/pkg/driver/sqldriver/insert_typed_test.go
+++ b/pkg/driver/sqldriver/insert_typed_test.go
@@ -52,7 +52,7 @@ func TestRunBulkInsertTypedPlainBulk(t *testing.T) {
 	src, cols := typedIntSource(4)
 	m := &mockExecer{}
 
-	if err := RunBulkInsert[int64](ctx, m, "t_bulk", typedRowSource(t, src, cols), qmark{}, 10); err != nil {
+	if err := RunBulkInsert[int64](ctx, m, "t_bulk", typedRowSource(t, src, cols), qmark{}, 10, 0); err != nil {
 		t.Fatalf("RunBulkInsert: %v", err)
 	}
 
@@ -82,7 +82,7 @@ func TestRunBulkInsertTypedRemainder(t *testing.T) {
 	src, cols := typedIntSource(total)
 	m := &mockExecer{}
 
-	if err := RunBulkInsert[int64](ctx, m, "t_rem", typedRowSource(t, src, cols), qmark{}, 500); err != nil {
+	if err := RunBulkInsert[int64](ctx, m, "t_rem", typedRowSource(t, src, cols), qmark{}, 500, 0); err != nil {
 		t.Fatalf("RunBulkInsert: %v", err)
 	}
 
@@ -141,7 +141,7 @@ func TestRunBulkInsertTypedClampsByColumns(t *testing.T) {
 	m := &mockExecer{}
 
 	if err := RunBulkInsert[int64](context.Background(), m, "t_wide",
-		typedRowSource(t, src, colNames), qmark{}, 2000); err != nil {
+		typedRowSource(t, src, colNames), qmark{}, 2000, 0); err != nil {
 		t.Fatalf("RunBulkInsert: %v", err)
 	}
 

--- a/pkg/driver/sqldriver/queries/types.go
+++ b/pkg/driver/sqldriver/queries/types.go
@@ -26,4 +26,11 @@ type Dialect interface {
 	// keep the pooled connection reusable on timeout, where client-side context
 	// cancellation alone would discard it.
 	StatementTimeoutHint(sql string, timeout time.Duration) string
+
+	// StatementDeadline returns the client-side deadline to pair with the
+	// server-side bound from StatementTimeoutHint. A dialect with a server-side
+	// hint pads the deadline so the backend's own timeout fires first and keeps
+	// the pooled connection; others return timeout unchanged. A non-positive
+	// timeout stays non-positive (disabled).
+	StatementDeadline(timeout time.Duration) time.Duration
 }

--- a/pkg/driver/sqldriver/queries/types.go
+++ b/pkg/driver/sqldriver/queries/types.go
@@ -20,14 +20,15 @@ type Dialect interface {
 	Deduplicate() bool
 
 	// StatementTimeoutHint returns sql with a server-side per-statement
-	// timeout bound (e.g. an optimizer-hint comment) applied, or sql unchanged
-	// when timeout is non-positive or the dialect has no such mechanism.
-	// Dialects that bound execution server-side (MySQL MAX_EXECUTION_TIME)
-	// keep the pooled connection reusable on timeout, where client-side context
-	// cancellation alone would discard it.
-	StatementTimeoutHint(sql string, timeout time.Duration) string
+	// timeout bound (e.g. an optimizer-hint comment) and reports whether that
+	// bound is active. The boolean remains true when sql already contains the
+	// canonical bound and therefore needs no textual change. Dialects that bound
+	// execution server-side (MySQL MAX_EXECUTION_TIME) keep the pooled connection
+	// reusable on timeout, where client-side context cancellation alone would
+	// discard it.
+	StatementTimeoutHint(sql string, timeout time.Duration) (hintedSQL string, active bool)
 
-	// StatementDeadline returns the client-side deadline to pair with the
+	// StatementDeadline returns the client-side deadline to pair with an active
 	// server-side bound from StatementTimeoutHint. A dialect with a server-side
 	// hint pads the deadline so the backend's own timeout fires first and keeps
 	// the pooled connection; others return timeout unchanged. A non-positive

--- a/pkg/driver/sqldriver/queries/types.go
+++ b/pkg/driver/sqldriver/queries/types.go
@@ -1,5 +1,7 @@
 package queries
 
+import "time"
+
 // Dialect abstracts database-specific SQL differences for database/sql drivers.
 type Dialect interface {
 	// Placeholder returns the SQL placeholder for the given 0-based parameter index.
@@ -16,4 +18,12 @@ type Dialect interface {
 	// PostgreSQL's wire protocol supports $1 back-references, so pgx returns true.
 	// database/sql drivers (MySQL, etc.) require one value per placeholder, so they return false.
 	Deduplicate() bool
+
+	// StatementTimeoutHint returns sql with a server-side per-statement
+	// timeout bound (e.g. an optimizer-hint comment) applied, or sql unchanged
+	// when timeout is non-positive or the dialect has no such mechanism.
+	// Dialects that bound execution server-side (MySQL MAX_EXECUTION_TIME)
+	// keep the pooled connection reusable on timeout, where client-side context
+	// cancellation alone would discard it.
+	StatementTimeoutHint(sql string, timeout time.Duration) string
 }

--- a/pkg/driver/sqldriver/rows.go
+++ b/pkg/driver/sqldriver/rows.go
@@ -2,6 +2,7 @@ package sqldriver
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/stroppy-io/stroppy/pkg/driver"
 )
@@ -31,8 +32,7 @@ func (r *Rows) Next() bool {
 
 	hasNext := r.sqlRows.Next()
 	if !hasNext {
-		r.closed = true
-		r.sqlRows.Close()
+		_ = r.close(true)
 	}
 
 	return hasNext
@@ -86,10 +86,27 @@ func (r *Rows) Err() error {
 }
 
 func (r *Rows) Close() error {
-	if !r.closed {
-		r.closed = true
-		r.sqlRows.Close()
+	return r.close(false)
+}
+
+func (r *Rows) close(currentResultDone bool) error {
+	if r.closed {
+		return r.sqlRows.Err()
 	}
 
-	return r.sqlRows.Err()
+	r.closed = true
+
+	// Consume every result set before the final Close so the driver's query
+	// context remains active while trailing server responses are received.
+	if !currentResultDone {
+		for r.sqlRows.Next() {
+		}
+	}
+
+	for r.sqlRows.NextResultSet() {
+		for r.sqlRows.Next() {
+		}
+	}
+
+	return errors.Join(r.sqlRows.Err(), r.sqlRows.Close())
 }

--- a/pkg/driver/sqldriver/rows.go
+++ b/pkg/driver/sqldriver/rows.go
@@ -2,7 +2,6 @@ package sqldriver
 
 import (
 	"database/sql"
-	"errors"
 
 	"github.com/stroppy-io/stroppy/pkg/driver"
 )
@@ -108,5 +107,5 @@ func (r *Rows) close(currentResultDone bool) error {
 		}
 	}
 
-	return errors.Join(r.sqlRows.Err(), r.sqlRows.Close())
+	return driver.JoinErrors(r.sqlRows.Err(), r.sqlRows.Close())
 }

--- a/pkg/driver/sqldriver/rows_test.go
+++ b/pkg/driver/sqldriver/rows_test.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	sqldriver "database/sql/driver"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -158,12 +160,21 @@ func TestRowsCloseDrainsEveryResultSet(t *testing.T) {
 
 func TestRowsClosePreservesTerminalErrors(t *testing.T) {
 	tests := []struct {
-		name        string
-		terminalErr error
-		closeErr    error
+		name            string
+		terminalErr     error
+		closeErr        error
+		wantErr         error
+		wantTimeoutOnce bool
 	}{
 		{name: "iteration", terminalErr: errors.New("iteration failed")},
 		{name: "close", closeErr: errors.New("close failed")},
+		{
+			name:            "duplicate deadline",
+			terminalErr:     context.DeadlineExceeded,
+			closeErr:        fmt.Errorf("close: %w", context.DeadlineExceeded),
+			wantErr:         context.DeadlineExceeded,
+			wantTimeoutOnce: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -183,13 +194,21 @@ func TestRowsClosePreservesTerminalErrors(t *testing.T) {
 			rows := NewRows(sqlRows)
 			err = rows.Close()
 
-			wantErr := tt.terminalErr
+			wantErr := tt.wantErr
+			if wantErr == nil {
+				wantErr = tt.terminalErr
+			}
+
 			if wantErr == nil {
 				wantErr = tt.closeErr
 			}
 
 			if !errors.Is(err, wantErr) {
 				t.Fatalf("Close() error = %v, want %v", err, wantErr)
+			}
+
+			if tt.wantTimeoutOnce && strings.Count(err.Error(), context.DeadlineExceeded.Error()) != 1 {
+				t.Fatalf("Close() error = %q, want one deadline", err)
 			}
 
 			if tt.terminalErr != nil && !errors.Is(rows.Err(), tt.terminalErr) {

--- a/pkg/driver/sqldriver/rows_test.go
+++ b/pkg/driver/sqldriver/rows_test.go
@@ -1,0 +1,315 @@
+package sqldriver
+
+import (
+	"context"
+	"database/sql"
+	sqldriver "database/sql/driver"
+	"errors"
+	"io"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type rowsTestConnector struct {
+	newRows func(context.Context) sqldriver.Rows
+}
+
+func (c *rowsTestConnector) Connect(context.Context) (sqldriver.Conn, error) {
+	return &rowsTestConn{newRows: c.newRows}, nil
+}
+
+func (*rowsTestConnector) Driver() sqldriver.Driver {
+	return rowsTestDriver{}
+}
+
+type rowsTestDriver struct{}
+
+func (rowsTestDriver) Open(string) (sqldriver.Conn, error) {
+	return nil, sqldriver.ErrBadConn
+}
+
+type rowsTestConn struct {
+	newRows func(context.Context) sqldriver.Rows
+}
+
+func (*rowsTestConn) Prepare(string) (sqldriver.Stmt, error) { return nil, sqldriver.ErrSkip }
+func (*rowsTestConn) Close() error                           { return nil }
+func (*rowsTestConn) Begin() (sqldriver.Tx, error)           { return nil, sqldriver.ErrSkip }
+
+func (c *rowsTestConn) QueryContext(
+	ctx context.Context,
+	_ string,
+	_ []sqldriver.NamedValue,
+) (sqldriver.Rows, error) {
+	return c.newRows(ctx), nil
+}
+
+func openRowsTestDB(t *testing.T, newRows func(context.Context) sqldriver.Rows) *sql.DB {
+	t.Helper()
+
+	db := sql.OpenDB(&rowsTestConnector{newRows: newRows})
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close test database: %v", err)
+		}
+	})
+
+	return db
+}
+
+type scriptedResultRows struct {
+	sets        [][][]sqldriver.Value
+	set         int
+	row         int
+	terminalErr error
+	closeErr    error
+	closeCalls  int
+	events      []string
+}
+
+func (*scriptedResultRows) Columns() []string { return []string{"value"} }
+
+func (r *scriptedResultRows) Next(dest []sqldriver.Value) error {
+	if r.row < len(r.sets[r.set]) {
+		dest[0] = r.sets[r.set][r.row][0]
+		r.events = append(r.events, "row")
+		r.row++
+
+		return nil
+	}
+
+	r.events = append(r.events, "end")
+	if r.set == len(r.sets)-1 && r.terminalErr != nil {
+		return r.terminalErr
+	}
+
+	return io.EOF
+}
+
+func (r *scriptedResultRows) HasNextResultSet() bool {
+	return r.set+1 < len(r.sets)
+}
+
+func (r *scriptedResultRows) NextResultSet() error {
+	r.events = append(r.events, "result")
+	if !r.HasNextResultSet() {
+		return io.EOF
+	}
+
+	r.set++
+	r.row = 0
+
+	return nil
+}
+
+func (r *scriptedResultRows) Close() error {
+	r.events = append(r.events, "close")
+	r.closeCalls++
+
+	return r.closeErr
+}
+
+func TestRowsCloseDrainsEveryResultSet(t *testing.T) {
+	raw := &scriptedResultRows{
+		sets: [][][]sqldriver.Value{
+			{{int64(1)}, {int64(2)}},
+			{{int64(3)}, {int64(4)}},
+		},
+	}
+	db := openRowsTestDB(t, func(context.Context) sqldriver.Rows { return raw })
+
+	sqlRows, err := db.QueryContext(context.Background(), "CALL test()")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	rows := NewRows(sqlRows)
+	if !rows.Next() {
+		t.Fatalf("first Next() = false, err = %v", rows.Err())
+	}
+
+	if got := rows.Values(); !reflect.DeepEqual(got, []any{int64(1)}) {
+		t.Fatalf("first row = %#v, want [1]", got)
+	}
+
+	if err := rows.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	wantEvents := []string{"row", "row", "end", "result", "row", "row", "end", "close"}
+	if !reflect.DeepEqual(raw.events, wantEvents) {
+		t.Fatalf("events = %v, want %v", raw.events, wantEvents)
+	}
+
+	if err := rows.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+
+	if raw.closeCalls != 1 {
+		t.Fatalf("driver Close() calls = %d, want 1", raw.closeCalls)
+	}
+}
+
+func TestRowsClosePreservesTerminalErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		terminalErr error
+		closeErr    error
+	}{
+		{name: "iteration", terminalErr: errors.New("iteration failed")},
+		{name: "close", closeErr: errors.New("close failed")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := &scriptedResultRows{
+				sets:        [][][]sqldriver.Value{{{int64(1)}}},
+				terminalErr: tt.terminalErr,
+				closeErr:    tt.closeErr,
+			}
+			db := openRowsTestDB(t, func(context.Context) sqldriver.Rows { return raw })
+
+			sqlRows, err := db.QueryContext(context.Background(), "SELECT 1")
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+
+			rows := NewRows(sqlRows)
+			err = rows.Close()
+
+			wantErr := tt.terminalErr
+			if wantErr == nil {
+				wantErr = tt.closeErr
+			}
+
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("Close() error = %v, want %v", err, wantErr)
+			}
+
+			if tt.terminalErr != nil && !errors.Is(rows.Err(), tt.terminalErr) {
+				t.Fatalf("Err() = %v, want terminal error", rows.Err())
+			}
+		})
+	}
+}
+
+type contextResultRows struct {
+	ctx            context.Context
+	rowReturned    bool
+	advanced       atomic.Bool
+	closeCalls     atomic.Int32
+	advanceStarted chan struct{}
+	closeStarted   chan struct{}
+	releaseClose   chan struct{}
+	advanceOnce    sync.Once
+	closeOnce      sync.Once
+	releaseOnce    sync.Once
+}
+
+func newContextResultRows(ctx context.Context) *contextResultRows {
+	return &contextResultRows{
+		ctx:            ctx,
+		advanceStarted: make(chan struct{}),
+		closeStarted:   make(chan struct{}),
+		releaseClose:   make(chan struct{}),
+	}
+}
+
+func (*contextResultRows) Columns() []string { return []string{"value"} }
+
+func (r *contextResultRows) Next(dest []sqldriver.Value) error {
+	if !r.rowReturned {
+		r.rowReturned = true
+		dest[0] = int64(1)
+
+		return nil
+	}
+
+	return io.EOF
+}
+
+func (r *contextResultRows) HasNextResultSet() bool { return !r.advanced.Load() }
+
+func (r *contextResultRows) NextResultSet() error {
+	r.advanced.Store(true)
+	r.advanceOnce.Do(func() { close(r.advanceStarted) })
+	<-r.ctx.Done()
+
+	return r.ctx.Err()
+}
+
+func (r *contextResultRows) Close() error {
+	r.closeCalls.Add(1)
+	r.closeOnce.Do(func() { close(r.closeStarted) })
+
+	if !r.advanced.Load() {
+		<-r.releaseClose
+	}
+
+	return nil
+}
+
+func (r *contextResultRows) release() {
+	r.releaseOnce.Do(func() { close(r.releaseClose) })
+}
+
+func TestRowsCloseKeepsContextActiveWhileAdvancingResultSets(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var raw *contextResultRows
+
+	db := openRowsTestDB(t, func(queryCtx context.Context) sqldriver.Rows {
+		raw = newContextResultRows(queryCtx)
+
+		return raw
+	})
+
+	res, err := RunQuery(ctx, db, NewRows, testDialect{}, zap.NewNop(), "CALL test()", nil, 0)
+	if err != nil {
+		t.Fatalf("RunQuery() error = %v", err)
+	}
+
+	if !res.Rows.Next() {
+		t.Fatalf("first Next() = false, err = %v", res.Rows.Err())
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- res.Rows.Close() }()
+
+	select {
+	case <-raw.advanceStarted:
+		cancel()
+	case <-raw.closeStarted:
+		raw.release()
+		<-closeDone
+		t.Fatal("driver rows closed before advancing the unread result set")
+	case <-time.After(time.Second):
+		cancel()
+		raw.release()
+		t.Fatal("timed out waiting for result-set cleanup")
+	}
+
+	select {
+	case err = <-closeDone:
+	case <-time.After(time.Second):
+		raw.release()
+		t.Fatal("timed out waiting for rows to close")
+	}
+
+	raw.release()
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Close() error = %v, want context.Canceled", err)
+	}
+
+	if calls := raw.closeCalls.Load(); calls != 1 {
+		t.Fatalf("driver Close() calls = %d, want 1", calls)
+	}
+}

--- a/pkg/driver/sqldriver/run_query.go
+++ b/pkg/driver/sqldriver/run_query.go
@@ -181,12 +181,16 @@ func RunQuery[R any](
 		}
 	}
 
-	processedSQL = dialect.StatementTimeoutHint(processedSQL, timeout)
+	hintedSQL := dialect.StatementTimeoutHint(processedSQL, timeout)
+	deadline := timeout
+	if hintedSQL != processedSQL {
+		deadline = dialect.StatementDeadline(timeout)
+	}
 
-	queryCtx, cancel := StatementTimeout(ctx, dialect.StatementDeadline(timeout))
+	queryCtx, cancel := StatementTimeout(ctx, deadline)
 
 	start := time.Now()
-	rawRows, err := db.QueryContext(queryCtx, processedSQL, argsArr...)
+	rawRows, err := db.QueryContext(queryCtx, hintedSQL, argsArr...)
 	elapsed := time.Since(start)
 
 	if err != nil {

--- a/pkg/driver/sqldriver/run_query.go
+++ b/pkg/driver/sqldriver/run_query.go
@@ -182,6 +182,7 @@ func RunQuery[R any](
 	}
 
 	hintedSQL := dialect.StatementTimeoutHint(processedSQL, timeout)
+
 	deadline := timeout
 	if hintedSQL != processedSQL {
 		deadline = dialect.StatementDeadline(timeout)

--- a/pkg/driver/sqldriver/run_query.go
+++ b/pkg/driver/sqldriver/run_query.go
@@ -112,7 +112,23 @@ func parseQueryTemplate(dialect queries.Dialect, sqlStr string) *parsedQuery {
 	}
 }
 
+// StatementTimeout returns a child context bounded by timeout, or ctx unchanged
+// (with a no-op cancel) when timeout is non-positive. Callers defer the cancel
+// to release the timer once the statement completes.
+func StatementTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, timeout)
+}
+
 // RunQuery executes sql with named :arg placeholders and returns rows cursor.
+// timeout > 0 bounds the single statement: every call derives a child context
+// so the deadline applies per statement rather than to an entire query suite,
+// and a dialect-provided server-side hint (MySQL MAX_EXECUTION_TIME) bounds the
+// backend where client-side cancellation alone would not keep the pooled
+// connection reusable.
 func RunQuery[R any](
 	ctx context.Context,
 	db QueryContext[R],
@@ -121,6 +137,7 @@ func RunQuery[R any](
 	lg *zap.Logger,
 	sqlStr string,
 	args map[string]any,
+	timeout time.Duration,
 ) (*driver.QueryResult, error) {
 	processedSQL, argsArr, err := ProcessArgs(dialect, sqlStr, args)
 	if err != nil {
@@ -133,8 +150,13 @@ func RunQuery[R any](
 		}
 	}
 
+	processedSQL = dialect.StatementTimeoutHint(processedSQL, timeout)
+
+	queryCtx, cancel := StatementTimeout(ctx, timeout)
+	defer cancel()
+
 	start := time.Now()
-	rawRows, err := db.QueryContext(ctx, processedSQL, argsArr...)
+	rawRows, err := db.QueryContext(queryCtx, processedSQL, argsArr...)
 	elapsed := time.Since(start)
 
 	if err != nil {

--- a/pkg/driver/sqldriver/run_query.go
+++ b/pkg/driver/sqldriver/run_query.go
@@ -113,14 +113,45 @@ func parseQueryTemplate(dialect queries.Dialect, sqlStr string) *parsedQuery {
 }
 
 // StatementTimeout returns a child context bounded by timeout, or ctx unchanged
-// (with a no-op cancel) when timeout is non-positive. Callers defer the cancel
-// to release the timer once the statement completes.
+// (with a no-op cancel) when timeout is non-positive. Callers release the child
+// once the statement and any result-row iteration complete.
 func StatementTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout <= 0 {
 		return ctx, func() {}
 	}
 
 	return context.WithTimeout(ctx, timeout)
+}
+
+type cancelRows struct {
+	driver.Rows
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (r *cancelRows) Next() bool {
+	next := r.Rows.Next()
+	if !next {
+		r.release()
+	}
+
+	return next
+}
+
+func (r *cancelRows) ReadAll(limit int) [][]any {
+	defer r.release()
+
+	return r.Rows.ReadAll(limit)
+}
+
+func (r *cancelRows) Close() error {
+	defer r.release()
+
+	return r.Rows.Close()
+}
+
+func (r *cancelRows) release() {
+	r.once.Do(r.cancel)
 }
 
 // RunQuery executes sql with named :arg placeholders and returns rows cursor.
@@ -153,19 +184,37 @@ func RunQuery[R any](
 	processedSQL = dialect.StatementTimeoutHint(processedSQL, timeout)
 
 	queryCtx, cancel := StatementTimeout(ctx, dialect.StatementDeadline(timeout))
-	defer cancel()
 
 	start := time.Now()
 	rawRows, err := db.QueryContext(queryCtx, processedSQL, argsArr...)
 	elapsed := time.Since(start)
 
 	if err != nil {
+		cancel()
+
 		return nil, fmt.Errorf("failed to execute sql: %w", err)
+	}
+
+	rows := wrapRows(rawRows)
+	if rows != nil {
+		if rowsErr := rows.Err(); rowsErr != nil {
+			_ = rows.Close()
+
+			cancel()
+
+			return nil, fmt.Errorf("failed to execute sql: %w", rowsErr)
+		}
+	}
+
+	if timeout > 0 && rows != nil {
+		rows = &cancelRows{Rows: rows, cancel: cancel}
+	} else {
+		cancel()
 	}
 
 	return &driver.QueryResult{
 		Stats: &stats.Query{Elapsed: elapsed},
-		Rows:  wrapRows(rawRows),
+		Rows:  rows,
 	}, nil
 }
 

--- a/pkg/driver/sqldriver/run_query.go
+++ b/pkg/driver/sqldriver/run_query.go
@@ -152,7 +152,7 @@ func RunQuery[R any](
 
 	processedSQL = dialect.StatementTimeoutHint(processedSQL, timeout)
 
-	queryCtx, cancel := StatementTimeout(ctx, timeout)
+	queryCtx, cancel := StatementTimeout(ctx, dialect.StatementDeadline(timeout))
 	defer cancel()
 
 	start := time.Now()

--- a/pkg/driver/sqldriver/run_query.go
+++ b/pkg/driver/sqldriver/run_query.go
@@ -181,10 +181,10 @@ func RunQuery[R any](
 		}
 	}
 
-	hintedSQL := dialect.StatementTimeoutHint(processedSQL, timeout)
+	hintedSQL, serverTimeoutActive := dialect.StatementTimeoutHint(processedSQL, timeout)
 
 	deadline := timeout
-	if hintedSQL != processedSQL {
+	if serverTimeoutActive {
 		deadline = dialect.StatementDeadline(timeout)
 	}
 

--- a/pkg/driver/sqldriver/run_query_test.go
+++ b/pkg/driver/sqldriver/run_query_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stroppy-io/stroppy/pkg/driver/sqldriver/queries"
 )
@@ -17,6 +18,9 @@ func (testDialect) Convert(v any) (any, error) {
 	return v, nil
 }
 func (testDialect) Deduplicate() bool { return false }
+func (testDialect) StatementTimeoutHint(sql string, _ time.Duration) string {
+	return sql
+}
 
 var errConvertTest = errors.New("convert failed")
 

--- a/pkg/driver/sqldriver/run_query_test.go
+++ b/pkg/driver/sqldriver/run_query_test.go
@@ -18,8 +18,8 @@ func (testDialect) Convert(v any) (any, error) {
 	return v, nil
 }
 func (testDialect) Deduplicate() bool { return false }
-func (testDialect) StatementTimeoutHint(sql string, _ time.Duration) string {
-	return sql
+func (testDialect) StatementTimeoutHint(sql string, _ time.Duration) (string, bool) {
+	return sql, false
 }
 func (testDialect) StatementDeadline(timeout time.Duration) time.Duration { return timeout }
 

--- a/pkg/driver/sqldriver/run_query_test.go
+++ b/pkg/driver/sqldriver/run_query_test.go
@@ -21,6 +21,7 @@ func (testDialect) Deduplicate() bool { return false }
 func (testDialect) StatementTimeoutHint(sql string, _ time.Duration) string {
 	return sql
 }
+func (testDialect) StatementDeadline(timeout time.Duration) time.Duration { return timeout }
 
 var errConvertTest = errors.New("convert failed")
 

--- a/pkg/driver/sqldriver/run_query_timeout_test.go
+++ b/pkg/driver/sqldriver/run_query_timeout_test.go
@@ -23,6 +23,37 @@ func (f *fakeQuery) QueryContext(ctx context.Context, _ string, _ ...any) (int, 
 
 func noopWrap(int) driver.Rows { return nil }
 
+type deadlineCaptureQuery struct {
+	sql      string
+	deadline time.Time
+	hasLimit bool
+}
+
+func (q *deadlineCaptureQuery) QueryContext(
+	ctx context.Context,
+	sql string,
+	_ ...any,
+) (int, error) {
+	q.sql = sql
+	q.deadline, q.hasLimit = ctx.Deadline()
+
+	return 0, nil
+}
+
+type selectiveHintDialect struct{ testDialect }
+
+func (selectiveHintDialect) StatementTimeoutHint(sql string, _ time.Duration) string {
+	if sql == "SELECT 1" {
+		return "SELECT /* timeout hint */ 1"
+	}
+
+	return sql
+}
+
+func (selectiveHintDialect) StatementDeadline(timeout time.Duration) time.Duration {
+	return timeout + time.Second
+}
+
 type lazyQueryRows struct {
 	ctx context.Context
 	err error
@@ -66,6 +97,67 @@ func TestStatementTimeoutDisabled(t *testing.T) {
 
 	if ctx != context.Background() {
 		t.Fatal("zero timeout should return the parent context unchanged")
+	}
+}
+
+func TestRunQueryDeadlineMatchesHintApplication(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 150 * time.Millisecond
+
+	tests := []struct {
+		name         string
+		sql          string
+		wantSQL      string
+		wantDeadline time.Duration
+	}{
+		{
+			name:         "hinted statement gets grace",
+			sql:          "SELECT 1",
+			wantSQL:      "SELECT /* timeout hint */ 1",
+			wantDeadline: timeout + time.Second,
+		},
+		{
+			name:         "unhinted statement gets exact timeout",
+			sql:          "DO 1",
+			wantSQL:      "DO 1",
+			wantDeadline: timeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			capture := &deadlineCaptureQuery{}
+			before := time.Now()
+
+			_, err := RunQuery(
+				context.Background(),
+				capture,
+				noopWrap,
+				selectiveHintDialect{},
+				zap.NewNop(),
+				tt.sql,
+				nil,
+				timeout,
+			)
+			after := time.Now()
+			if err != nil {
+				t.Fatalf("RunQuery() error = %v", err)
+			}
+			if capture.sql != tt.wantSQL {
+				t.Fatalf("QueryContext() SQL = %q, want %q", capture.sql, tt.wantSQL)
+			}
+			if !capture.hasLimit {
+				t.Fatal("QueryContext() context has no deadline")
+			}
+			earliest := before.Add(tt.wantDeadline)
+			latest := after.Add(tt.wantDeadline)
+			if capture.deadline.Before(earliest) || capture.deadline.After(latest) {
+				t.Fatalf("context deadline = %v, want between %v and %v", capture.deadline, earliest, latest)
+			}
+		})
 	}
 }
 

--- a/pkg/driver/sqldriver/run_query_timeout_test.go
+++ b/pkg/driver/sqldriver/run_query_timeout_test.go
@@ -23,6 +23,41 @@ func (f *fakeQuery) QueryContext(ctx context.Context, _ string, _ ...any) (int, 
 
 func noopWrap(int) driver.Rows { return nil }
 
+type lazyQueryRows struct {
+	ctx context.Context
+	err error
+}
+
+func (*lazyQueryRows) Columns() []string   { return nil }
+func (*lazyQueryRows) Values() []any       { return nil }
+func (*lazyQueryRows) ReadAll(int) [][]any { return nil }
+func (r *lazyQueryRows) Err() error        { return r.err }
+func (*lazyQueryRows) Close() error        { return nil }
+func (r *lazyQueryRows) Next() bool {
+	<-r.ctx.Done()
+	r.err = r.ctx.Err()
+
+	return false
+}
+
+type lazyQuery struct{}
+
+func (lazyQuery) QueryContext(ctx context.Context, _ string, _ ...any) (*lazyQueryRows, error) {
+	return &lazyQueryRows{ctx: ctx}, nil
+}
+
+type immediateRowsErrorQuery struct {
+	err error
+}
+
+func (q immediateRowsErrorQuery) QueryContext(
+	context.Context,
+	string,
+	...any,
+) (*lazyQueryRows, error) {
+	return &lazyQueryRows{err: q.err}, nil
+}
+
 func TestStatementTimeoutDisabled(t *testing.T) {
 	t.Parallel()
 
@@ -58,6 +93,63 @@ func TestRunQueryAppliesPerStatementDeadline(t *testing.T) {
 
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("deadline did not fire promptly: took %v", elapsed)
+	}
+
+	if parent.Err() != nil {
+		t.Fatalf("parent context mutated: %v", parent.Err())
+	}
+}
+
+func TestRunQueryReturnsImmediateRowsError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("rows")
+
+	res, err := RunQuery(
+		context.Background(),
+		immediateRowsErrorQuery{err: sentinel},
+		func(rows *lazyQueryRows) driver.Rows { return rows },
+		testDialect{},
+		zap.NewNop(),
+		"SELECT 1",
+		nil,
+		30*time.Millisecond,
+	)
+	if res != nil {
+		t.Fatalf("RunQuery() result = %#v, want nil", res)
+	}
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("RunQuery() error = %v, want sentinel", err)
+	}
+}
+
+func TestRunQueryDeadlineCoversRowIteration(t *testing.T) {
+	t.Parallel()
+
+	parent := context.Background()
+
+	res, err := RunQuery(
+		parent,
+		lazyQuery{},
+		func(rows *lazyQueryRows) driver.Rows { return rows },
+		testDialect{},
+		zap.NewNop(),
+		"SELECT 1",
+		nil,
+		30*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("RunQuery() error = %v", err)
+	}
+	defer res.Rows.Close()
+
+	if res.Rows.Next() {
+		t.Fatal("Next() = true, want deadline to stop row iteration")
+	}
+
+	if err := res.Rows.Err(); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Rows.Err() = %v, want context.DeadlineExceeded", err)
 	}
 
 	if parent.Err() != nil {

--- a/pkg/driver/sqldriver/run_query_timeout_test.go
+++ b/pkg/driver/sqldriver/run_query_timeout_test.go
@@ -1,0 +1,100 @@
+package sqldriver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+// fakeQuery surfaces the per-statement context RunQuery derives, so tests can
+// prove the deadline fires without a real database.
+type fakeQuery struct {
+	fn func(ctx context.Context) error
+}
+
+func (f *fakeQuery) QueryContext(ctx context.Context, _ string, _ ...any) (int, error) {
+	return 0, f.fn(ctx)
+}
+
+func noopWrap(int) driver.Rows { return nil }
+
+func TestStatementTimeoutDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := StatementTimeout(context.Background(), 0)
+	defer cancel()
+
+	if ctx != context.Background() {
+		t.Fatal("zero timeout should return the parent context unchanged")
+	}
+}
+
+func TestRunQueryAppliesPerStatementDeadline(t *testing.T) {
+	t.Parallel()
+
+	parent := context.Background()
+
+	f := &fakeQuery{fn: func(ctx context.Context) error {
+		<-ctx.Done()
+
+		return ctx.Err()
+	}}
+
+	start := time.Now()
+
+	_, err := RunQuery(parent, f, noopWrap, testDialect{}, zap.NewNop(), "SELECT 1", nil, 30*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context.DeadlineExceeded (timeout)", err)
+	}
+
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v was classified as canceled, want timeout", err)
+	}
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("deadline did not fire promptly: took %v", elapsed)
+	}
+
+	if parent.Err() != nil {
+		t.Fatalf("parent context mutated: %v", parent.Err())
+	}
+}
+
+func TestRunQueryConnectionReusableAfterTimeout(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	f := &fakeQuery{fn: func(ctx context.Context) error {
+		calls++
+		if calls == 1 {
+			<-ctx.Done()
+
+			return ctx.Err()
+		}
+
+		return nil
+	}}
+
+	_, err := RunQuery(
+		context.Background(), f, noopWrap, testDialect{}, zap.NewNop(), "SELECT 1", nil, 20*time.Millisecond,
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first query err = %v, want DeadlineExceeded", err)
+	}
+
+	// The same fake connection serves the next statement with a fresh,
+	// disabled deadline, proving the timer does not stick to the connection.
+	res, err := RunQuery(context.Background(), f, noopWrap, testDialect{}, zap.NewNop(), "SELECT 2", nil, 0)
+	if err != nil {
+		t.Fatalf("second query err = %v, want nil", err)
+	}
+
+	if res == nil {
+		t.Fatal("second query result = nil")
+	}
+}

--- a/pkg/driver/sqldriver/run_query_timeout_test.go
+++ b/pkg/driver/sqldriver/run_query_timeout_test.go
@@ -143,17 +143,22 @@ func TestRunQueryDeadlineMatchesHintApplication(t *testing.T) {
 				timeout,
 			)
 			after := time.Now()
+
 			if err != nil {
 				t.Fatalf("RunQuery() error = %v", err)
 			}
+
 			if capture.sql != tt.wantSQL {
 				t.Fatalf("QueryContext() SQL = %q, want %q", capture.sql, tt.wantSQL)
 			}
+
 			if !capture.hasLimit {
 				t.Fatal("QueryContext() context has no deadline")
 			}
+
 			earliest := before.Add(tt.wantDeadline)
 			latest := after.Add(tt.wantDeadline)
+
 			if capture.deadline.Before(earliest) || capture.deadline.After(latest) {
 				t.Fatalf("context deadline = %v, want between %v and %v", capture.deadline, earliest, latest)
 			}

--- a/pkg/driver/sqldriver/run_query_timeout_test.go
+++ b/pkg/driver/sqldriver/run_query_timeout_test.go
@@ -42,12 +42,16 @@ func (q *deadlineCaptureQuery) QueryContext(
 
 type selectiveHintDialect struct{ testDialect }
 
-func (selectiveHintDialect) StatementTimeoutHint(sql string, _ time.Duration) string {
+func (selectiveHintDialect) StatementTimeoutHint(sql string, _ time.Duration) (string, bool) {
 	if sql == "SELECT 1" {
-		return "SELECT /* timeout hint */ 1"
+		return "SELECT /* timeout hint */ 1", true
 	}
 
-	return sql
+	if sql == "SELECT /* timeout hint */ 1" {
+		return sql, true
+	}
+
+	return sql, false
 }
 
 func (selectiveHintDialect) StatementDeadline(timeout time.Duration) time.Duration {
@@ -114,6 +118,12 @@ func TestRunQueryDeadlineMatchesHintApplication(t *testing.T) {
 		{
 			name:         "hinted statement gets grace",
 			sql:          "SELECT 1",
+			wantSQL:      "SELECT /* timeout hint */ 1",
+			wantDeadline: timeout + time.Second,
+		},
+		{
+			name:         "canonical hint still gets grace",
+			sql:          "SELECT /* timeout hint */ 1",
 			wantSQL:      "SELECT /* timeout hint */ 1",
 			wantDeadline: timeout + time.Second,
 		},

--- a/pkg/driver/sqldriver/tx.go
+++ b/pkg/driver/sqldriver/tx.go
@@ -3,6 +3,7 @@ package sqldriver
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -26,6 +27,7 @@ type Tx[R any] struct {
 	isolation stroppy.TxIsolationLevel
 	dialect   queries.Dialect
 	logger    *zap.Logger
+	timeout   time.Duration
 }
 
 func NewTx[R any](
@@ -34,6 +36,7 @@ func NewTx[R any](
 	isolation stroppy.TxIsolationLevel,
 	dialect queries.Dialect,
 	logger *zap.Logger,
+	timeout time.Duration,
 ) *Tx[R] {
 	return &Tx[R]{
 		conn:      conn,
@@ -41,6 +44,7 @@ func NewTx[R any](
 		isolation: isolation,
 		dialect:   dialect,
 		logger:    logger,
+		timeout:   timeout,
 	}
 }
 
@@ -49,7 +53,7 @@ func (t *Tx[R]) RunQuery(
 	sqlStr string,
 	args map[string]any,
 ) (*driver.QueryResult, error) {
-	return RunQuery(ctx, t.conn, t.wrapRows, t.dialect, t.logger, sqlStr, args)
+	return RunQuery(ctx, t.conn, t.wrapRows, t.dialect, t.logger, sqlStr, args, t.timeout)
 }
 
 func (t *Tx[R]) Commit(ctx context.Context) error {
@@ -79,6 +83,7 @@ type ConnOnlyTx[R any] struct {
 	wrapRows  func(R) driver.Rows
 	dialect   queries.Dialect
 	logger    *zap.Logger
+	timeout   time.Duration
 	closeFunc func() error
 	done      bool
 }
@@ -88,6 +93,7 @@ func NewConnOnlyTx[R any](
 	wrapRows func(R) driver.Rows,
 	dialect queries.Dialect,
 	logger *zap.Logger,
+	timeout time.Duration,
 	closeFunc func() error,
 ) *ConnOnlyTx[R] {
 	return &ConnOnlyTx[R]{
@@ -95,6 +101,7 @@ func NewConnOnlyTx[R any](
 		wrapRows:  wrapRows,
 		dialect:   dialect,
 		logger:    logger,
+		timeout:   timeout,
 		closeFunc: closeFunc,
 	}
 }
@@ -104,7 +111,7 @@ func (t *ConnOnlyTx[R]) RunQuery(
 	sqlStr string,
 	args map[string]any,
 ) (*driver.QueryResult, error) {
-	return RunQuery(ctx, t.conn, t.wrapRows, t.dialect, t.logger, sqlStr, args)
+	return RunQuery(ctx, t.conn, t.wrapRows, t.dialect, t.logger, sqlStr, args, t.timeout)
 }
 
 func (t *ConnOnlyTx[R]) Commit(_ context.Context) error {

--- a/pkg/driver/ydb/dialect.go
+++ b/pkg/driver/ydb/dialect.go
@@ -24,6 +24,10 @@ func (ydbDialect) Deduplicate() bool        { return false }
 // for its per-statement deadline.
 func (ydbDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
 
+// StatementDeadline returns timeout unchanged; there is no server-side hint
+// to outlast.
+func (ydbDialect) StatementDeadline(timeout time.Duration) time.Duration { return timeout }
+
 func (ydbDialect) Convert(val any) (any, error) {
 	switch v := val.(type) { //nolint:varnamelen // switch type assertion idiom
 	case nil:

--- a/pkg/driver/ydb/dialect.go
+++ b/pkg/driver/ydb/dialect.go
@@ -20,6 +20,10 @@ type ydbDialect struct{}
 func (ydbDialect) Placeholder(_ int) string { return "?" }
 func (ydbDialect) Deduplicate() bool        { return false }
 
+// StatementTimeoutHint returns sql unchanged; YDB honors context cancellation
+// for its per-statement deadline.
+func (ydbDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
+
 func (ydbDialect) Convert(val any) (any, error) {
 	switch v := val.(type) { //nolint:varnamelen // switch type assertion idiom
 	case nil:

--- a/pkg/driver/ydb/dialect.go
+++ b/pkg/driver/ydb/dialect.go
@@ -22,7 +22,9 @@ func (ydbDialect) Deduplicate() bool        { return false }
 
 // StatementTimeoutHint returns sql unchanged; YDB honors context cancellation
 // for its per-statement deadline.
-func (ydbDialect) StatementTimeoutHint(sql string, _ time.Duration) string { return sql }
+func (ydbDialect) StatementTimeoutHint(sql string, _ time.Duration) (string, bool) {
+	return sql, false
+}
 
 // StatementDeadline returns timeout unchanged; there is no server-side hint
 // to outlast.

--- a/pkg/driver/ydb/driver.go
+++ b/pkg/driver/ydb/driver.go
@@ -35,12 +35,13 @@ func init() {
 }
 
 type Driver struct {
-	db       *sql.DB
-	nativeDB *ydbsdk.Driver
-	dialect  queries.Dialect
-	logger   *zap.Logger
-	sqlCfg   *stroppy.DriverConfig_SqlConfig
-	bulkSize int
+	db           *sql.DB
+	nativeDB     *ydbsdk.Driver
+	dialect      queries.Dialect
+	logger       *zap.Logger
+	sqlCfg       *stroppy.DriverConfig_SqlConfig
+	bulkSize     int
+	queryTimeout time.Duration
 }
 
 var _ driver.Driver = (*Driver)(nil)
@@ -88,12 +89,13 @@ func NewDriver(
 	}
 
 	return &Driver{
-		db:       db,
-		nativeDB: nativeDB,
-		dialect:  ydbDialect{},
-		logger:   lg,
-		sqlCfg:   sqlCfg,
-		bulkSize: bulkSize,
+		db:           db,
+		nativeDB:     nativeDB,
+		dialect:      ydbDialect{},
+		logger:       lg,
+		sqlCfg:       sqlCfg,
+		bulkSize:     bulkSize,
+		queryTimeout: opts.QueryTimeout,
 	}, nil
 }
 
@@ -194,7 +196,7 @@ func (d *Driver) Begin(ctx context.Context, isolation stroppy.TxIsolationLevel) 
 			return nil, err
 		}
 
-		return sqldriver.NewConnOnlyTx(conn, sqldriver.NewRows, d.dialect, d.logger, conn.Close), nil
+		return sqldriver.NewConnOnlyTx(conn, sqldriver.NewRows, d.dialect, d.logger, d.queryTimeout, conn.Close), nil
 	}
 
 	sqlTx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sqldriver.IsolationToSQL(isolation)})
@@ -208,6 +210,7 @@ func (d *Driver) Begin(ctx context.Context, isolation stroppy.TxIsolationLevel) 
 		isolation,
 		d.dialect,
 		d.logger,
+		d.queryTimeout,
 	), nil
 }
 
@@ -216,7 +219,7 @@ func (d *Driver) RunQuery(
 	sqlStr string,
 	args map[string]any,
 ) (*driver.QueryResult, error) {
-	return sqldriver.RunQuery(ctx, d.db, sqldriver.NewRows, d.dialect, d.logger, sqlStr, args)
+	return sqldriver.RunQuery(ctx, d.db, sqldriver.NewRows, d.dialect, d.logger, sqlStr, args, d.queryTimeout)
 }
 
 func (d *Driver) Teardown(ctx context.Context) error {

--- a/pkg/driver/ydb/insert_spec.go
+++ b/pkg/driver/ydb/insert_spec.go
@@ -384,7 +384,10 @@ func coerceInt64(col string, conv any) (any, error) {
 func (w *bulkUpsertWriter) resolveColumnKinds(ctx context.Context) error {
 	var desc options.Description
 
-	err := w.d.nativeDB.Table().Do(ctx, func(ctx context.Context, s table.Session) error {
+	stmtCtx, cancel := sqldriver.StatementTimeout(ctx, w.d.queryTimeout)
+	defer cancel()
+
+	err := w.d.nativeDB.Table().Do(stmtCtx, func(ctx context.Context, s table.Session) error {
 		var e error
 
 		desc, e = s.DescribeTable(ctx, w.tablePath)
@@ -600,8 +603,12 @@ func (d *Driver) flushBulk(
 	batch []types.Value,
 ) error {
 	rows := types.ListValue(batch...)
+
+	stmtCtx, cancel := sqldriver.StatementTimeout(ctx, d.queryTimeout)
+	defer cancel()
+
 	if err := d.nativeDB.Table().BulkUpsert(
-		ctx, tablePath, table.BulkUpsertDataRows(rows),
+		stmtCtx, tablePath, table.BulkUpsertDataRows(rows),
 	); err != nil {
 		return fmt.Errorf("ydb bulk upsert %q: %w", tableName, err)
 	}

--- a/pkg/driver/ydb/insert_spec.go
+++ b/pkg/driver/ydb/insert_spec.go
@@ -87,9 +87,9 @@ func (d *Driver) runInsertChunk(
 	case driver.InsertNative, driver.InsertColumnar:
 		return d.bulkUpsertRuntime(ctx, tableName, src)
 	case driver.InsertPlainBulk:
-		return sqldriver.RunBulkInsert(ctx, d.db, tableName, src, d.dialect, d.bulkSize)
+		return sqldriver.RunBulkInsert(ctx, d.db, tableName, src, d.dialect, d.bulkSize, d.queryTimeout)
 	case driver.InsertPlainQuery:
-		return sqldriver.RunBulkInsert(ctx, d.db, tableName, src, d.dialect, 1)
+		return sqldriver.RunBulkInsert(ctx, d.db, tableName, src, d.dialect, 1, d.queryTimeout)
 	default:
 		return fmt.Errorf("%w: %s", driver.ErrInsertMethodNotSupported, method)
 	}

--- a/test/integration/help_test.go
+++ b/test/integration/help_test.go
@@ -1,0 +1,28 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolutionHelpListsQueryTimeout(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	binary := filepath.Join(repoRoot, "build", "stroppy")
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatalf("stroppy binary not found at %s (run `make build` first): %v", binary, err)
+	}
+
+	output, err := exec.Command(binary, "help", "resolution").CombinedOutput()
+	if err != nil {
+		t.Fatalf("stroppy help resolution: %v\n%s", err, output)
+	}
+
+	if !strings.Contains(string(output), "--query-timeout") {
+		t.Fatalf("stroppy help resolution omitted --query-timeout:\n%s", output)
+	}
+}

--- a/test/integration/query_timeout_test.go
+++ b/test/integration/query_timeout_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"go.uber.org/zap"
 
 	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
@@ -72,8 +73,8 @@ func assertReusable(t *testing.T, drv driver.Driver) {
 }
 
 // TestQueryTimeoutPostgres blocks pg_sleep past the deadline and verifies the
-// statement is cut off as a timeout (pgx CancelRequest → context.DeadlineExceeded)
-// rather than a parent cancel, and that the pooled connection is reusable after.
+// statement is classified as a timeout rather than a parent cancel, and that
+// the pooled connection is reusable afterward.
 func TestQueryTimeoutPostgres(t *testing.T) {
 	skipIfRequested(t)
 
@@ -91,7 +92,10 @@ func TestQueryTimeoutPostgres(t *testing.T) {
 		t.Fatalf("ClassifyError = %q, want %q (err=%v)", facts.Kind, driver.ErrorKindTimeout, err)
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("pg timeout err = %v, want context.DeadlineExceeded", err)
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "57014" {
+			t.Fatalf("pg timeout err = %v, want deadline or SQLSTATE 57014", err)
+		}
 	}
 	if errors.Is(err, context.Canceled) {
 		t.Fatalf("pg timeout err = %v was classified as canceled", err)

--- a/test/integration/query_timeout_test.go
+++ b/test/integration/query_timeout_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	gomysql "github.com/go-sql-driver/mysql"
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.uber.org/zap"
 
@@ -72,7 +73,45 @@ func assertReusable(t *testing.T, drv driver.Driver) {
 	}
 }
 
-func assertMySQLClientTimeout(
+func querySingleString(t *testing.T, drv driver.Driver, sql string) string {
+	t.Helper()
+
+	res, err := drv.RunQuery(context.Background(), sql, nil)
+	if err != nil {
+		t.Fatalf("query %q: %v", sql, err)
+	}
+	defer res.Rows.Close()
+
+	if !res.Rows.Next() {
+		t.Fatalf("query %q returned no rows: %v", sql, res.Rows.Err())
+	}
+
+	values := res.Rows.Values()
+	if len(values) != 1 {
+		t.Fatalf("query %q returned %d values, want 1", sql, len(values))
+	}
+
+	value, ok := values[0].(string)
+	if !ok {
+		t.Fatalf("query %q returned %T, want string", sql, values[0])
+	}
+
+	return value
+}
+
+func assertTimeoutElapsed(t *testing.T, elapsed, timeout time.Duration) {
+	t.Helper()
+
+	if minimum := timeout / 2; elapsed < minimum {
+		t.Fatalf("query timed out after %v, want at least %v", elapsed, minimum)
+	}
+
+	if maximum := timeout + 500*time.Millisecond; elapsed > maximum {
+		t.Fatalf("query timed out after %v, want at most %v", elapsed, maximum)
+	}
+}
+
+func assertMySQLClientTimeoutError(
 	t *testing.T,
 	drv driver.Driver,
 	sql string,
@@ -96,10 +135,51 @@ func assertMySQLClientTimeout(
 	if errors.Is(err, context.Canceled) {
 		t.Fatalf("query %q error = %v was classified as canceled", sql, err)
 	}
-	if limit := timeout + 500*time.Millisecond; elapsed > limit {
-		t.Fatalf("query %q timed out after %v, want client timeout within %v", sql, elapsed, limit)
+
+	assertTimeoutElapsed(t, elapsed, timeout)
+}
+
+func assertMySQLClientTimeout(
+	t *testing.T,
+	drv driver.Driver,
+	sql string,
+	timeout time.Duration,
+) {
+	t.Helper()
+	assertMySQLClientTimeoutError(t, drv, sql, timeout)
+	assertReusable(t, drv)
+}
+
+func assertMySQLServerTimeout(
+	t *testing.T,
+	drv driver.Driver,
+	sql string,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	start := time.Now()
+	err := runQueryToCompletion(drv, sql)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("query %q returned nil error, want MySQL timeout", sql)
 	}
 
+	if facts := drv.ClassifyError(err); facts.Kind != driver.ErrorKindTimeout {
+		t.Fatalf("ClassifyError = %q, want %q (err=%v)", facts.Kind, driver.ErrorKindTimeout, err)
+	}
+
+	var mysqlErr *gomysql.MySQLError
+	if !errors.As(err, &mysqlErr) || mysqlErr.Number != 3024 {
+		t.Fatalf("query %q error = %v, want MySQL error 3024", sql, err)
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		t.Fatalf("query %q error = %v, want server timeout", sql, err)
+	}
+
+	assertTimeoutElapsed(t, elapsed, timeout)
 	assertReusable(t, drv)
 }
 
@@ -138,39 +218,73 @@ func TestQueryTimeoutPostgres(t *testing.T) {
 	assertReusable(t, drv)
 }
 
-// TestQueryTimeoutMySQL runs a large metadata join past the deadline and verifies
-// the server-side MAX_EXECUTION_TIME hint (error 3024) fires ahead of the padded
-// client deadline, so the connection is not discarded and stays reusable.
+// TestQueryTimeoutMySQL verifies an eligible SELECT receives a server-side
+// MAX_EXECUTION_TIME hint and reports MySQL error 3024 near the configured bound.
 func TestQueryTimeoutMySQL(t *testing.T) {
 	skipIfRequested(t)
 
+	const timeout = 150 * time.Millisecond
+
 	url := envOr(envMySQLAllURL, defaultMySQLAllURL)
-	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_MYSQL, url, 150*time.Millisecond)
+	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_MYSQL, url, timeout)
 
 	const query = "SELECT COUNT(*) FROM information_schema.columns a " +
 		"CROSS JOIN information_schema.columns b CROSS JOIN information_schema.columns c"
 
-	start := time.Now()
-	err := runQueryToCompletion(drv, query)
-	elapsed := time.Since(start)
+	assertMySQLServerTimeout(t, drv, query, timeout)
+}
 
-	if err == nil {
-		t.Fatal("large metadata join returned nil error, want timeout")
-	}
-	if facts := drv.ClassifyError(err); facts.Kind != driver.ErrorKindTimeout {
-		t.Fatalf("ClassifyError = %q, want %q (err=%v)", facts.Kind, driver.ErrorKindTimeout, err)
-	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("mysql timeout err = %v reached the client deadline, want server-side 3024", err)
-	}
-	if errors.Is(err, context.Canceled) {
-		t.Fatalf("mysql timeout err = %v was classified as canceled", err)
-	}
-	if elapsed > 5*time.Second {
-		t.Fatalf("large metadata join ran %v, deadline did not fire", elapsed)
-	}
+func TestQueryTimeoutMySQLMergesOptimizerHints(t *testing.T) {
+	skipIfRequested(t)
 
-	assertReusable(t, drv)
+	const timeout = 150 * time.Millisecond
+
+	url := envOr(envMySQLAllURL, defaultMySQLAllURL)
+	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_MYSQL, url, timeout)
+
+	t.Run("SET_VAR survives", func(t *testing.T) {
+		const query = "SELECT /*+ SET_VAR(sort_buffer_size=32768) */ " +
+			"CAST(@@sort_buffer_size AS CHAR)"
+
+		if got := querySingleString(t, drv, query); got != "32768" {
+			t.Fatalf("statement sort_buffer_size = %q, want 32768", got)
+		}
+	})
+
+	t.Run("existing timeout is replaced", func(t *testing.T) {
+		const query = "SELECT /*+ SET_VAR(sort_buffer_size=32768) " +
+			"mAx_ExEcUtIoN_tImE ( 5000 ) */ COUNT(*) " +
+			"FROM information_schema.columns a " +
+			"CROSS JOIN information_schema.columns b " +
+			"CROSS JOIN information_schema.columns c"
+
+		assertMySQLServerTimeout(t, drv, query, timeout)
+	})
+}
+
+func TestQueryTimeoutMySQLSelectSleep(t *testing.T) {
+	skipIfRequested(t)
+
+	const timeout = 150 * time.Millisecond
+
+	url := envOr(envMySQLAllURL, defaultMySQLAllURL)
+	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_MYSQL, url, timeout)
+
+	assertMySQLClientTimeout(t, drv, "SELECT SLEEP(10)", timeout)
+}
+
+func TestQueryTimeoutMySQLUnrepresentableDuration(t *testing.T) {
+	skipIfRequested(t)
+
+	const timeout = time.Millisecond - time.Nanosecond
+
+	url := envOr(envMySQLAllURL, defaultMySQLAllURL)
+	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_MYSQL, url, timeout)
+
+	const query = "SELECT COUNT(*) FROM information_schema.columns a " +
+		"CROSS JOIN information_schema.columns b CROSS JOIN information_schema.columns c"
+
+	assertMySQLClientTimeoutError(t, drv, query, timeout)
 }
 
 func TestQueryTimeoutMySQLUnhintedStatements(t *testing.T) {

--- a/test/integration/query_timeout_test.go
+++ b/test/integration/query_timeout_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/stroppy-io/stroppy/pkg/config"
+	"github.com/stroppy-io/stroppy/pkg/driver"
+	_ "github.com/stroppy-io/stroppy/pkg/driver/mysql"
+	_ "github.com/stroppy-io/stroppy/pkg/driver/postgres"
+)
+
+// dispatchQueryTimeout builds a stroppy driver with a per-statement deadline.
+func dispatchQueryTimeout(t *testing.T, typ config.DriverType, url string, timeout time.Duration) driver.Driver {
+	t.Helper()
+
+	drv, err := driver.Dispatch(context.Background(), driver.Options{
+		Config:       &config.DriverConfig{DriverType: typ, URL: url},
+		Logger:       zap.NewNop(),
+		QueryTimeout: timeout,
+	})
+	if err != nil {
+		t.Fatalf("driver.Dispatch(%s): %v", typ, err)
+	}
+
+	t.Cleanup(func() { _ = drv.Teardown(context.Background()) })
+
+	return drv
+}
+
+// assertReusable drives a fast query on the same driver after a timeout to
+// prove the pooled connection is still serviceable.
+func assertReusable(t *testing.T, drv driver.Driver) {
+	t.Helper()
+
+	res, err := drv.RunQuery(context.Background(), "SELECT 1", nil)
+	if err != nil {
+		t.Fatalf("reuse query = %v, want nil", err)
+	}
+	defer res.Rows.Close()
+
+	if !res.Rows.Next() {
+		t.Fatal("reuse query returned no rows")
+	}
+
+	if err := res.Rows.Err(); err != nil {
+		t.Fatalf("reuse query rows: %v", err)
+	}
+}
+
+// TestQueryTimeoutPostgres blocks pg_sleep past the deadline and verifies the
+// statement is cut off as a timeout (pgx CancelRequest → context.DeadlineExceeded)
+// rather than a parent cancel, and that the pooled connection is reusable after.
+func TestQueryTimeoutPostgres(t *testing.T) {
+	skipIfRequested(t)
+
+	url := envOr(envTmpfsURL, defaultTmpfsURL)
+	drv := dispatchQueryTimeout(t, config.DriverTypePostgres, url, 150*time.Millisecond)
+
+	start := time.Now()
+	_, err := drv.RunQuery(context.Background(), "SELECT pg_sleep(10)", nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("pg_sleep returned nil error, want timeout")
+	}
+	if facts := drv.ClassifyError(err); facts.Kind != driver.ErrorKindTimeout {
+		t.Fatalf("ClassifyError = %q, want %q (err=%v)", facts.Kind, driver.ErrorKindTimeout, err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("pg timeout err = %v, want context.DeadlineExceeded", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("pg timeout err = %v was classified as canceled", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("pg_sleep(10) ran %v, deadline did not fire", elapsed)
+	}
+
+	assertReusable(t, drv)
+}
+
+// TestQueryTimeoutMySQL blocks SELECT SLEEP past the deadline and verifies the
+// server-side MAX_EXECUTION_TIME hint (error 3024) fires ahead of the padded
+// client deadline, so the connection is not discarded and stays reusable.
+func TestQueryTimeoutMySQL(t *testing.T) {
+	skipIfRequested(t)
+
+	url := envOr(envMySQLAllURL, defaultMySQLAllURL)
+	drv := dispatchQueryTimeout(t, config.DriverTypeMySQL, url, 150*time.Millisecond)
+
+	start := time.Now()
+	_, err := drv.RunQuery(context.Background(), "SELECT SLEEP(10)", nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("SELECT SLEEP returned nil error, want timeout")
+	}
+	if facts := drv.ClassifyError(err); facts.Kind != driver.ErrorKindTimeout {
+		t.Fatalf("ClassifyError = %q, want %q (err=%v)", facts.Kind, driver.ErrorKindTimeout, err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("mysql timeout err = %v reached the client deadline, want server-side 3024", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("mysql timeout err = %v was classified as canceled", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("SELECT SLEEP(10) ran %v, deadline did not fire", elapsed)
+	}
+
+	assertReusable(t, drv)
+}

--- a/test/integration/query_timeout_test.go
+++ b/test/integration/query_timeout_test.go
@@ -27,7 +27,7 @@ func dispatchQueryTimeout(
 
 	drv, err := driver.Dispatch(context.Background(), driver.Options{
 		Config:       &stroppy.DriverConfig{DriverType: typ, Url: url},
-		Logger:       zap.NewNop(),
+		Logger:       zap.NewExample(),
 		QueryTimeout: timeout,
 	})
 	if err != nil {
@@ -37,6 +37,18 @@ func dispatchQueryTimeout(
 	t.Cleanup(func() { _ = drv.Teardown(context.Background()) })
 
 	return drv
+}
+
+func runQueryToCompletion(drv driver.Driver, sql string) error {
+	res, err := drv.RunQuery(context.Background(), sql, nil)
+	if err != nil {
+		return err
+	}
+	defer res.Rows.Close()
+
+	res.Rows.ReadAll(0)
+
+	return res.Rows.Err()
 }
 
 // assertReusable drives a fast query on the same driver after a timeout to
@@ -69,7 +81,7 @@ func TestQueryTimeoutPostgres(t *testing.T) {
 	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_POSTGRES, url, 150*time.Millisecond)
 
 	start := time.Now()
-	_, err := drv.RunQuery(context.Background(), "SELECT pg_sleep(10)", nil)
+	err := runQueryToCompletion(drv, "SELECT pg_sleep(10)")
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -91,8 +103,8 @@ func TestQueryTimeoutPostgres(t *testing.T) {
 	assertReusable(t, drv)
 }
 
-// TestQueryTimeoutMySQL blocks SELECT SLEEP past the deadline and verifies the
-// server-side MAX_EXECUTION_TIME hint (error 3024) fires ahead of the padded
+// TestQueryTimeoutMySQL runs a large metadata join past the deadline and verifies
+// the server-side MAX_EXECUTION_TIME hint (error 3024) fires ahead of the padded
 // client deadline, so the connection is not discarded and stays reusable.
 func TestQueryTimeoutMySQL(t *testing.T) {
 	skipIfRequested(t)
@@ -100,12 +112,15 @@ func TestQueryTimeoutMySQL(t *testing.T) {
 	url := envOr(envMySQLAllURL, defaultMySQLAllURL)
 	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_MYSQL, url, 150*time.Millisecond)
 
+	const query = "SELECT COUNT(*) FROM information_schema.columns a " +
+		"CROSS JOIN information_schema.columns b CROSS JOIN information_schema.columns c"
+
 	start := time.Now()
-	_, err := drv.RunQuery(context.Background(), "SELECT SLEEP(10)", nil)
+	err := runQueryToCompletion(drv, query)
 	elapsed := time.Since(start)
 
 	if err == nil {
-		t.Fatalf("SELECT SLEEP returned nil error, want timeout")
+		t.Fatal("large metadata join returned nil error, want timeout")
 	}
 	if facts := drv.ClassifyError(err); facts.Kind != driver.ErrorKindTimeout {
 		t.Fatalf("ClassifyError = %q, want %q (err=%v)", facts.Kind, driver.ErrorKindTimeout, err)
@@ -117,7 +132,7 @@ func TestQueryTimeoutMySQL(t *testing.T) {
 		t.Fatalf("mysql timeout err = %v was classified as canceled", err)
 	}
 	if elapsed > 5*time.Second {
-		t.Fatalf("SELECT SLEEP(10) ran %v, deadline did not fire", elapsed)
+		t.Fatalf("large metadata join ran %v, deadline did not fire", elapsed)
 	}
 
 	assertReusable(t, drv)

--- a/test/integration/query_timeout_test.go
+++ b/test/integration/query_timeout_test.go
@@ -72,6 +72,37 @@ func assertReusable(t *testing.T, drv driver.Driver) {
 	}
 }
 
+func assertMySQLClientTimeout(
+	t *testing.T,
+	drv driver.Driver,
+	sql string,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	start := time.Now()
+	err := runQueryToCompletion(drv, sql)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("query %q returned nil error, want client timeout", sql)
+	}
+	if facts := drv.ClassifyError(err); facts.Kind != driver.ErrorKindTimeout {
+		t.Fatalf("ClassifyError = %q, want %q (err=%v)", facts.Kind, driver.ErrorKindTimeout, err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("query %q error = %v, want context.DeadlineExceeded", sql, err)
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("query %q error = %v was classified as canceled", sql, err)
+	}
+	if limit := timeout + 500*time.Millisecond; elapsed > limit {
+		t.Fatalf("query %q timed out after %v, want client timeout within %v", sql, elapsed, limit)
+	}
+
+	assertReusable(t, drv)
+}
+
 // TestQueryTimeoutPostgres blocks pg_sleep past the deadline and verifies the
 // statement is classified as a timeout rather than a parent cancel, and that
 // the pooled connection is reusable afterward.
@@ -140,4 +171,31 @@ func TestQueryTimeoutMySQL(t *testing.T) {
 	}
 
 	assertReusable(t, drv)
+}
+
+func TestQueryTimeoutMySQLUnhintedStatements(t *testing.T) {
+	skipIfRequested(t)
+
+	const timeout = 150 * time.Millisecond
+
+	url := envOr(envMySQLAllURL, defaultMySQLAllURL)
+	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_MYSQL, url, timeout)
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "do", sql: "DO SLEEP(10)"},
+		{name: "leading comment select", sql: "/* probe */ SELECT SLEEP(10)"},
+		{
+			name: "cte",
+			sql:  "WITH sleeper AS (SELECT SLEEP(10) AS value) SELECT value FROM sleeper",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertMySQLClientTimeout(t, drv, tt.sql, timeout)
+		})
+	}
 }

--- a/test/integration/query_timeout_test.go
+++ b/test/integration/query_timeout_test.go
@@ -10,18 +10,23 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/stroppy-io/stroppy/pkg/config"
+	stroppy "github.com/stroppy-io/stroppy/pkg/common/proto/stroppy"
 	"github.com/stroppy-io/stroppy/pkg/driver"
 	_ "github.com/stroppy-io/stroppy/pkg/driver/mysql"
 	_ "github.com/stroppy-io/stroppy/pkg/driver/postgres"
 )
 
 // dispatchQueryTimeout builds a stroppy driver with a per-statement deadline.
-func dispatchQueryTimeout(t *testing.T, typ config.DriverType, url string, timeout time.Duration) driver.Driver {
+func dispatchQueryTimeout(
+	t *testing.T,
+	typ stroppy.DriverConfig_DriverType,
+	url string,
+	timeout time.Duration,
+) driver.Driver {
 	t.Helper()
 
 	drv, err := driver.Dispatch(context.Background(), driver.Options{
-		Config:       &config.DriverConfig{DriverType: typ, URL: url},
+		Config:       &stroppy.DriverConfig{DriverType: typ, Url: url},
 		Logger:       zap.NewNop(),
 		QueryTimeout: timeout,
 	})
@@ -61,7 +66,7 @@ func TestQueryTimeoutPostgres(t *testing.T) {
 	skipIfRequested(t)
 
 	url := envOr(envTmpfsURL, defaultTmpfsURL)
-	drv := dispatchQueryTimeout(t, config.DriverTypePostgres, url, 150*time.Millisecond)
+	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_POSTGRES, url, 150*time.Millisecond)
 
 	start := time.Now()
 	_, err := drv.RunQuery(context.Background(), "SELECT pg_sleep(10)", nil)
@@ -93,7 +98,7 @@ func TestQueryTimeoutMySQL(t *testing.T) {
 	skipIfRequested(t)
 
 	url := envOr(envMySQLAllURL, defaultMySQLAllURL)
-	drv := dispatchQueryTimeout(t, config.DriverTypeMySQL, url, 150*time.Millisecond)
+	drv := dispatchQueryTimeout(t, stroppy.DriverConfig_DRIVER_TYPE_MYSQL, url, 150*time.Millisecond)
 
 	start := time.Now()
 	_, err := drv.RunQuery(context.Background(), "SELECT SLEEP(10)", nil)


### PR DESCRIPTION
## What

Adds a typed `--query-timeout` run parameter (precedence: CLI `--query-timeout` > env `QUERY_TIMEOUT` > `-e` > config `run.queryTimeout` > default) that bounds each executed statement with a child `context.WithTimeout`. Default is **disabled** (`0`), preserving today's behavior; a negative value is rejected.

## Enforcement

- The shared `pkg/driver/sqldriver/run_query.go` derives the deadline per statement, so every standalone **and** transactional query (postgres/mysql/picodata/ydb/noop) gets the bound.
- The shared bulk-insert exec path (`sqldriver.RunBulkInsert`) and PostgreSQL's native/columnar/bulk insert exec paths apply the same per-statement deadline.

## Backend statement timeouts

- **MySQL**: `MAX_EXECUTION_TIME` optimizer hint is inserted after the `SELECT` keyword, bounding the server side of each query. go-sql-driver/mysql force-closes a connection on client-side context cancellation, so the hint is what keeps a timed-out query's pooled connection reusable. MySQL error 3024 (`ER_QUERY_TIMEOUT`) classifies as `ErrorKindTimeout`.
- **PostgreSQL**: relies on pgx's context cancellation, which already translates a deadline into a protocol `CancelRequest`; setting a session `statement_timeout` would need transaction-scoped `SET LOCAL` (wrong for autocommit) or an acquire/reset dance that defeats the pool — and it adds a leak risk without improving cancellation reliability. So no session setting is used, and nothing can leak.
- **Other drivers** (picodata/ydb/noop) honor context cancellation.

## Error classification

Timeouts surface as `context.DeadlineExceeded` → `ErrorKindTimeout`; parent-run cancellation stays `context.Canceled` → `ErrorKindCanceled`. They stay separate in retry/error handling. Unit tests prove the child deadline fires, is a timeout (not a cancel), and the connection is reusable after a timeout.

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-statement query timeouts via `--query-timeout` and `queryTimeout`.
  * Supported timeouts across PostgreSQL, MySQL, YDB, Pico, and other drivers.
  * Added MySQL execution-time hints and timeout-specific error reporting.
  * Added timeout support for inserts, transactions, and result-set handling.

* **Bug Fixes**
  * Prevented duplicate timeout errors during result cleanup.
  * Improved connection reuse after timed-out queries.
  * Negative timeout values are now rejected with a clear error.

* **Documentation**
  * Updated help topics, configuration schemas, shared parameter documentation, and the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->