### PR TITLE
Consolidate logging around one process-wide logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
-- Logging now uses one safely replaceable process-wide logger, with configurable level and output mode precedence plus redacted database connection diagnostics.
+- Logging now uses one safely replaceable process-wide logger, with configurable level and output mode precedence plus redacted database connection diagnostics. ([#154](https://github.com/stroppy-io/stroppy/pull/154))
 - Driver insert-method defaults now fill only load requests that leave their method unset, preserving methods selected by workloads. ([#152](https://github.com/stroppy-io/stroppy/pull/152))
 - SIGINT and SIGTERM now cancel the running workload and trigger graceful teardown; a second signal forces immediate exit. Exit status is 130 (SIGINT) or 143 (SIGTERM) after a graceful cancellation, 2 after a forced exit, and 1 for other errors. ([#148](https://github.com/stroppy-io/stroppy/pull/148))
 - Built-in workloads expose their tuning options as typed parameters while preserving the existing environment-variable names. ([#128](https://github.com/stroppy-io/stroppy/pull/128))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
+- Logging now uses one safely replaceable process-wide logger, with configurable level and output mode precedence plus redacted database connection diagnostics.
 - Driver insert-method defaults now fill only load requests that leave their method unset, preserving methods selected by workloads. ([#152](https://github.com/stroppy-io/stroppy/pull/152))
 - SIGINT and SIGTERM now cancel the running workload and trigger graceful teardown; a second signal forces immediate exit. Exit status is 130 (SIGINT) or 143 (SIGTERM) after a graceful cancellation, 2 after a forced exit, and 1 for other errors. ([#148](https://github.com/stroppy-io/stroppy/pull/148))
 - Built-in workloads expose their tuning options as typed parameters while preserving the existing environment-variable names. ([#128](https://github.com/stroppy-io/stroppy/pull/128))

--- a/cmd/stroppy/commands/help/help_test.go
+++ b/cmd/stroppy/commands/help/help_test.go
@@ -17,3 +17,23 @@ func TestRemovedConfigFieldsAreAbsentFromHelp(t *testing.T) {
 		}
 	}
 }
+
+func TestLoggerDefaultsInConfigFileHelp(t *testing.T) {
+	for _, topic := range topics {
+		if topic.Name != "config-file" {
+			continue
+		}
+
+		if !strings.Contains(topic.Long, "With the debug/development defaults, stroppy logs:") {
+			t.Error("config-file help does not state the debug/development logger defaults")
+		}
+
+		if strings.Contains(topic.Long, "At INFO level (default)") {
+			t.Error("config-file help incorrectly states that info is the logger default")
+		}
+
+		return
+	}
+
+	t.Error("config-file help topic is not registered")
+}

--- a/cmd/stroppy/commands/help/help_test.go
+++ b/cmd/stroppy/commands/help/help_test.go
@@ -32,6 +32,14 @@ func TestLoggerDefaultsInConfigFileHelp(t *testing.T) {
 			t.Error("config-file help incorrectly states that info is the logger default")
 		}
 
+		if strings.Contains(topic.Long, "Logger and OTEL exporter config (no CLI equivalent)") {
+			t.Error("config-file help incorrectly says logger configuration has no CLI equivalent")
+		}
+
+		if !strings.Contains(topic.Long, "--log-level/--log-mode override logger fields") {
+			t.Error("config-file help does not describe logger CLI overrides")
+		}
+
 		return
 	}
 

--- a/cmd/stroppy/commands/help/topic_config_file.go
+++ b/cmd/stroppy/commands/help/topic_config_file.go
@@ -141,7 +141,7 @@ DEBUG LOGGING
     env_override   when real env takes precedence over -e or file env keys
     driver_preset  which source was applied per driver index
 
-  At INFO level (default) stroppy logs:
+  With the debug/development defaults, stroppy logs:
 
     "Loaded config file: <path>"
 

--- a/cmd/stroppy/commands/help/topic_config_file.go
+++ b/cmd/stroppy/commands/help/topic_config_file.go
@@ -62,7 +62,8 @@ Example stroppy-config.json:
 
     script   string            Workload name, .sql path, or inline SQL
     sql      string            Explicit SQL file override (2nd positional)
-    global   object            Logger and OTEL exporter config (no CLI equivalent)
+    global   object            Logger and OTEL exporter config; --log-level/--log-mode override logger fields,
+                              while exporter has no CLI equivalent
     drivers  map[string]obj    Per-index driver configs (keys "0", "1", ...)
     run      object            Typed scenario params: executor, vus, iterations, duration,
                               queryTimeout

--- a/cmd/stroppy/commands/help/topic_config_file.go
+++ b/cmd/stroppy/commands/help/topic_config_file.go
@@ -76,8 +76,10 @@ Example stroppy-config.json:
   alias together with its lower-camel name. Former int32 fields accept bare or
   quoted decimal/exponent forms only when the value is exactly integral and
   in range. global.seed accepts null or a bare unsigned JSON integer only.
-  Logger enums accept their LOG_LEVEL_*/LOG_MODE_* names or valid numeric
-  ordinals.
+  Logger enums accept short names (debug, info, warn, error, fatal;
+  development, production), their LOG_LEVEL_*/LOG_MODE_* names, or valid
+  numeric ordinals. Fractional, out-of-range, and wrong-type values are
+  rejected. Logger defaults are debug/development.
 
   The generated schema is docs/jsonschema/run.schema.json; regenerate it with
   go generate ./pkg/config after changing the file envelope.
@@ -112,7 +114,12 @@ PRECEDENCE (highest to lowest)
 
     workload / sql positionals:  CLI arg > config file "script"/"sql" fields
     steps / noSteps:             CLI --steps > config file "steps" field
-    logger / OTEL exporter:      config file "global" only (no CLI equivalent)
+    logger:  --log-level/--log-mode > LOG_LEVEL/LOG_MODE process env >
+             -e LOG_LEVEL/LOG_MODE > global.logger > debug/development
+    OTEL exporter: global config only (no CLI equivalent)
+
+  Database URLs in configuration diagnostics are redacted: passwords, tokens,
+  secrets, credentials, and API keys never appear in logs.
 
   There is no "--" k6-args passthrough. Use typed
   executor/vus/iterations/duration/queryTimeout parameters. The

--- a/cmd/stroppy/commands/help/topic_envs.go
+++ b/cmd/stroppy/commands/help/topic_envs.go
@@ -41,6 +41,12 @@ SOURCES AND PRECEDENCE
     5. Config file "env" map
     6. Declared default
 
+  Logging is configured separately before workload binding. --log-level and
+  --log-mode take precedence over LOG_LEVEL/LOG_MODE process variables, then
+  -e LOG_LEVEL/LOG_MODE, then global.logger in the config file, then the
+  debug/development defaults. Each accepts a short name, its v5
+  LOG_LEVEL_*/LOG_MODE_* name, or a valid ordinal.
+
   Process environment examples:
 
     SCALE_FACTOR=10 stroppy run tpcc/tx

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -28,6 +29,15 @@ const (
 	flagDriverOpt    = "--driver-opt"
 )
 
+const (
+	loggerLevelParam = "log-level"
+	loggerModeParam  = "log-mode"
+	envLogLevel      = "LOG_LEVEL"
+	envLogMode       = "LOG_MODE"
+	defaultLogLevel  = "debug"
+	defaultLogMode   = "development"
+)
+
 var (
 	errNoScript           = errors.New("script argument is required")
 	errFlagRequiresValue  = errors.New("flag requires a value")
@@ -43,7 +53,11 @@ var (
 	errK6PassthroughRemoved = errors.New(
 		"the '--' k6 passthrough is removed; use --executor/--vus/--iterations/--duration",
 	)
-	errUnknownWorkload = errors.New("unknown workload; expected a registered Go workload, a .sql file, or inline SQL")
+	errUnknownWorkload = errors.New(
+		"unknown workload; expected a registered Go workload, a .sql file, or inline SQL",
+	)
+	errInvalidConfigLogLevel = errors.New("invalid config log level")
+	errInvalidConfigLogMode  = errors.New("invalid config log mode")
 )
 
 var Cmd = &cobra.Command{
@@ -62,6 +76,13 @@ The workload and optional sql_file positionals must be adjacent.
 Environment flags:
   -e, --env KEY=VALUE     Set a legacy env value for the workload.
                           Real env and typed flags take precedence.
+
+Logging:
+  --log-level VALUE       Minimum level: debug, info, warn, error, or fatal.
+  --log-mode VALUE        Output mode: development or production.
+                          Each accepts its LOG_LEVEL_*/LOG_MODE_* name or ordinal.
+                          Sources: flags > process env > -e > global.logger > defaults.
+                          Defaults: debug and development.
 
 Typed parameter flags:
   --name VALUE            Set a run or selected-workload parameter.
@@ -118,11 +139,25 @@ Signals:
 			return printSelectedWorkloadHelp(cmd, parsed.scriptArg, parsed.sqlArg)
 		}
 
-		// Load config file if -f is specified or stroppy-config.json exists.
+		// Resolve -e values before loading configuration so logger input is ready
+		// before any configuration diagnostics are emitted.
+		envOverrides, err := runner.ResolveEnvOverrides(parsed.envArgs)
+		if err != nil {
+			return invalidConfig(err)
+		}
+
+		// Load configuration without emitting diagnostics. The effective logger is
+		// initialized immediately afterward so every following log shares it.
 		fileConfig, _, err := runner.LoadRunConfig(parsed.fileArg)
 		if err != nil {
 			return invalidConfig(fmt.Errorf("failed to load config file: %w", err))
 		}
+
+		if err := initializeLogger(parsed.typedParams, envOverrides, fileConfig); err != nil {
+			return invalidConfig(err)
+		}
+
+		runner.LogConfigFile(fileConfig)
 
 		// Apply effective values: CLI overrides config file.
 		scriptArg := runner.EffectiveScript(parsed.scriptArg, fileConfig)
@@ -172,15 +207,9 @@ Signals:
 			}
 		}
 
-		// Resolve -e overrides (uppercase keys, validate format).
-		envOverrides, err := runner.ResolveEnvOverrides(parsed.envArgs)
-		if err != nil {
-			return invalidConfig(err)
-		}
-
 		paramInputs := bench.ParamInputs{
-			CLI:       parsed.typedParams,
-			LegacyEnv: envOverrides,
+			CLI:       withoutLoggerParams(parsed.typedParams),
+			LegacyEnv: withoutLoggerEnv(envOverrides),
 		}
 
 		driverConfigs := runner.DriverCLIConfigs{}
@@ -188,7 +217,7 @@ Signals:
 		if fileConfig != nil {
 			paramInputs.RunConfig = fileConfig.Run
 			paramInputs.WorkloadConfig = fileConfig.Params
-			paramInputs.LegacyConfigEnv = fileConfig.RunConfig.Env
+			paramInputs.LegacyConfigEnv = withoutLoggerEnv(fileConfig.RunConfig.Env)
 
 			driverConfigs, err = runner.DriverCLIConfigsFromFile(fileConfig.RunConfig.Drivers)
 			if err != nil {
@@ -315,6 +344,130 @@ func loadedRunConfig(loaded *runner.LoadedConfig) *config.RunConfig {
 	return loaded.RunConfig
 }
 
+func initializeLogger(
+	cli, legacyEnv map[string]string,
+	loaded *runner.LoadedConfig,
+) error {
+	var fileLogger *config.LoggerConfig
+	if loaded != nil && loaded.RunConfig != nil && loaded.RunConfig.Global != nil {
+		fileLogger = loaded.RunConfig.Global.Logger
+	}
+
+	level, err := resolveLogLevel(cli, legacyEnv, fileLogger)
+	if err != nil {
+		return err
+	}
+
+	mode, err := resolveLogMode(cli, legacyEnv, fileLogger)
+	if err != nil {
+		return err
+	}
+
+	return logger.Init(level, mode)
+}
+
+func resolveLogLevel(cli, legacyEnv map[string]string, fileLogger *config.LoggerConfig) (string, error) {
+	if value, ok := cli[loggerLevelParam]; ok {
+		return parseLogLevel(value)
+	}
+
+	if value, ok := os.LookupEnv(envLogLevel); ok {
+		return parseLogLevel(value)
+	}
+
+	if value, ok := legacyEnv[envLogLevel]; ok {
+		return parseLogLevel(value)
+	}
+
+	if fileLogger != nil {
+		return loggerLevelValue(fileLogger.LogLevel)
+	}
+
+	return defaultLogLevel, nil
+}
+
+func resolveLogMode(cli, legacyEnv map[string]string, fileLogger *config.LoggerConfig) (string, error) {
+	if value, ok := cli[loggerModeParam]; ok {
+		return parseLogMode(value)
+	}
+
+	if value, ok := os.LookupEnv(envLogMode); ok {
+		return parseLogMode(value)
+	}
+
+	if value, ok := legacyEnv[envLogMode]; ok {
+		return parseLogMode(value)
+	}
+
+	if fileLogger != nil {
+		return loggerModeValue(fileLogger.LogMode)
+	}
+
+	return defaultLogMode, nil
+}
+
+func parseLogLevel(value string) (string, error) {
+	level, err := config.ParseLogLevel(value)
+	if err != nil {
+		return "", err
+	}
+
+	return level.Short(), nil
+}
+
+func parseLogMode(value string) (string, error) {
+	mode, err := config.ParseLogMode(value)
+	if err != nil {
+		return "", err
+	}
+
+	return mode.Short(), nil
+}
+
+func loggerLevelValue(value config.LogLevel) (string, error) {
+	if short := value.Short(); short != "" {
+		return short, nil
+	}
+
+	return "", fmt.Errorf("%w: %s", errInvalidConfigLogLevel, value.String())
+}
+
+func loggerModeValue(value config.LogMode) (string, error) {
+	if short := value.Short(); short != "" {
+		return short, nil
+	}
+
+	return "", fmt.Errorf("%w: %s", errInvalidConfigLogMode, value.String())
+}
+
+func withoutLoggerParams(values map[string]string) map[string]string {
+	if _, hasLevel := values[loggerLevelParam]; !hasLevel {
+		if _, hasMode := values[loggerModeParam]; !hasMode {
+			return values
+		}
+	}
+
+	without := maps.Clone(values)
+	delete(without, loggerLevelParam)
+	delete(without, loggerModeParam)
+
+	return without
+}
+
+func withoutLoggerEnv(values map[string]string) map[string]string {
+	if _, hasLevel := values[envLogLevel]; !hasLevel {
+		if _, hasMode := values[envLogMode]; !hasMode {
+			return values
+		}
+	}
+
+	without := maps.Clone(values)
+	delete(without, envLogLevel)
+	delete(without, envLogMode)
+
+	return without
+}
+
 func metricsConfig(cfg *config.RunConfig) *bench.MetricsConfig {
 	metrics := &bench.MetricsConfig{ServiceVersion: version.Version}
 	if cfg == nil || cfg.Global == nil {
@@ -406,6 +559,8 @@ func printWorkloadHelp(cmd *cobra.Command, description bench.Description) error 
 	output.WriteString("  -d, --driver NAME        Use a driver preset\n")
 	output.WriteString("  -D, --driver-opt K=V     Override a driver field\n")
 	output.WriteString("  -e, --env KEY=VALUE      Set a legacy workload environment value\n")
+	output.WriteString("      --log-level VALUE     Set global log level\n")
+	output.WriteString("      --log-mode VALUE      Set global log output mode\n")
 	output.WriteString("      --steps NAMES        Run only named steps\n")
 	output.WriteString("      --no-steps NAMES     Skip named steps\n")
 	output.WriteString("  -h, --help               Show this help\n")

--- a/cmd/stroppy/commands/run/run_test.go
+++ b/cmd/stroppy/commands/run/run_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
 	_ "github.com/stroppy-io/stroppy/internal/workloads/simple"
@@ -18,6 +19,105 @@ import (
 	"github.com/stroppy-io/stroppy/pkg/config"
 	_ "github.com/stroppy-io/stroppy/pkg/driver/noop"
 )
+
+func unsetLoggerEnv(t *testing.T) {
+	t.Helper()
+
+	oldLevel, hadLevel := os.LookupEnv(envLogLevel)
+	oldMode, hadMode := os.LookupEnv(envLogMode)
+
+	require.NoError(t, os.Unsetenv(envLogLevel))
+	require.NoError(t, os.Unsetenv(envLogMode))
+	t.Cleanup(func() {
+		if hadLevel {
+			require.NoError(t, os.Setenv(envLogLevel, oldLevel))
+		} else {
+			require.NoError(t, os.Unsetenv(envLogLevel))
+		}
+
+		if hadMode {
+			require.NoError(t, os.Setenv(envLogMode, oldMode))
+		} else {
+			require.NoError(t, os.Unsetenv(envLogMode))
+		}
+	})
+}
+
+func TestResolveLoggerSettingsPrecedence(t *testing.T) {
+	t.Setenv(envLogLevel, "error")
+	t.Setenv(envLogMode, "production")
+
+	fileLogger := &config.LoggerConfig{
+		LogLevel: config.LogLevelInfo,
+		LogMode:  config.LogModeDevelopment,
+	}
+
+	tests := []struct {
+		name      string
+		cli       map[string]string
+		legacy    map[string]string
+		wantLevel string
+		wantMode  string
+	}{
+		{
+			name:      "cli independently overrides each field",
+			cli:       map[string]string{loggerLevelParam: "warn"},
+			legacy:    map[string]string{envLogMode: "LOG_MODE_DEVELOPMENT"},
+			wantLevel: "warn",
+			wantMode:  "production",
+		},
+		{
+			name:      "process environment independently overrides legacy and config",
+			legacy:    map[string]string{envLogLevel: "debug", envLogMode: "development"},
+			wantLevel: "error",
+			wantMode:  "production",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			level, err := resolveLogLevel(test.cli, test.legacy, fileLogger)
+			require.NoError(t, err)
+			require.Equal(t, test.wantLevel, level)
+
+			mode, err := resolveLogMode(test.cli, test.legacy, fileLogger)
+			require.NoError(t, err)
+			require.Equal(t, test.wantMode, mode)
+		})
+	}
+}
+
+func TestResolveLoggerSettingsFallbacks(t *testing.T) {
+	unsetLoggerEnv(t)
+
+	level, err := resolveLogLevel(nil, map[string]string{envLogLevel: "LOG_LEVEL_FATAL"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "fatal", level)
+
+	mode, err := resolveLogMode(nil, map[string]string{envLogMode: "0"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "development", mode)
+
+	level, err = resolveLogLevel(nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, defaultLogLevel, level)
+
+	mode, err = resolveLogMode(nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, defaultLogMode, mode)
+}
+
+func TestWithoutLoggerParams(t *testing.T) {
+	inputs := map[string]string{"scale-factor": "1", loggerLevelParam: "debug", loggerModeParam: "development"}
+	require.Equal(t, map[string]string{"scale-factor": "1"}, withoutLoggerParams(inputs))
+
+	wantInputs := map[string]string{
+		"scale-factor":   "1",
+		loggerLevelParam: "debug",
+		loggerModeParam:  "development",
+	}
+	require.Equal(t, wantInputs, inputs)
+}
 
 //nolint:cyclop // one table covers the complete run argument grammar
 func TestParseRunArgs(t *testing.T) {

--- a/docs/jsonschema/run.schema.json
+++ b/docs/jsonschema/run.schema.json
@@ -588,10 +588,15 @@
                 {
                   "enum": [
                     "LOG_LEVEL_DEBUG",
+                    "debug",
                     "LOG_LEVEL_INFO",
+                    "info",
                     "LOG_LEVEL_WARN",
+                    "warn",
                     "LOG_LEVEL_ERROR",
-                    "LOG_LEVEL_FATAL"
+                    "error",
+                    "LOG_LEVEL_FATAL",
+                    "fatal"
                   ],
                   "type": "string"
                 },
@@ -619,7 +624,9 @@
                 {
                   "enum": [
                     "LOG_MODE_DEVELOPMENT",
-                    "LOG_MODE_PRODUCTION"
+                    "development",
+                    "LOG_MODE_PRODUCTION",
+                    "production"
                   ],
                   "type": "string"
                 },
@@ -644,10 +651,15 @@
                 {
                   "enum": [
                     "LOG_LEVEL_DEBUG",
+                    "debug",
                     "LOG_LEVEL_INFO",
+                    "info",
                     "LOG_LEVEL_WARN",
+                    "warn",
                     "LOG_LEVEL_ERROR",
-                    "LOG_LEVEL_FATAL"
+                    "error",
+                    "LOG_LEVEL_FATAL",
+                    "fatal"
                   ],
                   "type": "string"
                 },
@@ -675,7 +687,9 @@
                 {
                   "enum": [
                     "LOG_MODE_DEVELOPMENT",
-                    "LOG_MODE_PRODUCTION"
+                    "development",
+                    "LOG_MODE_PRODUCTION",
+                    "production"
                   ],
                   "type": "string"
                 },

--- a/internal/jsonschema-gen/main.go
+++ b/internal/jsonschema-gen/main.go
@@ -315,9 +315,9 @@ func aliasCollision(canonical, alias string) map[string]any {
 func logLevelNames() []string {
 	values := config.LogLevelValues()
 
-	names := make([]string, len(values))
-	for index, value := range values {
-		names[index] = value.String()
+	names := make([]string, 0, len(values)+len(values))
+	for _, value := range values {
+		names = append(names, value.String(), value.Short())
 	}
 
 	return names
@@ -326,9 +326,9 @@ func logLevelNames() []string {
 func logModeNames() []string {
 	values := config.LogModeValues()
 
-	names := make([]string, len(values))
-	for index, value := range values {
-		names[index] = value.String()
+	names := make([]string, 0, len(values)+len(values))
+	for _, value := range values {
+		names = append(names, value.String(), value.Short())
 	}
 
 	return names

--- a/internal/jsonschema-gen/main_test.go
+++ b/internal/jsonschema-gen/main_test.go
@@ -77,12 +77,19 @@ func TestBuildSchemaDescribesAcceptedScalarForms(t *testing.T) {
 	logForms := anyOf(t, logLevel)
 	require.Equal(t, "string", object(t, logForms[0])["type"])
 	require.Equal(t, []string{
-		"LOG_LEVEL_DEBUG",
-		"LOG_LEVEL_INFO",
-		"LOG_LEVEL_WARN",
-		"LOG_LEVEL_ERROR",
-		"LOG_LEVEL_FATAL",
+		"LOG_LEVEL_DEBUG", "debug",
+		"LOG_LEVEL_INFO", "info",
+		"LOG_LEVEL_WARN", "warn",
+		"LOG_LEVEL_ERROR", "error",
+		"LOG_LEVEL_FATAL", "fatal",
 	}, stringSlice(t, object(t, logForms[0])["enum"]))
+	logMode := firstAnyOf(t, loggerProperties["logMode"])
+	modeForms := anyOf(t, logMode)
+	require.Equal(t, []string{
+		"LOG_MODE_DEVELOPMENT", "development",
+		"LOG_MODE_PRODUCTION", "production",
+	}, stringSlice(t, object(t, modeForms[0])["enum"]))
+
 	require.Equal(t, "integer", object(t, logForms[1])["type"])
 	require.Equal(t, []int{0, 1, 2, 3, 4}, intSlice(t, object(t, logForms[1])["enum"]))
 }

--- a/internal/runner/config_file.go
+++ b/internal/runner/config_file.go
@@ -21,6 +21,7 @@ var errConfigEnvCollision = errors.New("config env keys collide case-insensitive
 
 // LoadedConfig keeps the run config separate from typed parameter scopes.
 type LoadedConfig struct {
+	Path      string
 	RunConfig *config.RunConfig
 	Run       map[string]json.RawMessage
 	Params    map[string]json.RawMessage
@@ -65,12 +66,18 @@ func LoadRunConfig(path string) (*LoadedConfig, bool, error) {
 		return nil, false, fmt.Errorf("parsing config file %q: %w", path, err)
 	}
 
-	if cfg.Global != nil && cfg.Global.Logger != nil {
-		logger.NewFromConfig(configLogger(cfg.Global.Logger))
+	return &LoadedConfig{Path: path, RunConfig: cfg, Run: runParams, Params: workloadParams}, true, nil
+}
+
+// LogConfigFile emits config-file diagnostics after logger initialization.
+func LogConfigFile(loaded *LoadedConfig) {
+	if loaded == nil || loaded.RunConfig == nil {
+		return
 	}
 
+	cfg := loaded.RunConfig
 	lg := logger.Global().Named("config_file")
-	lg.Info("Loaded config file", zap.String("path", path))
+	lg.Info("Loaded config file", zap.String("path", loaded.Path))
 
 	if cfg.GetScript() != "" {
 		lg.Debug("Config file script", zap.String("script", cfg.GetScript()))
@@ -78,8 +85,8 @@ func LoadRunConfig(path string) (*LoadedConfig, bool, error) {
 
 	if len(cfg.Env) > 0 {
 		keys := make([]string, 0, len(cfg.Env))
-		for k := range cfg.Env {
-			keys = append(keys, k)
+		for key := range cfg.Env {
+			keys = append(keys, key)
 		}
 
 		sort.Strings(keys)
@@ -90,39 +97,9 @@ func LoadRunConfig(path string) (*LoadedConfig, bool, error) {
 		lg.Debug("Config file driver",
 			zap.Uint32("index", idx),
 			zap.String("type", drv.GetDriverType()),
-			zap.String("url", drv.GetURL()),
+			zap.String("url", logger.RedactDSN(drv.GetURL())),
 		)
 	}
-
-	return &LoadedConfig{RunConfig: cfg, Run: runParams, Params: workloadParams}, true, nil
-}
-
-func configLogger(cfg *config.LoggerConfig) *logger.Config {
-	level := "debug"
-
-	switch cfg.LogLevel {
-	case config.LogLevelDebug:
-		level = "debug"
-	case config.LogLevelInfo:
-		level = "info"
-	case config.LogLevelWarn:
-		level = "warn"
-	case config.LogLevelError:
-		level = "error"
-	case config.LogLevelFatal:
-		level = "fatal"
-	}
-
-	mode := logger.DevelopmentMod
-
-	switch cfg.LogMode {
-	case config.LogModeDevelopment:
-		mode = logger.DevelopmentMod
-	case config.LogModeProduction:
-		mode = logger.ProductionMod
-	}
-
-	return &logger.Config{LogLevel: level, LogMod: mode}
 }
 
 func normalizeRunConfigEnv(runConfig *config.RunConfig) error {

--- a/internal/runner/config_file_test.go
+++ b/internal/runner/config_file_test.go
@@ -2,17 +2,46 @@ package runner_test
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stroppy-io/stroppy/internal/runner"
+	"github.com/stroppy-io/stroppy/pkg/common/logger"
 	"github.com/stroppy-io/stroppy/pkg/config"
 )
+
+func TestLoadRunConfigIsSilentUntilLogged(t *testing.T) {
+	core, observed := observer.New(zap.DebugLevel)
+
+	require.NoError(t, logger.Init("debug", "development", zap.WrapCore(func(zapcore.Core) zapcore.Core {
+		return core
+	})))
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+		"drivers":{"0":{"driverType":"postgres","url":"postgres://user:secret@host/db?token=token"}}
+	}`), 0o600))
+
+	loaded, found, err := runner.LoadRunConfig(path)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Empty(t, observed.All())
+
+	runner.LogConfigFile(loaded)
+
+	entries := observed.All()
+	require.Len(t, entries, 2)
+	require.Equal(t, "Loaded config file", entries[0].Message)
+	require.NotContains(t, entries[1].ContextMap()["url"], "secret")
+	require.NotContains(t, entries[1].ContextMap()["url"], "=token")
+}
 
 func TestLoadRunConfig_ExplicitPath(t *testing.T) {
 	t.Run("valid file", func(t *testing.T) {
@@ -261,59 +290,6 @@ func TestLoadRunConfigStrictErrors(t *testing.T) {
 			_, _, err := runner.LoadRunConfig(path)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), test.path)
-		})
-	}
-}
-
-func TestLoadRunConfigLogger(t *testing.T) {
-	const configPathEnv = "STROPPY_TEST_CONFIG_PATH"
-
-	if path := os.Getenv(configPathEnv); path != "" {
-		_, _, err := runner.LoadRunConfig(path)
-		require.NoError(t, err)
-
-		return
-	}
-
-	tests := []struct {
-		name        string
-		logger      string
-		wantLog     bool
-		wantJSONLog bool
-	}{
-		{
-			name:   "error suppresses loader info",
-			logger: `{"logLevel":"LOG_LEVEL_ERROR","logMode":"LOG_MODE_DEVELOPMENT"}`,
-		},
-		{
-			name:        "info production emits JSON",
-			logger:      `{"logLevel":"LOG_LEVEL_INFO","logMode":"LOG_MODE_PRODUCTION"}`,
-			wantLog:     true,
-			wantJSONLog: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			path := filepath.Join(t.TempDir(), "config.json")
-			require.NoError(t, os.WriteFile(
-				path,
-				[]byte(`{"global":{"logger":`+test.logger+`}}`),
-				0o600,
-			))
-
-			cmd := exec.Command(os.Args[0], "-test.run=^TestLoadRunConfigLogger$")
-
-			cmd.Env = append(os.Environ(), configPathEnv+"="+path)
-			output, err := cmd.CombinedOutput()
-			require.NoError(t, err, string(output))
-
-			gotLog := strings.Contains(string(output), "Loaded config file")
-			assert.Equal(t, test.wantLog, gotLog, string(output))
-
-			if test.wantJSONLog {
-				assert.Contains(t, string(output), `"level":"info"`)
-			}
 		})
 	}
 }

--- a/internal/runner/config_file_test.go
+++ b/internal/runner/config_file_test.go
@@ -26,7 +26,8 @@ func TestLoadRunConfigIsSilentUntilLogged(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "config.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{
-		"drivers":{"0":{"driverType":"postgres","url":"postgres://user:secret@host/db?token=token"}}
+		"drivers":{"0":{"driverType":"postgres","url":"host=localhost user=bench password=dsn-secret`+
+		` sslmode=require token=token-secret client_secret=client-secret"}}
 	}`), 0o600))
 
 	loaded, found, err := runner.LoadRunConfig(path)
@@ -39,8 +40,15 @@ func TestLoadRunConfigIsSilentUntilLogged(t *testing.T) {
 	entries := observed.All()
 	require.Len(t, entries, 2)
 	require.Equal(t, "Loaded config file", entries[0].Message)
-	require.NotContains(t, entries[1].ContextMap()["url"], "secret")
-	require.NotContains(t, entries[1].ContextMap()["url"], "=token")
+
+	url := entries[1].ContextMap()["url"]
+	for _, secret := range []string{"dsn-secret", "token-secret", "client-secret"} {
+		require.NotContains(t, url, secret)
+	}
+
+	for _, option := range []string{"host=localhost", "user=bench", "sslmode=require"} {
+		require.Contains(t, url, option)
+	}
 }
 
 func TestLoadRunConfig_ExplicitPath(t *testing.T) {

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -285,42 +285,32 @@ func redactMySQL(dsn string) (redacted string, ok bool) {
 	return formatted, true
 }
 
-func hasMySQLStructure(dsn string) bool {
-	if !strings.Contains(dsn, "/") {
-		return false
+type mysqlEnvelope struct {
+	userinfoEnd int
+	valid       bool
+}
+
+func parseMySQLEnvelope(dsn string) mysqlEnvelope {
+	end := len(dsn)
+	if queryStart := strings.IndexByte(dsn, '?'); queryStart >= 0 {
+		end = queryStart
 	}
 
-	return hasMySQLUsernameEnvelope(dsn) || hasCredentialFreeMySQLEnvelope(dsn)
-}
-
-func hasCredentialFreeMySQLEnvelope(dsn string) bool {
-	return !strings.Contains(dsn, "@") && looksLikeMySQLEndpointSuffix(dsn, 0)
-}
-
-func hasMySQLUsernameEnvelope(dsn string) bool {
-	for at := len(dsn) - 1; at >= 0; at-- {
-		if dsn[at] == '@' && looksLikeMySQLEndpointSuffix(dsn, at+1) {
-			return true
+	for at := end - 1; at >= 0; at-- {
+		if dsn[at] == '@' && isMySQLEndpoint(dsn, at+1, end) {
+			return mysqlEnvelope{userinfoEnd: at, valid: true}
 		}
 	}
 
-	return false
-}
-
-func hasMySQLPasswordEnvelope(dsn string) bool {
-	for at := len(dsn) - 1; at >= 0; at-- {
-		if dsn[at] != '@' || !looksLikeMySQLEndpointSuffix(dsn, at+1) {
-			continue
-		}
-
-		return strings.IndexByte(dsn[:at], ':') >= 0
+	if isMySQLEndpoint(dsn, 0, end) {
+		return mysqlEnvelope{userinfoEnd: -1, valid: true}
 	}
 
-	return false
+	return mysqlEnvelope{userinfoEnd: -1}
 }
 
-func looksLikeMySQLEndpointSuffix(dsn string, start int) bool {
-	if start == len(dsn) {
+func isMySQLEndpoint(dsn string, start, end int) bool {
+	if start >= end {
 		return false
 	}
 
@@ -328,20 +318,30 @@ func looksLikeMySQLEndpointSuffix(dsn string, start int) bool {
 		return true
 	}
 
-	for index := start; index < len(dsn); index++ {
-		switch dsn[index] {
-		case '(', '[', '/':
-			return true
-		case '?', '#', '@':
+	suffix := dsn[start:end]
+	open := strings.IndexByte(suffix, '(')
+
+	slash := strings.IndexByte(suffix, '/')
+	if open >= 0 && (slash < 0 || open < slash) {
+		closing := strings.IndexByte(suffix[open+1:], ')')
+		if closing < 0 {
 			return false
-		default:
-			if isASCIIWhitespace(dsn[index]) {
-				return false
-			}
 		}
+
+		return open+closing+2 < len(suffix) && suffix[open+closing+2] == '/'
 	}
 
-	return false
+	return slash > 0
+}
+
+func hasMySQLStructure(dsn string) bool {
+	return parseMySQLEnvelope(dsn).valid
+}
+
+func hasMySQLPasswordEnvelope(dsn string) bool {
+	envelope := parseMySQLEnvelope(dsn)
+
+	return envelope.valid && envelope.userinfoEnd >= 0 && strings.IndexByte(dsn[:envelope.userinfoEnd], ':') >= 0
 }
 
 type conninfoAssignment struct {

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -148,7 +148,7 @@ func RedactDSN(dsn string) string {
 		return dsn
 	}
 
-	return redactUserinfo(redactQueryValues(dsn))
+	return redactUserinfo(redactKeywordValues(redactQueryValues(dsn)))
 }
 
 func redactQueryValues(dsn string) string {
@@ -175,6 +175,125 @@ func redactQueryValues(dsn string) string {
 	}
 
 	return dsn[:queryStart+1] + strings.Join(parts, "&") + dsn[queryEnd:]
+}
+
+type conninfoAssignment struct {
+	key                  string
+	valueStart, valueEnd int
+	next                 int
+}
+
+func redactKeywordValues(dsn string) string {
+	var result strings.Builder
+
+	lastRedaction := 0
+
+	for index := 0; index < len(dsn); {
+		assignment := nextConninfoAssignment(dsn, index)
+		index = assignment.next
+
+		if !isSecretKey(assignment.key) {
+			continue
+		}
+
+		result.WriteString(dsn[lastRedaction:assignment.valueStart])
+		result.WriteString(redactedSecret)
+
+		lastRedaction = assignment.valueEnd
+	}
+
+	if lastRedaction == 0 {
+		return dsn
+	}
+
+	result.WriteString(dsn[lastRedaction:])
+
+	return result.String()
+}
+
+func nextConninfoAssignment(dsn string, index int) conninfoAssignment {
+	index = skipConninfoSpaces(dsn, index)
+
+	keyStart := index
+	keyEnd := conninfoKeyEnd(dsn, index)
+	index = skipConninfoSpaces(dsn, keyEnd)
+
+	if keyEnd == keyStart || index == len(dsn) || dsn[index] != '=' || !isConninfoKey(dsn[keyStart:keyEnd]) {
+		return conninfoAssignment{next: skipConninfoToken(dsn, index)}
+	}
+
+	valueStart := skipConninfoSpaces(dsn, index+1)
+	valueEnd := conninfoValueEnd(dsn, valueStart)
+
+	return conninfoAssignment{
+		key:        dsn[keyStart:keyEnd],
+		valueStart: valueStart,
+		valueEnd:   valueEnd,
+		next:       valueEnd,
+	}
+}
+
+func skipConninfoSpaces(dsn string, index int) int {
+	for index < len(dsn) && unicode.IsSpace(rune(dsn[index])) {
+		index++
+	}
+
+	return index
+}
+
+func conninfoKeyEnd(dsn string, index int) int {
+	for index < len(dsn) && !unicode.IsSpace(rune(dsn[index])) && dsn[index] != '=' {
+		index++
+	}
+
+	return index
+}
+
+func skipConninfoToken(dsn string, index int) int {
+	for index < len(dsn) && !unicode.IsSpace(rune(dsn[index])) {
+		index++
+	}
+
+	return index
+}
+
+func isConninfoKey(key string) bool {
+	for _, r := range key {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '-' {
+			return false
+		}
+	}
+
+	return key != ""
+}
+
+func conninfoValueEnd(dsn string, start int) int {
+	if start == len(dsn) || dsn[start] != '\'' {
+		for start < len(dsn) && !unicode.IsSpace(rune(dsn[start])) {
+			start++
+		}
+
+		return start
+	}
+
+	for index := start + 1; index < len(dsn); index++ {
+		if dsn[index] == '\\' && index+1 < len(dsn) {
+			index++
+
+			continue
+		}
+
+		if dsn[index] == '\'' {
+			index++
+			for index < len(dsn) && !unicode.IsSpace(rune(dsn[index])) {
+				index++
+			}
+
+			return index
+		}
+	}
+
+	return len(dsn)
 }
 
 func isSecretKey(key string) bool {
@@ -284,14 +403,14 @@ func fromHex(value byte) (byte, bool) {
 }
 
 func redactUserinfo(dsn string) string {
-	end := len(dsn)
-	if queryStart := strings.IndexByte(dsn, '?'); queryStart >= 0 {
-		end = queryStart
+	start := 0
+	if scheme := strings.Index(dsn, "://"); scheme >= 0 {
+		start = scheme + len("://")
 	}
 
-	start := 0
-	if scheme := strings.Index(dsn[:end], "://"); scheme >= 0 {
-		start = scheme + len("://")
+	end := authorityEnd(dsn, start)
+	if start == 0 && strings.Contains(dsn[:end], "=") {
+		return dsn
 	}
 
 	at := strings.LastIndexByte(dsn[start:end], '@')
@@ -311,4 +430,12 @@ func redactUserinfo(dsn string) string {
 	colon += start
 
 	return dsn[:colon+1] + redactedSecret + dsn[at:]
+}
+
+func authorityEnd(dsn string, start int) int {
+	if delimiter := strings.IndexAny(dsn[start:], "/?#"); delimiter >= 0 {
+		return start + delimiter
+	}
+
+	return len(dsn)
 }

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -148,39 +148,21 @@ func RedactDSN(dsn string) string {
 		return dsn
 	}
 
-	switch {
-	case hasURIScheme(dsn):
-		return redactURI(dsn)
-	case isConninfoDSN(dsn):
-		return redactConninfo(dsn)
-	default:
-		return redactMySQLDSN(dsn)
-	}
+	redacted := redactAuthorityUserinfo(dsn)
+	redacted = redactMySQLUserinfo(redacted)
+	redacted = redactConninfo(redacted)
+
+	return redactQueryValues(redacted)
 }
 
-func hasURIScheme(dsn string) bool {
+func redactAuthorityUserinfo(dsn string) string {
 	schemeEnd := strings.Index(dsn, "://")
-	if schemeEnd <= 0 || !unicode.IsLetter(rune(dsn[0])) {
-		return false
+	if schemeEnd < 0 {
+		return dsn
 	}
 
-	for _, r := range dsn[1:schemeEnd] {
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '+' && r != '-' && r != '.' {
-			return false
-		}
-	}
-
-	return true
-}
-
-func redactURI(dsn string) string {
-	return redactURIUserinfo(redactQueryValues(dsn))
-}
-
-func redactURIUserinfo(dsn string) string {
-	schemeEnd := strings.Index(dsn, "://")
 	start := schemeEnd + len("://")
-	end := uriAuthorityEnd(dsn, start)
+	end := authorityEnd(dsn, start)
 
 	at := strings.LastIndexByte(dsn[start:end], '@')
 	if at < 0 {
@@ -197,7 +179,7 @@ func redactURIUserinfo(dsn string) string {
 	return dsn[:start+colon+1] + redactedSecret + dsn[at:]
 }
 
-func uriAuthorityEnd(dsn string, start int) int {
+func authorityEnd(dsn string, start int) int {
 	if delimiter := strings.IndexAny(dsn[start:], "/?#"); delimiter >= 0 {
 		return start + delimiter
 	}
@@ -209,12 +191,16 @@ func isConninfoDSN(dsn string) bool {
 	return nextConninfoAssignment(dsn, 0).key != ""
 }
 
-func redactMySQLDSN(dsn string) string {
-	return redactQueryValues(redactMySQLUserinfo(dsn))
-}
-
 func redactMySQLUserinfo(dsn string) string {
+	if strings.Contains(dsn, "://") {
+		return dsn
+	}
+
 	at := mysqlUserinfoEnd(dsn)
+	if at < 0 {
+		at = malformedMySQLUserinfoEnd(dsn)
+	}
+
 	if at < 0 {
 		return dsn
 	}
@@ -231,7 +217,7 @@ func mysqlUserinfoEnd(dsn string) int {
 	userinfoEnd := -1
 
 	for index := range dsn {
-		if dsn[index] == '@' && isMySQLProtocolDelimiter(dsn, index+1) {
+		if dsn[index] == '@' && hasMySQLEndpoint(dsn, index+1) {
 			userinfoEnd = index
 		}
 	}
@@ -239,27 +225,83 @@ func mysqlUserinfoEnd(dsn string) int {
 	return userinfoEnd
 }
 
-func isMySQLProtocolDelimiter(dsn string, start int) bool {
-	if start == len(dsn) || dsn[start] == '/' {
-		return start < len(dsn)
-	}
-
-	end := start
-	for end < len(dsn) && (unicode.IsLetter(rune(dsn[end])) || unicode.IsDigit(rune(dsn[end]))) {
-		end++
-	}
-
-	if end == start {
+func hasMySQLEndpoint(dsn string, start int) bool {
+	if start == len(dsn) {
 		return false
 	}
 
-	if end < len(dsn) && dsn[end] == '(' {
+	if dsn[start] == '/' {
 		return true
 	}
 
-	protocol := dsn[start:end]
+	protocolEnd := mysqlProtocolEnd(dsn, start)
+	if protocolEnd < 0 || protocolEnd+1 >= len(dsn) {
+		return false
+	}
 
-	return (protocol == "tcp" || protocol == "unix") && (end == len(dsn) || dsn[end] == '/')
+	addressEnd := strings.IndexByte(dsn[protocolEnd+1:], ')')
+	if addressEnd < 0 {
+		return false
+	}
+
+	addressEnd += protocolEnd + 1
+
+	return addressEnd+1 < len(dsn) && dsn[addressEnd+1] == '/'
+}
+
+func mysqlProtocolEnd(dsn string, start int) int {
+	for index := start; index < len(dsn); index++ {
+		switch dsn[index] {
+		case '(':
+			if index > start {
+				return index
+			}
+		case '/', '?', '#', '@':
+			return -1
+		default:
+			if unicode.IsSpace(rune(dsn[index])) {
+				return -1
+			}
+		}
+	}
+
+	return -1
+}
+
+func malformedMySQLUserinfoEnd(dsn string) int {
+	colon := strings.IndexByte(dsn, ':')
+	if colon < 0 {
+		return -1
+	}
+
+	at := strings.LastIndexByte(dsn[colon+1:], '@')
+	if at < 0 {
+		return -1
+	}
+
+	at += colon + 1
+	if isConninfoDSN(dsn) && !looksLikeMySQLEndpoint(dsn, at+1) {
+		return -1
+	}
+
+	return at
+}
+
+func looksLikeMySQLEndpoint(dsn string, start int) bool {
+	for index := start; index < len(dsn); index++ {
+		switch dsn[index] {
+		case '(', '[', '/':
+			return true
+		case '?', '#', '@':
+			return false
+		default:
+			if unicode.IsSpace(rune(dsn[index])) {
+				return false
+			}
+		}
+	}
+
+	return false
 }
 
 func redactQueryValues(dsn string) string {
@@ -330,7 +372,7 @@ func nextConninfoAssignment(dsn string, index int) conninfoAssignment {
 	index = skipConninfoSpaces(dsn, keyEnd)
 
 	if keyEnd == keyStart || index == len(dsn) || dsn[index] != '=' || !isConninfoKey(dsn[keyStart:keyEnd]) {
-		return conninfoAssignment{next: skipConninfoToken(dsn, index)}
+		return conninfoAssignment{next: skipConninfoToken(dsn, keyStart)}
 	}
 
 	valueStart := skipConninfoSpaces(dsn, index+1)

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -286,7 +286,15 @@ func redactMySQL(dsn string) (redacted string, ok bool) {
 }
 
 func hasMySQLStructure(dsn string) bool {
-	return strings.Contains(dsn, "/") && hasMySQLUsernameEnvelope(dsn)
+	if !strings.Contains(dsn, "/") {
+		return false
+	}
+
+	return hasMySQLUsernameEnvelope(dsn) || hasCredentialFreeMySQLEnvelope(dsn)
+}
+
+func hasCredentialFreeMySQLEnvelope(dsn string) bool {
+	return !strings.Contains(dsn, "@") && looksLikeMySQLEndpointSuffix(dsn, 0)
 }
 
 func hasMySQLUsernameEnvelope(dsn string) bool {

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -286,7 +286,17 @@ func redactMySQL(dsn string) (redacted string, ok bool) {
 }
 
 func hasMySQLStructure(dsn string) bool {
-	return strings.Contains(dsn, "/") && hasMySQLPasswordEnvelope(dsn)
+	return strings.Contains(dsn, "/") && hasMySQLUsernameEnvelope(dsn)
+}
+
+func hasMySQLUsernameEnvelope(dsn string) bool {
+	for at := len(dsn) - 1; at >= 0; at-- {
+		if dsn[at] == '@' && looksLikeMySQLEndpointSuffix(dsn, at+1) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func hasMySQLPasswordEnvelope(dsn string) bool {

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -3,10 +3,11 @@ package logger
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync/atomic"
-	"unicode"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -135,375 +136,337 @@ func NewStructLogger(name string) StructLogger {
 }
 
 const (
-	redactedSecret           = "xxxxx"
-	queryDecodePasses        = 2
-	percentEscapeDigits      = 2
-	hexAlphabetBase     byte = 10
+	redactedSecret = "xxxxx"
+	redactedDSN    = "<redacted-dsn>"
 )
 
-// RedactDSN masks credentials in database URLs and DSNs while preserving the
-// endpoint, database path, and non-secret query options.
+// RedactDSN masks credentials in supported connection-string grammars. Inputs
+// that cannot be classified unambiguously never appear in diagnostics.
 func RedactDSN(dsn string) string {
-	if dsn == "" {
+	if dsn == "" || dsn == redactedDSN {
 		return dsn
 	}
 
-	redacted := redactAuthorityUserinfo(dsn)
-	redacted = redactMySQLUserinfo(redacted)
-	redacted = redactConninfo(redacted)
-
-	return redactQueryValues(redacted)
-}
-
-func redactAuthorityUserinfo(dsn string) string {
-	schemeEnd := strings.Index(dsn, "://")
-	if schemeEnd < 0 {
-		return dsn
-	}
-
-	start := schemeEnd + len("://")
-	end := authorityEnd(dsn, start)
-
-	at := strings.LastIndexByte(dsn[start:end], '@')
-	if at < 0 {
-		return dsn
-	}
-
-	at += start
-
-	colon := strings.IndexByte(dsn[start:at], ':')
-	if colon < 0 {
-		return dsn
-	}
-
-	return dsn[:start+colon+1] + redactedSecret + dsn[at:]
-}
-
-func authorityEnd(dsn string, start int) int {
-	if delimiter := strings.IndexAny(dsn[start:], "/?#"); delimiter >= 0 {
-		return start + delimiter
-	}
-
-	return len(dsn)
-}
-
-func isConninfoDSN(dsn string) bool {
-	return nextConninfoAssignment(dsn, 0).key != ""
-}
-
-func redactMySQLUserinfo(dsn string) string {
-	if strings.Contains(dsn, "://") {
-		return dsn
-	}
-
-	at := mysqlUserinfoEnd(dsn)
-	if at < 0 {
-		at = malformedMySQLUserinfoEnd(dsn)
-	}
-
-	if at < 0 {
-		return dsn
-	}
-
-	colon := strings.IndexByte(dsn[:at], ':')
-	if colon < 0 {
-		return dsn
-	}
-
-	return dsn[:colon+1] + redactedSecret + dsn[at:]
-}
-
-func mysqlUserinfoEnd(dsn string) int {
-	userinfoEnd := -1
-
-	for index := range dsn {
-		if dsn[index] == '@' && hasMySQLEndpoint(dsn, index+1) {
-			userinfoEnd = index
+	if hasLeadingSchemeLike(dsn) {
+		if !hasLeadingRFCASCIIScheme(dsn) {
+			return redactedDSN
 		}
-	}
 
-	return userinfoEnd
-}
-
-func hasMySQLEndpoint(dsn string, start int) bool {
-	if start == len(dsn) {
-		return false
-	}
-
-	if dsn[start] == '/' {
-		return true
-	}
-
-	protocolEnd := mysqlProtocolEnd(dsn, start)
-	if protocolEnd < 0 || protocolEnd+1 >= len(dsn) {
-		return false
-	}
-
-	addressEnd := strings.IndexByte(dsn[protocolEnd+1:], ')')
-	if addressEnd < 0 {
-		return false
-	}
-
-	addressEnd += protocolEnd + 1
-
-	return addressEnd+1 < len(dsn) && dsn[addressEnd+1] == '/'
-}
-
-func mysqlProtocolEnd(dsn string, start int) int {
-	for index := start; index < len(dsn); index++ {
-		switch dsn[index] {
-		case '(':
-			if index > start {
-				return index
-			}
-		case '/', '?', '#', '@':
-			return -1
-		default:
-			if unicode.IsSpace(rune(dsn[index])) {
-				return -1
-			}
+		redacted, ok := redactURI(dsn)
+		if !ok {
+			return redactedDSN
 		}
+
+		if _, mysqlOK := redactMySQL(dsn); mysqlOK {
+			return redactedDSN
+		}
+
+		return redacted
 	}
 
-	return -1
+	if redacted, ok := redactMySQL(dsn); ok {
+		return redacted
+	}
+
+	assignments, ok := parseConninfo(dsn)
+	if ok {
+		if hasAmbiguousMySQLCredentialEnvelope(dsn) {
+			return redactedDSN
+		}
+
+		return redactConninfo(dsn, assignments)
+	}
+
+	return redactedDSN
 }
 
-func malformedMySQLUserinfoEnd(dsn string) int {
-	colon := strings.IndexByte(dsn, ':')
-	if colon < 0 {
-		return -1
+func hasLeadingSchemeLike(dsn string) bool {
+	separator := strings.Index(dsn, "://")
+	if separator <= 0 {
+		return false
 	}
 
-	at := strings.LastIndexByte(dsn[colon+1:], '@')
-	if at < 0 {
-		return -1
-	}
-
-	at += colon + 1
-	if isConninfoDSN(dsn) && !looksLikeMySQLEndpoint(dsn, at+1) {
-		return -1
-	}
-
-	return at
+	return !strings.ContainsAny(dsn[:separator], ":@/?#")
 }
 
-func looksLikeMySQLEndpoint(dsn string, start int) bool {
-	for index := start; index < len(dsn); index++ {
-		switch dsn[index] {
-		case '(', '[', '/':
-			return true
-		case '?', '#', '@':
+func hasLeadingRFCASCIIScheme(dsn string) bool {
+	separator := strings.Index(dsn, "://")
+	if separator <= 0 || !isASCIIAlpha(dsn[0]) {
+		return false
+	}
+
+	for index := 1; index < separator; index++ {
+		value := dsn[index]
+		if !isASCIIAlpha(value) && !isASCIIDigit(value) && value != '+' && value != '-' && value != '.' {
 			return false
-		default:
-			if unicode.IsSpace(rune(dsn[index])) {
-				return false
+		}
+	}
+
+	return true
+}
+
+func redactURI(dsn string) (string, bool) {
+	parsed, err := url.Parse(dsn)
+	if err != nil || parsed.Opaque != "" || parsed.Host == "" {
+		return "", false
+	}
+
+	values, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return "", false
+	}
+
+	for key, values := range values {
+		secret, certain := isSecretQueryKey(key)
+		if !certain {
+			return "", false
+		}
+
+		if secret {
+			for index := range values {
+				values[index] = redactedSecret
 			}
 		}
 	}
 
-	return false
-}
-
-func redactQueryValues(dsn string) string {
-	queryStart := strings.IndexByte(dsn, '?')
-	if queryStart < 0 {
-		return dsn
-	}
-
-	queryEnd := strings.IndexByte(dsn[queryStart+1:], '#')
-	if queryEnd >= 0 {
-		queryEnd += queryStart + 1
-	} else {
-		queryEnd = len(dsn)
-	}
-
-	query := dsn[queryStart+1 : queryEnd]
-
-	parts := strings.Split(query, "&")
-	for index, part := range parts {
-		key, _, hasValue := strings.Cut(part, "=")
-		if hasValue && isSecretKey(key) {
-			parts[index] = key + "=" + redactedSecret
+	parsed.RawQuery = values.Encode()
+	if parsed.User != nil {
+		if _, present := parsed.User.Password(); present {
+			parsed.User = url.UserPassword(parsed.User.Username(), redactedSecret)
 		}
 	}
 
-	return dsn[:queryStart+1] + strings.Join(parts, "&") + dsn[queryEnd:]
+	return parsed.Redacted(), true
+}
+
+func redactMySQL(dsn string) (redacted string, ok bool) {
+	defer func() {
+		if recover() != nil {
+			redacted, ok = "", false
+		}
+	}()
+
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return "", false
+	}
+
+	if cfg.Passwd != "" {
+		cfg.Passwd = redactedSecret
+	} else if hasPasswordEnvelope(dsn) {
+		return "", false
+	}
+
+	for key := range cfg.Params {
+		if isSecretName(key) {
+			cfg.Params[key] = redactedSecret
+		}
+	}
+
+	formatted := cfg.FormatDSN()
+	if hasPasswordEnvelope(dsn) && !strings.Contains(formatted, redactedSecret) {
+		return "", false
+	}
+
+	return formatted, true
+}
+
+func hasPasswordEnvelope(dsn string) bool {
+	colon := strings.IndexByte(dsn, ':')
+	at := strings.LastIndexByte(dsn, '@')
+
+	return colon >= 0 && colon < at
+}
+
+func hasAmbiguousMySQLCredentialEnvelope(dsn string) bool {
+	if !hasPasswordEnvelope(dsn) {
+		return false
+	}
+
+	at := strings.LastIndexByte(dsn, '@')
+
+	return strings.ContainsAny(dsn[at+1:], "([")
 }
 
 type conninfoAssignment struct {
 	key                  string
 	valueStart, valueEnd int
-	next                 int
 }
 
-func redactConninfo(dsn string) string {
-	var result strings.Builder
+func parseConninfo(dsn string) ([]conninfoAssignment, bool) {
+	index := skipASCIIWhitespace(dsn, 0)
+	if index == len(dsn) {
+		return nil, false
+	}
 
-	lastRedaction := 0
+	assignments := make([]conninfoAssignment, 0)
 
-	for index := 0; index < len(dsn); {
-		assignment := nextConninfoAssignment(dsn, index)
-		index = assignment.next
+	for index < len(dsn) {
+		keyStart := index
+		for index < len(dsn) && dsn[index] != '=' && !isASCIIWhitespace(dsn[index]) {
+			if !isConninfoKeyByte(dsn[index]) {
+				return nil, false
+			}
 
-		if !isSecretKey(assignment.key) {
-			continue
+			index++
 		}
 
-		result.WriteString(dsn[lastRedaction:assignment.valueStart])
-		result.WriteString(redactedSecret)
+		if index == keyStart || index == len(dsn) || dsn[index] != '=' {
+			return nil, false
+		}
 
-		lastRedaction = assignment.valueEnd
-	}
-
-	if lastRedaction == 0 {
-		return dsn
-	}
-
-	result.WriteString(dsn[lastRedaction:])
-
-	return result.String()
-}
-
-func nextConninfoAssignment(dsn string, index int) conninfoAssignment {
-	index = skipConninfoSpaces(dsn, index)
-
-	keyStart := index
-	keyEnd := conninfoKeyEnd(dsn, index)
-	index = skipConninfoSpaces(dsn, keyEnd)
-
-	if keyEnd == keyStart || index == len(dsn) || dsn[index] != '=' || !isConninfoKey(dsn[keyStart:keyEnd]) {
-		return conninfoAssignment{next: skipConninfoToken(dsn, keyStart)}
-	}
-
-	valueStart := skipConninfoSpaces(dsn, index+1)
-	valueEnd := conninfoValueEnd(dsn, valueStart)
-
-	return conninfoAssignment{
-		key:        dsn[keyStart:keyEnd],
-		valueStart: valueStart,
-		valueEnd:   valueEnd,
-		next:       valueEnd,
-	}
-}
-
-func skipConninfoSpaces(dsn string, index int) int {
-	for index < len(dsn) && unicode.IsSpace(rune(dsn[index])) {
+		key := dsn[keyStart:index]
 		index++
-	}
 
-	return index
-}
+		valueStart := index
 
-func conninfoKeyEnd(dsn string, index int) int {
-	for index < len(dsn) && !unicode.IsSpace(rune(dsn[index])) && dsn[index] != '=' {
-		index++
-	}
-
-	return index
-}
-
-func skipConninfoToken(dsn string, index int) int {
-	for index < len(dsn) && !unicode.IsSpace(rune(dsn[index])) {
-		index++
-	}
-
-	return index
-}
-
-func isConninfoKey(key string) bool {
-	for _, r := range key {
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '-' {
-			return false
-		}
-	}
-
-	return key != ""
-}
-
-func conninfoValueEnd(dsn string, start int) int {
-	if start == len(dsn) || dsn[start] != '\'' {
-		return unquotedConninfoValueEnd(dsn, start)
-	}
-
-	return quotedConninfoValueEnd(dsn, start)
-}
-
-func unquotedConninfoValueEnd(dsn string, start int) int {
-	for start < len(dsn) {
-		if dsn[start] == '\\' && start+1 < len(dsn) {
-			start += 2
-
-			continue
+		valueEnd, next, ok := conninfoValueSpan(dsn, index)
+		if !ok {
+			return nil, false
 		}
 
-		if unicode.IsSpace(rune(dsn[start])) {
-			break
+		assignments = append(assignments, conninfoAssignment{
+			key:        key,
+			valueStart: valueStart,
+			valueEnd:   valueEnd,
+		})
+
+		if next == len(dsn) {
+			return assignments, true
 		}
 
-		start++
+		if !isASCIIWhitespace(dsn[next]) {
+			return nil, false
+		}
+
+		index = skipASCIIWhitespace(dsn, next)
 	}
 
-	return start
+	return assignments, true
 }
 
-func quotedConninfoValueEnd(dsn string, start int) int {
+func conninfoValueSpan(dsn string, start int) (end, next int, ok bool) {
+	if start < len(dsn) && dsn[start] == '\'' {
+		return quotedConninfoValueSpan(dsn, start)
+	}
+
+	return unquotedConninfoValueSpan(dsn, start)
+}
+
+func quotedConninfoValueSpan(dsn string, start int) (end, next int, ok bool) {
 	for index := start + 1; index < len(dsn); index++ {
-		if dsn[index] == '\\' && index+1 < len(dsn) {
+		if dsn[index] == '\\' {
+			if index+1 == len(dsn) {
+				return 0, 0, false
+			}
+
 			index++
 
 			continue
 		}
 
 		if dsn[index] == '\'' {
-			index++
-			for index < len(dsn) && !unicode.IsSpace(rune(dsn[index])) {
-				index++
+			return index + 1, index + 1, true
+		}
+	}
+
+	return 0, 0, false
+}
+
+func unquotedConninfoValueSpan(dsn string, start int) (end, next int, ok bool) {
+	index := start
+	for index < len(dsn) && !isASCIIWhitespace(dsn[index]) {
+		if dsn[index] == '\\' {
+			if index+1 == len(dsn) {
+				return 0, 0, false
 			}
 
-			return index
-		}
-	}
+			index += 2
 
-	return len(dsn)
-}
-
-func isSecretKey(key string) bool {
-	decoded := decodeQueryKey(key)
-
-	return hasSecretKeySuffix(normalizeQueryKey(decoded)) ||
-		hasSecretKeySuffix(normalizeQueryKey(stripMalformedEscapes(decoded)))
-}
-
-func decodeQueryKey(value string) string {
-	for range queryDecodePasses {
-		decoded := urlQueryUnescape(value)
-		if decoded == value {
-			break
+			continue
 		}
 
-		value = decoded
+		index++
 	}
 
-	return value
+	return index, index, true
 }
 
-func normalizeQueryKey(value string) string {
+func redactConninfo(dsn string, assignments []conninfoAssignment) string {
+	var result strings.Builder
+
+	last := 0
+
+	for _, assignment := range assignments {
+		if !isSecretName(assignment.key) {
+			continue
+		}
+
+		result.WriteString(dsn[last:assignment.valueStart])
+		result.WriteString(redactedSecret)
+
+		last = assignment.valueEnd
+	}
+
+	if last == 0 {
+		return dsn
+	}
+
+	result.WriteString(dsn[last:])
+
+	return result.String()
+}
+
+func skipASCIIWhitespace(dsn string, index int) int {
+	for index < len(dsn) && isASCIIWhitespace(dsn[index]) {
+		index++
+	}
+
+	return index
+}
+
+func isASCIIWhitespace(value byte) bool {
+	switch value {
+	case ' ', '\t', '\n', '\r', '\v', '\f':
+		return true
+	default:
+		return false
+	}
+}
+
+func isConninfoKeyByte(value byte) bool {
+	return isASCIIAlpha(value) || isASCIIDigit(value) || value == '_' || value == '-'
+}
+
+func isSecretQueryKey(key string) (secret, certain bool) {
+	decoded, err := url.QueryUnescape(key)
+	if err != nil || strings.Contains(decoded, "%") {
+		return false, false
+	}
+
+	return isSecretName(decoded), true
+}
+
+func isSecretName(name string) bool {
 	var normalized strings.Builder
 
-	for _, r := range value {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			normalized.WriteRune(unicode.ToLower(r))
+	for index := range len(name) {
+		value := name[index]
+		switch {
+		case isASCIIAlpha(value):
+			normalized.WriteByte(toASCIILower(value))
+		case isASCIIDigit(value):
+			normalized.WriteByte(value)
+		case value == '_', value == '-', value == '.':
+		default:
+			return false
 		}
 	}
 
-	return normalized.String()
-}
-
-func hasSecretKeySuffix(key string) bool {
 	for _, suffix := range []string{
 		"password", "passwd", "pwd", "secret", "token", "credential", "credentials", "apikey",
 	} {
-		if strings.HasSuffix(key, suffix) {
+		if strings.HasSuffix(normalized.String(), suffix) {
 			return true
 		}
 	}
@@ -511,64 +474,18 @@ func hasSecretKeySuffix(key string) bool {
 	return false
 }
 
-func stripMalformedEscapes(value string) string {
-	var result strings.Builder
-
-	for index := 0; index < len(value); index++ {
-		if value[index] != '%' {
-			result.WriteByte(value[index])
-
-			continue
-		}
-
-		index += min(percentEscapeDigits, len(value)-index-1)
-	}
-
-	return result.String()
+func isASCIIAlpha(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
 }
 
-func urlQueryUnescape(value string) string {
-	var result strings.Builder
-
-	for index := 0; index < len(value); index++ {
-		if value[index] == '+' {
-			result.WriteByte(' ')
-
-			continue
-		}
-
-		if value[index] != '%' || index+percentEscapeDigits >= len(value) {
-			result.WriteByte(value[index])
-
-			continue
-		}
-
-		high, okHigh := fromHex(value[index+1])
-
-		low, okLow := fromHex(value[index+percentEscapeDigits])
-		if !okHigh || !okLow {
-			result.WriteByte(value[index])
-
-			continue
-		}
-
-		result.WriteByte(high<<4 | low)
-
-		index += percentEscapeDigits
-	}
-
-	return result.String()
+func isASCIIDigit(value byte) bool {
+	return value >= '0' && value <= '9'
 }
 
-func fromHex(value byte) (byte, bool) {
-	switch {
-	case value >= '0' && value <= '9':
-		return value - '0', true
-	case value >= 'a' && value <= 'f':
-		return value - 'a' + hexAlphabetBase, true
-	case value >= 'A' && value <= 'F':
-		return value - 'A' + hexAlphabetBase, true
-	default:
-		return 0, false
+func toASCIILower(value byte) byte {
+	if value >= 'A' && value <= 'Z' {
+		return value + ('a' - 'A')
 	}
+
+	return value
 }

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -26,9 +26,8 @@ type Config struct {
 }
 
 var (
-	errInvalidLogMode     = errors.New("invalid log mode")
-	errInvalidQueryEscape = errors.New("invalid query escape")
-	globalLogger          atomic.Pointer[zap.Logger]
+	errInvalidLogMode = errors.New("invalid log mode")
+	globalLogger      atomic.Pointer[zap.Logger]
 )
 
 func init() {
@@ -179,36 +178,47 @@ func redactQueryValues(dsn string) string {
 }
 
 func isSecretKey(key string) bool {
-	decoded := key
+	decoded := decodeQueryKey(key)
+
+	return hasSecretKeySuffix(normalizeQueryKey(decoded)) ||
+		hasSecretKeySuffix(normalizeQueryKey(stripMalformedEscapes(decoded)))
+}
+
+func decodeQueryKey(value string) string {
 	for range queryDecodePasses {
-		value, err := urlQueryUnescape(decoded)
-		if err != nil {
-			decoded = stripMalformedEscapes(decoded)
-
+		decoded := urlQueryUnescape(value)
+		if decoded == value {
 			break
 		}
 
-		if value == decoded {
-			break
-		}
-
-		decoded = value
+		value = decoded
 	}
 
+	return value
+}
+
+func normalizeQueryKey(value string) string {
 	var normalized strings.Builder
 
-	for _, r := range decoded {
+	for _, r := range value {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
 			normalized.WriteRune(unicode.ToLower(r))
 		}
 	}
 
-	switch normalized.String() {
-	case "password", "passwd", "pwd", "token", "authtoken", "accesstoken", "secret", "credential", "credentials", "apikey":
-		return true
-	default:
-		return false
+	return normalized.String()
+}
+
+func hasSecretKeySuffix(key string) bool {
+	for _, suffix := range []string{
+		"password", "passwd", "pwd", "secret", "token", "credential", "credentials", "apikey",
+	} {
+		if strings.HasSuffix(key, suffix) {
+			return true
+		}
 	}
+
+	return false
 }
 
 func stripMalformedEscapes(value string) string {
@@ -227,7 +237,7 @@ func stripMalformedEscapes(value string) string {
 	return result.String()
 }
 
-func urlQueryUnescape(value string) (string, error) {
+func urlQueryUnescape(value string) string {
 	var result strings.Builder
 
 	for index := 0; index < len(value); index++ {
@@ -247,7 +257,9 @@ func urlQueryUnescape(value string) (string, error) {
 
 		low, okLow := fromHex(value[index+percentEscapeDigits])
 		if !okHigh || !okLow {
-			return "", errInvalidQueryEscape
+			result.WriteByte(value[index])
+
+			continue
 		}
 
 		result.WriteByte(high<<4 | low)
@@ -255,7 +267,7 @@ func urlQueryUnescape(value string) (string, error) {
 		index += percentEscapeDigits
 	}
 
-	return result.String(), nil
+	return result.String()
 }
 
 func fromHex(value byte) (byte, bool) {

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -165,6 +165,9 @@ func RedactDSN(dsn string) string {
 	}
 
 	assignments, conninfoOK := parseConninfo(dsn)
+	if conninfoOK && containsASCIIWhitespace(dsn) {
+		return redactConninfo(dsn, assignments)
+	}
 
 	mysqlRedacted, mysqlOK := redactMySQL(dsn)
 	if conninfoOK {
@@ -286,17 +289,7 @@ func redactMySQL(dsn string) (redacted string, ok bool) {
 }
 
 func hasMySQLStructure(dsn string) bool {
-	if !strings.Contains(dsn, "/") {
-		return false
-	}
-
-	for index := range len(dsn) {
-		if isASCIIWhitespace(dsn[index]) {
-			return false
-		}
-	}
-
-	return true
+	return strings.Contains(dsn, "/") && hasMySQLPasswordEnvelope(dsn)
 }
 
 func hasMySQLPasswordEnvelope(dsn string) bool {
@@ -322,7 +315,7 @@ func looksLikeMySQLEndpointSuffix(dsn string, start int) bool {
 
 	for index := start; index < len(dsn); index++ {
 		switch dsn[index] {
-		case '(', '[':
+		case '(', '[', '/':
 			return true
 		case '?', '#', '@':
 			return false
@@ -471,6 +464,16 @@ func skipASCIIWhitespace(dsn string, index int) int {
 	}
 
 	return index
+}
+
+func containsASCIIWhitespace(value string) bool {
+	for index := range len(value) {
+		if isASCIIWhitespace(value[index]) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func isASCIIWhitespace(value byte) bool {

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -1,14 +1,17 @@
 package logger
 
 import (
+	"errors"
 	"fmt"
-	"os"
+	"strings"
 	"sync/atomic"
+	"unicode"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
+// LogMod names a logger output mode.
 type LogMod string
 
 const (
@@ -16,105 +19,284 @@ const (
 	ProductionMod  LogMod = "production"
 )
 
+// Config is the plain-Go logger configuration.
 type Config struct {
-	LogMod   LogMod `default:"production" mapstructure:"mod"   validate:"oneof=production development"`
-	LogLevel string `default:"info"       mapstructure:"level" validate:"oneof=debug info warn error"`
+	LogMod   LogMod `default:"development" mapstructure:"mod"   validate:"oneof=production development"`
+	LogLevel string `default:"debug"       mapstructure:"level" validate:"oneof=debug info warn error fatal"`
 }
 
-var globalLogger = atomic.Pointer[zap.Logger]{}
+var (
+	errInvalidLogMode     = errors.New("invalid log mode")
+	errInvalidQueryEscape = errors.New("invalid query escape")
+	globalLogger          atomic.Pointer[zap.Logger]
+)
 
 func init() {
-	setGlobalLogger(newDefault())
+	globalLogger.Store(newDefault())
 }
 
-// newDefault creates new default logger.
+// Init validates and installs a new process-wide logger. Invalid settings leave
+// the previously installed logger unchanged.
+func Init(level, mode string, opts ...zap.Option) error {
+	built, err := build(level, mode, opts...)
+	if err != nil {
+		return err
+	}
+
+	globalLogger.Store(built)
+
+	return nil
+}
+
+// NewFromConfig installs a logger built from a plain-Go configuration.
+//
+// It preserves the historical panic-on-invalid-config behavior; prefer Init
+// when configuration errors must be returned to the caller.
+func NewFromConfig(cfg *Config, opts ...zap.Option) *zap.Logger {
+	if cfg == nil {
+		panic("logger config is nil")
+	}
+
+	if err := Init(cfg.LogLevel, string(cfg.LogMod), opts...); err != nil {
+		panic(err)
+	}
+
+	return Global()
+}
+
+func build(level, mode string, opts ...zap.Option) (*zap.Logger, error) {
+	zapLevel, err := zapcore.ParseLevel(level)
+	if err != nil {
+		return nil, fmt.Errorf("invalid log level %q: %w", level, err)
+	}
+
+	logMod, err := ParseMode(mode)
+	if err != nil {
+		return nil, err
+	}
+
+	built, err := newZapCfg(logMod, zapLevel).Build(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return built, nil
+}
+
+// ParseMode validates a logger output mode.
+func ParseMode(mode string) (LogMod, error) {
+	switch LogMod(mode) {
+	case DevelopmentMod, ProductionMod:
+		return LogMod(mode), nil
+	default:
+		return "", fmt.Errorf("%w: %q (want %q or %q)", errInvalidLogMode, mode, DevelopmentMod, ProductionMod)
+	}
+}
+
+// Global returns the process-wide logger. It is always non-nil.
+func Global() *zap.Logger {
+	return globalLogger.Load()
+}
+
+// newDefault creates the startup logger used before Init runs.
 func newDefault(opts ...zap.Option) *zap.Logger {
-	cfg := newZapCfg(DevelopmentMod, zapcore.DebugLevel)
-	logger, _ := cfg.Build(opts...)
+	logger, err := newZapCfg(DevelopmentMod, zapcore.DebugLevel).Build(opts...)
+	if err != nil {
+		panic(err)
+	}
 
 	return logger
 }
 
-// newZapCfg creates new zap config.
+// newZapCfg creates a zap config for the given mode and level.
 func newZapCfg(mod LogMod, logLevel zapcore.Level) zap.Config {
 	var cfg zap.Config
 
 	switch mod {
 	case ProductionMod:
 		cfg = zap.NewProductionConfig()
-		cfg.Level.SetLevel(logLevel)
 	case DevelopmentMod:
 		cfg = zap.NewDevelopmentConfig()
-		cfg.Level.SetLevel(logLevel)
 	default:
 		cfg = zap.NewDevelopmentConfig()
-		cfg.Level.SetLevel(logLevel)
 	}
 
+	cfg.Level.SetLevel(logLevel)
 	cfg.DisableStacktrace = true
 
 	return cfg
 }
 
-// NewFromConfig creates new logger from config.
-func NewFromConfig(cfg *Config, opts ...zap.Option) *zap.Logger {
-	level, parseErr := zapcore.ParseLevel(cfg.LogLevel)
-	if parseErr != nil {
-		levels := getAllLevelsNames()
-		panic(fmt.Errorf("available levels is '%v' error: %w", levels, parseErr))
-	}
+// StructLogger is an alias for *zap.Logger included in project structs.
+type StructLogger = *zap.Logger
 
-	zapCfg := newZapCfg(cfg.LogMod, level)
-
-	logger, err := zapCfg.Build(opts...)
-	if err != nil {
-		panic(err)
-	}
-
-	setGlobalLogger(logger)
-
-	return Global()
-}
-
-func getAllLevelsNames() []string {
-	levelsFrom := int(zapcore.DebugLevel)
-	levelsTo := int(zapcore.FatalLevel)
-
-	levels := make([]string, 0, levelsTo-levelsFrom)
-	for i := levelsFrom; i <= levelsTo; i++ {
-		levels = append(levels, zapcore.Level(i).String()) //nolint: gosec // it's safe
-	}
-
-	return levels
+// NewStructLogger returns a named child of the process-wide logger.
+func NewStructLogger(name string) StructLogger {
+	return Global().Named(name)
 }
 
 const (
-	envLogLevel = "LOG_LEVEL"
-	envLogMod   = "LOG_MODE"
+	redactedSecret           = "xxxxx"
+	queryDecodePasses        = 2
+	percentEscapeDigits      = 2
+	hexAlphabetBase     byte = 10
 )
 
-func NewFromEnv(opts ...zap.Option) *zap.Logger {
-	cfg := &Config{
-		LogLevel: os.Getenv(envLogLevel),
-		LogMod:   LogMod(os.Getenv(envLogMod)),
+// RedactDSN masks credentials in database URLs and DSNs while preserving the
+// endpoint, database path, and non-secret query options.
+func RedactDSN(dsn string) string {
+	if dsn == "" {
+		return dsn
 	}
 
-	return NewFromConfig(cfg, opts...)
+	return redactUserinfo(redactQueryValues(dsn))
 }
 
-func setGlobalLogger(logger *zap.Logger) {
-	globalLogger.Store(logger)
+func redactQueryValues(dsn string) string {
+	queryStart := strings.IndexByte(dsn, '?')
+	if queryStart < 0 {
+		return dsn
+	}
+
+	queryEnd := strings.IndexByte(dsn[queryStart+1:], '#')
+	if queryEnd >= 0 {
+		queryEnd += queryStart + 1
+	} else {
+		queryEnd = len(dsn)
+	}
+
+	query := dsn[queryStart+1 : queryEnd]
+
+	parts := strings.Split(query, "&")
+	for index, part := range parts {
+		key, _, hasValue := strings.Cut(part, "=")
+		if hasValue && isSecretKey(key) {
+			parts[index] = key + "=" + redactedSecret
+		}
+	}
+
+	return dsn[:queryStart+1] + strings.Join(parts, "&") + dsn[queryEnd:]
 }
 
-// Global returns the global logger.
-func Global() *zap.Logger {
-	return globalLogger.Load()
+func isSecretKey(key string) bool {
+	decoded := key
+	for range queryDecodePasses {
+		value, err := urlQueryUnescape(decoded)
+		if err != nil {
+			decoded = stripMalformedEscapes(decoded)
+
+			break
+		}
+
+		if value == decoded {
+			break
+		}
+
+		decoded = value
+	}
+
+	var normalized strings.Builder
+
+	for _, r := range decoded {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			normalized.WriteRune(unicode.ToLower(r))
+		}
+	}
+
+	switch normalized.String() {
+	case "password", "passwd", "pwd", "token", "authtoken", "accesstoken", "secret", "credential", "credentials", "apikey":
+		return true
+	default:
+		return false
+	}
 }
 
-// StructLogger is an alias for *zap.Logger included in project struct.
-type StructLogger = *zap.Logger
+func stripMalformedEscapes(value string) string {
+	var result strings.Builder
 
-// NewStructLogger returns a new StructLogger with the given name.
-func NewStructLogger(name string) StructLogger {
-	return Global().Named(name)
+	for index := 0; index < len(value); index++ {
+		if value[index] != '%' {
+			result.WriteByte(value[index])
+
+			continue
+		}
+
+		index += min(percentEscapeDigits, len(value)-index-1)
+	}
+
+	return result.String()
+}
+
+func urlQueryUnescape(value string) (string, error) {
+	var result strings.Builder
+
+	for index := 0; index < len(value); index++ {
+		if value[index] == '+' {
+			result.WriteByte(' ')
+
+			continue
+		}
+
+		if value[index] != '%' || index+percentEscapeDigits >= len(value) {
+			result.WriteByte(value[index])
+
+			continue
+		}
+
+		high, okHigh := fromHex(value[index+1])
+
+		low, okLow := fromHex(value[index+percentEscapeDigits])
+		if !okHigh || !okLow {
+			return "", errInvalidQueryEscape
+		}
+
+		result.WriteByte(high<<4 | low)
+
+		index += percentEscapeDigits
+	}
+
+	return result.String(), nil
+}
+
+func fromHex(value byte) (byte, bool) {
+	switch {
+	case value >= '0' && value <= '9':
+		return value - '0', true
+	case value >= 'a' && value <= 'f':
+		return value - 'a' + hexAlphabetBase, true
+	case value >= 'A' && value <= 'F':
+		return value - 'A' + hexAlphabetBase, true
+	default:
+		return 0, false
+	}
+}
+
+func redactUserinfo(dsn string) string {
+	end := len(dsn)
+	if queryStart := strings.IndexByte(dsn, '?'); queryStart >= 0 {
+		end = queryStart
+	}
+
+	start := 0
+	if scheme := strings.Index(dsn[:end], "://"); scheme >= 0 {
+		start = scheme + len("://")
+	}
+
+	at := strings.LastIndexByte(dsn[start:end], '@')
+	if at < 0 {
+		return dsn
+	}
+
+	at += start
+
+	userinfo := dsn[start:at]
+
+	colon := strings.LastIndexByte(userinfo, ':')
+	if colon < 0 {
+		return dsn
+	}
+
+	colon += start
+
+	return dsn[:colon+1] + redactedSecret + dsn[at:]
 }

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -164,17 +164,19 @@ func RedactDSN(dsn string) string {
 		return redacted
 	}
 
-	if redacted, ok := redactMySQL(dsn); ok {
-		return redacted
-	}
+	assignments, conninfoOK := parseConninfo(dsn)
 
-	assignments, ok := parseConninfo(dsn)
-	if ok {
-		if hasAmbiguousMySQLCredentialEnvelope(dsn) {
+	mysqlRedacted, mysqlOK := redactMySQL(dsn)
+	if conninfoOK {
+		if mysqlOK || hasMySQLStructure(dsn) && hasMySQLPasswordEnvelope(dsn) {
 			return redactedDSN
 		}
 
 		return redactConninfo(dsn, assignments)
+	}
+
+	if mysqlOK {
+		return mysqlRedacted
 	}
 
 	return redactedDSN
@@ -217,7 +219,7 @@ func redactURI(dsn string) (string, bool) {
 	}
 
 	for key, values := range values {
-		secret, certain := isSecretQueryKey(key)
+		secret, certain := classifyQueryKey(key)
 		if !certain {
 			return "", false
 		}
@@ -246,46 +248,92 @@ func redactMySQL(dsn string) (redacted string, ok bool) {
 		}
 	}()
 
+	if !hasMySQLStructure(dsn) {
+		return "", false
+	}
+
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
 		return "", false
 	}
 
-	if cfg.Passwd != "" {
-		cfg.Passwd = redactedSecret
-	} else if hasPasswordEnvelope(dsn) {
+	passwordPresent := hasMySQLPasswordEnvelope(dsn)
+	if cfg.Passwd != "" && !passwordPresent {
 		return "", false
 	}
 
+	if passwordPresent {
+		cfg.Passwd = redactedSecret
+	}
+
 	for key := range cfg.Params {
-		if isSecretName(key) {
+		secret, certain := classifyQueryKey(key)
+		if !certain {
+			return "", false
+		}
+
+		if secret {
 			cfg.Params[key] = redactedSecret
 		}
 	}
 
 	formatted := cfg.FormatDSN()
-	if hasPasswordEnvelope(dsn) && !strings.Contains(formatted, redactedSecret) {
+	if passwordPresent && !strings.Contains(formatted, redactedSecret) {
 		return "", false
 	}
 
 	return formatted, true
 }
 
-func hasPasswordEnvelope(dsn string) bool {
-	colon := strings.IndexByte(dsn, ':')
-	at := strings.LastIndexByte(dsn, '@')
-
-	return colon >= 0 && colon < at
-}
-
-func hasAmbiguousMySQLCredentialEnvelope(dsn string) bool {
-	if !hasPasswordEnvelope(dsn) {
+func hasMySQLStructure(dsn string) bool {
+	if !strings.Contains(dsn, "/") {
 		return false
 	}
 
-	at := strings.LastIndexByte(dsn, '@')
+	for index := range len(dsn) {
+		if isASCIIWhitespace(dsn[index]) {
+			return false
+		}
+	}
 
-	return strings.ContainsAny(dsn[at+1:], "([")
+	return true
+}
+
+func hasMySQLPasswordEnvelope(dsn string) bool {
+	for at := len(dsn) - 1; at >= 0; at-- {
+		if dsn[at] != '@' || !looksLikeMySQLEndpointSuffix(dsn, at+1) {
+			continue
+		}
+
+		return strings.IndexByte(dsn[:at], ':') >= 0
+	}
+
+	return false
+}
+
+func looksLikeMySQLEndpointSuffix(dsn string, start int) bool {
+	if start == len(dsn) {
+		return false
+	}
+
+	if dsn[start] == '/' {
+		return true
+	}
+
+	for index := start; index < len(dsn); index++ {
+		switch dsn[index] {
+		case '(', '[':
+			return true
+		case '?', '#', '@':
+			return false
+		default:
+			if isASCIIWhitespace(dsn[index]) {
+				return false
+			}
+		}
+	}
+
+	return false
 }
 
 type conninfoAssignment struct {
@@ -438,16 +486,48 @@ func isConninfoKeyByte(value byte) bool {
 	return isASCIIAlpha(value) || isASCIIDigit(value) || value == '_' || value == '-'
 }
 
-func isSecretQueryKey(key string) (secret, certain bool) {
-	decoded, err := url.QueryUnescape(key)
-	if err != nil || strings.Contains(decoded, "%") {
+func classifyQueryKey(key string) (secret, certain bool) {
+	decoded, ok := decodeQueryKey(key)
+	if !ok {
 		return false, false
 	}
 
-	return isSecretName(decoded), true
+	normalized, ok := normalizeSecretName(decoded)
+	if !ok {
+		return false, false
+	}
+
+	return hasSecretSuffix(normalized), true
+}
+
+func decodeQueryKey(key string) (string, bool) {
+	for range 2 {
+		decoded, err := url.QueryUnescape(key)
+		if err != nil {
+			return "", false
+		}
+
+		if decoded == key {
+			break
+		}
+
+		key = decoded
+	}
+
+	if strings.Contains(key, "%") {
+		return "", false
+	}
+
+	return key, true
 }
 
 func isSecretName(name string) bool {
+	normalized, ok := normalizeSecretName(name)
+
+	return ok && hasSecretSuffix(normalized)
+}
+
+func normalizeSecretName(name string) (string, bool) {
 	var normalized strings.Builder
 
 	for index := range len(name) {
@@ -459,14 +539,18 @@ func isSecretName(name string) bool {
 			normalized.WriteByte(value)
 		case value == '_', value == '-', value == '.':
 		default:
-			return false
+			return "", false
 		}
 	}
 
+	return normalized.String(), true
+}
+
+func hasSecretSuffix(name string) bool {
 	for _, suffix := range []string{
 		"password", "passwd", "pwd", "secret", "token", "credential", "credentials", "apikey",
 	} {
-		if strings.HasSuffix(normalized.String(), suffix) {
+		if strings.HasSuffix(name, suffix) {
 			return true
 		}
 	}

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -168,7 +168,7 @@ func RedactDSN(dsn string) string {
 
 	mysqlRedacted, mysqlOK := redactMySQL(dsn)
 	if conninfoOK {
-		if mysqlOK || hasMySQLStructure(dsn) && hasMySQLPasswordEnvelope(dsn) {
+		if mysqlOK {
 			return redactedDSN
 		}
 
@@ -248,21 +248,12 @@ func redactMySQL(dsn string) (redacted string, ok bool) {
 		}
 	}()
 
-	if !hasMySQLStructure(dsn) {
-		return "", false
-	}
-
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
 		return "", false
 	}
 
-	passwordPresent := hasMySQLPasswordEnvelope(dsn)
-	if cfg.Passwd != "" && !passwordPresent {
-		return "", false
-	}
-
-	if passwordPresent {
+	if cfg.Passwd != "" {
 		cfg.Passwd = redactedSecret
 	}
 
@@ -277,76 +268,7 @@ func redactMySQL(dsn string) (redacted string, ok bool) {
 		}
 	}
 
-	formatted := cfg.FormatDSN()
-	if passwordPresent && !strings.Contains(formatted, redactedSecret) {
-		return "", false
-	}
-
-	return formatted, true
-}
-
-type mysqlEnvelope struct {
-	userinfoEnd int
-	valid       bool
-}
-
-func parseMySQLEnvelope(dsn string) mysqlEnvelope {
-	databaseSlash := strings.LastIndexByte(dsn, '/')
-	if databaseSlash < 0 {
-		return mysqlEnvelope{userinfoEnd: -1}
-	}
-
-	end := len(dsn)
-	if queryStart := strings.IndexByte(dsn[databaseSlash+1:], '?'); queryStart >= 0 {
-		end = databaseSlash + queryStart + 1
-	}
-
-	for at := databaseSlash - 1; at >= 0; at-- {
-		if dsn[at] == '@' && isMySQLEndpoint(dsn, at+1, end) {
-			return mysqlEnvelope{userinfoEnd: at, valid: true}
-		}
-	}
-
-	if isMySQLEndpoint(dsn, 0, end) {
-		return mysqlEnvelope{userinfoEnd: -1, valid: true}
-	}
-
-	return mysqlEnvelope{userinfoEnd: -1}
-}
-
-func isMySQLEndpoint(dsn string, start, end int) bool {
-	if start >= end {
-		return false
-	}
-
-	if dsn[start] == '/' {
-		return true
-	}
-
-	suffix := dsn[start:end]
-	open := strings.IndexByte(suffix, '(')
-
-	slash := strings.IndexByte(suffix, '/')
-	if open >= 0 && (slash < 0 || open < slash) {
-		closing := strings.IndexByte(suffix[open+1:], ')')
-		if closing < 0 {
-			return false
-		}
-
-		return open+closing+2 < len(suffix) && suffix[open+closing+2] == '/'
-	}
-
-	return slash > 0
-}
-
-func hasMySQLStructure(dsn string) bool {
-	return parseMySQLEnvelope(dsn).valid
-}
-
-func hasMySQLPasswordEnvelope(dsn string) bool {
-	envelope := parseMySQLEnvelope(dsn)
-
-	return envelope.valid && envelope.userinfoEnd >= 0 && strings.IndexByte(dsn[:envelope.userinfoEnd], ':') >= 0
+	return cfg.FormatDSN(), true
 }
 
 type conninfoAssignment struct {

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -148,7 +148,118 @@ func RedactDSN(dsn string) string {
 		return dsn
 	}
 
-	return redactUserinfo(redactKeywordValues(redactQueryValues(dsn)))
+	switch {
+	case hasURIScheme(dsn):
+		return redactURI(dsn)
+	case isConninfoDSN(dsn):
+		return redactConninfo(dsn)
+	default:
+		return redactMySQLDSN(dsn)
+	}
+}
+
+func hasURIScheme(dsn string) bool {
+	schemeEnd := strings.Index(dsn, "://")
+	if schemeEnd <= 0 || !unicode.IsLetter(rune(dsn[0])) {
+		return false
+	}
+
+	for _, r := range dsn[1:schemeEnd] {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '+' && r != '-' && r != '.' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func redactURI(dsn string) string {
+	return redactURIUserinfo(redactQueryValues(dsn))
+}
+
+func redactURIUserinfo(dsn string) string {
+	schemeEnd := strings.Index(dsn, "://")
+	start := schemeEnd + len("://")
+	end := uriAuthorityEnd(dsn, start)
+
+	at := strings.LastIndexByte(dsn[start:end], '@')
+	if at < 0 {
+		return dsn
+	}
+
+	at += start
+
+	colon := strings.IndexByte(dsn[start:at], ':')
+	if colon < 0 {
+		return dsn
+	}
+
+	return dsn[:start+colon+1] + redactedSecret + dsn[at:]
+}
+
+func uriAuthorityEnd(dsn string, start int) int {
+	if delimiter := strings.IndexAny(dsn[start:], "/?#"); delimiter >= 0 {
+		return start + delimiter
+	}
+
+	return len(dsn)
+}
+
+func isConninfoDSN(dsn string) bool {
+	return nextConninfoAssignment(dsn, 0).key != ""
+}
+
+func redactMySQLDSN(dsn string) string {
+	return redactQueryValues(redactMySQLUserinfo(dsn))
+}
+
+func redactMySQLUserinfo(dsn string) string {
+	at := mysqlUserinfoEnd(dsn)
+	if at < 0 {
+		return dsn
+	}
+
+	colon := strings.IndexByte(dsn[:at], ':')
+	if colon < 0 {
+		return dsn
+	}
+
+	return dsn[:colon+1] + redactedSecret + dsn[at:]
+}
+
+func mysqlUserinfoEnd(dsn string) int {
+	userinfoEnd := -1
+
+	for index := range dsn {
+		if dsn[index] == '@' && isMySQLProtocolDelimiter(dsn, index+1) {
+			userinfoEnd = index
+		}
+	}
+
+	return userinfoEnd
+}
+
+func isMySQLProtocolDelimiter(dsn string, start int) bool {
+	if start == len(dsn) || dsn[start] == '/' {
+		return start < len(dsn)
+	}
+
+	end := start
+	for end < len(dsn) && (unicode.IsLetter(rune(dsn[end])) || unicode.IsDigit(rune(dsn[end]))) {
+		end++
+	}
+
+	if end == start {
+		return false
+	}
+
+	if end < len(dsn) && dsn[end] == '(' {
+		return true
+	}
+
+	protocol := dsn[start:end]
+
+	return (protocol == "tcp" || protocol == "unix") && (end == len(dsn) || dsn[end] == '/')
 }
 
 func redactQueryValues(dsn string) string {
@@ -183,7 +294,7 @@ type conninfoAssignment struct {
 	next                 int
 }
 
-func redactKeywordValues(dsn string) string {
+func redactConninfo(dsn string) string {
 	var result strings.Builder
 
 	lastRedaction := 0
@@ -269,13 +380,31 @@ func isConninfoKey(key string) bool {
 
 func conninfoValueEnd(dsn string, start int) int {
 	if start == len(dsn) || dsn[start] != '\'' {
-		for start < len(dsn) && !unicode.IsSpace(rune(dsn[start])) {
-			start++
-		}
-
-		return start
+		return unquotedConninfoValueEnd(dsn, start)
 	}
 
+	return quotedConninfoValueEnd(dsn, start)
+}
+
+func unquotedConninfoValueEnd(dsn string, start int) int {
+	for start < len(dsn) {
+		if dsn[start] == '\\' && start+1 < len(dsn) {
+			start += 2
+
+			continue
+		}
+
+		if unicode.IsSpace(rune(dsn[start])) {
+			break
+		}
+
+		start++
+	}
+
+	return start
+}
+
+func quotedConninfoValueEnd(dsn string, start int) int {
 	for index := start + 1; index < len(dsn); index++ {
 		if dsn[index] == '\\' && index+1 < len(dsn) {
 			index++
@@ -400,42 +529,4 @@ func fromHex(value byte) (byte, bool) {
 	default:
 		return 0, false
 	}
-}
-
-func redactUserinfo(dsn string) string {
-	start := 0
-	if scheme := strings.Index(dsn, "://"); scheme >= 0 {
-		start = scheme + len("://")
-	}
-
-	end := authorityEnd(dsn, start)
-	if start == 0 && strings.Contains(dsn[:end], "=") {
-		return dsn
-	}
-
-	at := strings.LastIndexByte(dsn[start:end], '@')
-	if at < 0 {
-		return dsn
-	}
-
-	at += start
-
-	userinfo := dsn[start:at]
-
-	colon := strings.LastIndexByte(userinfo, ':')
-	if colon < 0 {
-		return dsn
-	}
-
-	colon += start
-
-	return dsn[:colon+1] + redactedSecret + dsn[at:]
-}
-
-func authorityEnd(dsn string, start int) int {
-	if delimiter := strings.IndexAny(dsn[start:], "/?#"); delimiter >= 0 {
-		return start + delimiter
-	}
-
-	return len(dsn)
 }

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -291,12 +291,17 @@ type mysqlEnvelope struct {
 }
 
 func parseMySQLEnvelope(dsn string) mysqlEnvelope {
-	end := len(dsn)
-	if queryStart := strings.IndexByte(dsn, '?'); queryStart >= 0 {
-		end = queryStart
+	databaseSlash := strings.LastIndexByte(dsn, '/')
+	if databaseSlash < 0 {
+		return mysqlEnvelope{userinfoEnd: -1}
 	}
 
-	for at := end - 1; at >= 0; at-- {
+	end := len(dsn)
+	if queryStart := strings.IndexByte(dsn[databaseSlash+1:], '?'); queryStart >= 0 {
+		end = databaseSlash + queryStart + 1
+	}
+
+	for at := databaseSlash - 1; at >= 0; at-- {
 		if dsn[at] == '@' && isMySQLEndpoint(dsn, at+1, end) {
 			return mysqlEnvelope{userinfoEnd: at, valid: true}
 		}

--- a/pkg/common/logger/logger.go
+++ b/pkg/common/logger/logger.go
@@ -165,9 +165,6 @@ func RedactDSN(dsn string) string {
 	}
 
 	assignments, conninfoOK := parseConninfo(dsn)
-	if conninfoOK && containsASCIIWhitespace(dsn) {
-		return redactConninfo(dsn, assignments)
-	}
 
 	mysqlRedacted, mysqlOK := redactMySQL(dsn)
 	if conninfoOK {
@@ -464,16 +461,6 @@ func skipASCIIWhitespace(dsn string, index int) int {
 	}
 
 	return index
-}
-
-func containsASCIIWhitespace(value string) bool {
-	for index := range len(value) {
-		if isASCIIWhitespace(value[index]) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func isASCIIWhitespace(value byte) bool {

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -189,6 +189,7 @@ func TestRedactDSNMySQL(t *testing.T) {
 			name:          "explicit empty password",
 			dsn:           "user:@tcp(db:3306)/bench?charset=utf8",
 			emptyPassword: true,
+			passwordless:  true,
 		},
 		{
 			name: "whitespace password",
@@ -241,6 +242,21 @@ func TestRedactDSNMySQL(t *testing.T) {
 			dsn:          "tcp(db:3306)/bench@foo[bar?note=@foo[bar&charset=utf8",
 			passwordless: true,
 		},
+		{
+			name:         "username only query punctuation",
+			dsn:          "user@tcp(db:3306)/bench?note=@foo%2Fbar&encoded=%2F%40&charset=utf8",
+			passwordless: true,
+		},
+		{
+			name:         "credential free query punctuation",
+			dsn:          "tcp(db:3306)/bench?note=@foo%2Fbar&encoded=%2F%40&charset=utf8",
+			passwordless: true,
+		},
+		{
+			name:         "Unix socket punctuation",
+			dsn:          "user@unix(/tmp/mysql))socket?file)/bench?charset=utf8",
+			passwordless: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -286,18 +302,6 @@ func TestRedactDSNMySQL(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestRedactDSNFallsBackForMalformedMySQL(t *testing.T) {
-	for _, dsn := range []string{
-		"user:marker-secret@tcp[db:3306]/bench",
-		"bench=prod:marker-secret@tcp[db:3306]/bench",
-		"user:marker-secret@custom-net(db:3306)",
-	} {
-		got := RedactDSN(dsn)
-		require.Equal(t, redactedDSN, got)
-		require.NotContains(t, got, "marker-secret")
 	}
 }
 

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -108,34 +108,69 @@ func TestNewStructLogger(t *testing.T) {
 }
 
 func TestRedactDSN(t *testing.T) {
-	secrets := []string{"dsn-secret", "db-pass", "query-token", "query-secret", "api-secret"}
 	tests := []struct {
-		name string
-		dsn  string
-		want string
+		name      string
+		dsn       string
+		want      string
+		secrets   []string
+		preserved []string
 	}{
 		{
-			name: "url userinfo and repeated query secrets",
+			name: "userinfo and named query secrets",
 			dsn: "postgres://user:dsn-secret@host:5432/db?sslmode=require" +
 				"&PASSWORD=db-pass&token=query-token&Token=query-secret" +
 				"&api-key=api-secret&keep=yes",
 			want: "postgres://user:xxxxx@host:5432/db?sslmode=require" +
 				"&PASSWORD=xxxxx&token=xxxxx&Token=xxxxx&api-key=xxxxx&keep=yes",
+			secrets:   []string{"dsn-secret", "db-pass", "query-token", "query-secret", "api-secret"},
+			preserved: []string{"sslmode=require", "keep=yes"},
 		},
 		{
-			name: "mysql no scheme",
-			dsn:  "user:dsn-secret@tcp(host:3306)/db?passwd=db-pass",
-			want: "user:xxxxx@tcp(host:3306)/db?passwd=xxxxx",
+			name: "secret suffix families",
+			dsn: "postgres://host/db?password=password-secret&passwd=passwd-secret&pwd=pwd-secret" +
+				"&dbPassword=db-password&db_password=db-underscore-password" +
+				"&clientSecret=client-secret&client_secret=client-underscore-secret" +
+				"&oauth_client_secret=oauth-secret&credential=credential-secret&credentials=credentials-secret" +
+				"&apiKey=api-key-secret&x-api-key=x-api-secret" +
+				"&access_token=access-secret&refreshToken=refresh-secret&auth-token=auth-secret" +
+				"&application_name=stroppy&sslmode=require",
+			want: "postgres://host/db?password=xxxxx&passwd=xxxxx&pwd=xxxxx" +
+				"&dbPassword=xxxxx&db_password=xxxxx" +
+				"&clientSecret=xxxxx&client_secret=xxxxx" +
+				"&oauth_client_secret=xxxxx&credential=xxxxx&credentials=xxxxx" +
+				"&apiKey=xxxxx&x-api-key=xxxxx" +
+				"&access_token=xxxxx&refreshToken=xxxxx&auth-token=xxxxx" +
+				"&application_name=stroppy&sslmode=require",
+			secrets: []string{
+				"password-secret", "passwd-secret", "pwd-secret", "db-password", "db-underscore-password",
+				"client-secret", "client-underscore-secret", "oauth-secret", "credential-secret", "credentials-secret",
+				"api-key-secret", "x-api-secret", "access-secret", "refresh-secret", "auth-secret",
+			},
+			preserved: []string{"application_name=stroppy", "sslmode=require"},
 		},
 		{
-			name: "encoded secret key",
-			dsn:  "grpc://host/db?access%54oken=query-token&credentialS=query-secret",
-			want: "grpc://host/db?access%54oken=xxxxx&credentialS=xxxxx",
+			name: "encoded separators case variants and repeated values",
+			dsn: "grpc://host/db?CLIENT%5fSECRET=client-secret" +
+				"&oauth%255Fclient%255Fsecret=oauth-secret&refresh%2Dtoken=refresh-secret" +
+				"&x%2Dapi%2Dkey=api-secret&Token=first-token&token=second-token" +
+				"&keep=yes&sslmode=require",
+			want: "grpc://host/db?CLIENT%5fSECRET=xxxxx" +
+				"&oauth%255Fclient%255Fsecret=xxxxx&refresh%2Dtoken=xxxxx" +
+				"&x%2Dapi%2Dkey=xxxxx&Token=xxxxx&token=xxxxx" +
+				"&keep=yes&sslmode=require",
+			secrets: []string{
+				"client-secret", "oauth-secret", "refresh-secret", "api-secret", "first-token", "second-token",
+			},
+			preserved: []string{"keep=yes", "sslmode=require"},
 		},
 		{
-			name: "malformed URL",
-			dsn:  "postgres://user:dsn-secret@%zz/db?pwd=query-secret",
-			want: "postgres://user:xxxxx@%zz/db?pwd=xxxxx",
+			name: "malformed no scheme",
+			dsn: "user:userinfo-secret@tcp(host:3306)/db?db%5Fpassword%zz=db-password" +
+				"&client%_secret=client-secret&password%zz=password-secret&keep=yes&charset=utf8",
+			want: "user:xxxxx@tcp(host:3306)/db?db%5Fpassword%zz=xxxxx" +
+				"&client%_secret=xxxxx&password%zz=xxxxx&keep=yes&charset=utf8",
+			secrets:   []string{"userinfo-secret", "db-password", "client-secret", "password-secret"},
+			preserved: []string{"keep=yes", "charset=utf8"},
 		},
 	}
 
@@ -144,20 +179,16 @@ func TestRedactDSN(t *testing.T) {
 			got := RedactDSN(test.dsn)
 			require.Equal(t, test.want, got)
 
-			for _, secret := range secrets {
+			for _, secret := range test.secrets {
 				require.NotContains(t, got, secret)
+			}
+
+			for _, option := range test.preserved {
+				require.Contains(t, got, option)
 			}
 		})
 	}
 
 	require.Equal(t, "postgres://host/db?sslmode=require", RedactDSN("postgres://host/db?sslmode=require"))
 	require.Empty(t, RedactDSN(""))
-}
-
-func TestRedactDSNDoesNotLeakMalformedSecretKeys(t *testing.T) {
-	got := RedactDSN("user:userinfo-secret@host/db?password%zz=malformed-secret&secret=still-secret")
-	require.NotContains(t, got, "userinfo-secret")
-	require.NotContains(t, got, "malformed-secret")
-	require.NotContains(t, got, "still-secret")
-	require.Contains(t, got, "password%zz=xxxxx")
 }

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -203,6 +203,21 @@ func TestRedactDSNMySQL(t *testing.T) {
 			dsn:          "user@tcp(db:3306)/bench?charset=utf8",
 			passwordless: true,
 		},
+		{
+			name:         "credential free address",
+			dsn:          "tcp(db:3306)/bench?charset=utf8",
+			passwordless: true,
+		},
+		{
+			name:         "credential free custom network",
+			dsn:          "custom-net(db:3306)/bench?charset=utf8",
+			passwordless: true,
+		},
+		{
+			name:         "credential free addressless network",
+			dsn:          "tcp/bench?charset=utf8",
+			passwordless: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -171,6 +171,7 @@ func TestRedactDSNMySQL(t *testing.T) {
 		name          string
 		dsn           string
 		emptyPassword bool
+		passwordless  bool
 	}{
 		{
 			name: "password contains scheme separator",
@@ -196,6 +197,11 @@ func TestRedactDSNMySQL(t *testing.T) {
 		{
 			name: "addressless protocol",
 			dsn:  "user:marker-secret@tcp/bench?charset=utf8",
+		},
+		{
+			name:         "username only",
+			dsn:          "user@tcp(db:3306)/bench?charset=utf8",
+			passwordless: true,
 		},
 	}
 
@@ -223,7 +229,13 @@ func TestRedactDSNMySQL(t *testing.T) {
 			require.Equal(t, original.Net, parsed.Net)
 			require.Equal(t, original.Addr, parsed.Addr)
 			require.Equal(t, original.DBName, parsed.DBName)
-			require.Equal(t, redactedSecret, parsed.Passwd)
+
+			if test.passwordless {
+				require.Empty(t, original.Passwd)
+				require.Empty(t, parsed.Passwd)
+			} else {
+				require.Equal(t, redactedSecret, parsed.Passwd)
+			}
 
 			for key, value := range original.Params {
 				secret, certain := classifyQueryKey(key)

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -218,6 +218,16 @@ func TestRedactDSNMySQL(t *testing.T) {
 			dsn:          "tcp/bench?charset=utf8",
 			passwordless: true,
 		},
+		{
+			name:         "username only endpoint boundaries",
+			dsn:          "user@tcp(db:3306)/bench@foo[bar?note=@foo[bar&charset=utf8",
+			passwordless: true,
+		},
+		{
+			name:         "credential free endpoint boundaries",
+			dsn:          "tcp(db:3306)/bench@foo[bar?note=@foo[bar&charset=utf8",
+			passwordless: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -199,6 +199,14 @@ func TestRedactDSNMySQL(t *testing.T) {
 			dsn:  "user:marker-secret@tcp/bench?charset=utf8",
 		},
 		{
+			name: "query punctuation in password",
+			dsn:  "user:marker?secret@tcp(db:3306)/bench?charset=utf8",
+		},
+		{
+			name: "Unix socket password",
+			dsn:  "user:marker-secret@unix(/tmp/mysql.sock)/bench?charset=utf8",
+		},
+		{
 			name:         "username only",
 			dsn:          "user@tcp(db:3306)/bench?charset=utf8",
 			passwordless: true,
@@ -211,6 +219,11 @@ func TestRedactDSNMySQL(t *testing.T) {
 		{
 			name:         "credential free custom network",
 			dsn:          "custom-net(db:3306)/bench?charset=utf8",
+			passwordless: true,
+		},
+		{
+			name:         "credential free Unix socket",
+			dsn:          "unix(/tmp/mysql.sock)/bench?charset=utf8",
 			passwordless: true,
 		},
 		{
@@ -242,7 +255,7 @@ func TestRedactDSNMySQL(t *testing.T) {
 			got := RedactDSN(test.dsn)
 			require.NotEqual(t, redactedDSN, got)
 
-			for _, marker := range []string{"marker-secret", "marker secret", "query-secret"} {
+			for _, marker := range []string{"marker-secret", "marker secret", "marker?secret", "query-secret"} {
 				require.NotContains(t, got, marker)
 			}
 

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -1,6 +1,8 @@
 package logger
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,77 +10,154 @@ import (
 )
 
 func TestNewDefault(t *testing.T) {
-	logger := newDefault()
+	lg := newDefault()
 
-	require.NotNil(t, logger)
-	require.True(t, logger.Core().Enabled(zapcore.DebugLevel))
+	require.NotNil(t, lg)
+	require.True(t, lg.Core().Enabled(zapcore.DebugLevel))
 }
 
 func TestNewZapCfg(t *testing.T) {
 	tests := []struct {
-		name     string
-		mod      LogMod
-		level    zapcore.Level
-		expected zapcore.Level
+		name  string
+		mode  LogMod
+		level zapcore.Level
 	}{
-		{
-			name:     "Production mode",
-			mod:      ProductionMod,
-			level:    zapcore.InfoLevel,
-			expected: zapcore.InfoLevel,
-		},
-		{
-			name:     "Development mode",
-			mod:      DevelopmentMod,
-			level:    zapcore.DebugLevel,
-			expected: zapcore.DebugLevel,
-		},
-		{
-			name:     "Unknown mode",
-			mod:      "unknown",
-			level:    zapcore.WarnLevel,
-			expected: zapcore.WarnLevel,
-		},
+		{name: "production", mode: ProductionMod, level: zapcore.InfoLevel},
+		{name: "development", mode: DevelopmentMod, level: zapcore.DebugLevel},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := newZapCfg(tt.mod, tt.level)
-			require.Equal(t, tt.expected, cfg.Level.Level())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := newZapCfg(test.mode, test.level)
+			require.Equal(t, test.level, cfg.Level.Level())
 			require.True(t, cfg.DisableStacktrace)
 		})
 	}
 }
 
-func TestNewFromConfig(t *testing.T) {
-	config := &Config{
-		LogMod:   DevelopmentMod,
-		LogLevel: zapcore.InfoLevel.String(),
-	}
-	logger := NewFromConfig(config)
+func TestInitReplacesGlobal(t *testing.T) {
+	require.NoError(t, Init("info", "production"))
 
-	require.NotNil(t, logger)
-	require.True(t, logger.Core().Enabled(zapcore.InfoLevel))
+	lg := Global()
+	require.True(t, lg.Core().Enabled(zapcore.InfoLevel))
+	require.False(t, lg.Core().Enabled(zapcore.DebugLevel))
 }
 
-func TestGlobal(t *testing.T) {
-	logger1 := Global()
-	require.NotNil(t, logger1)
+func TestInitFailurePreservesGlobal(t *testing.T) {
+	require.NoError(t, Init("warn", "development"))
 
-	// Set a new logger and test again
-	config := &Config{
-		LogMod:   ProductionMod,
-		LogLevel: zapcore.WarnLevel.String(),
+	before := Global()
+
+	require.Error(t, Init("verbose", "development"))
+	require.Same(t, before, Global())
+
+	require.Error(t, Init("warn", "pretty"))
+	require.Same(t, before, Global())
+}
+
+func TestGlobalConcurrentReplacement(t *testing.T) {
+	const (
+		workers    = 32
+		iterations = 100
+	)
+
+	var (
+		wait   sync.WaitGroup
+		failed atomic.Bool
+	)
+	for range workers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+
+			for range iterations {
+				if Global() == nil || Init("debug", "development") != nil {
+					failed.Store(true)
+				}
+			}
+		}()
 	}
-	logger2 := NewFromConfig(config)
-	require.Same(t, logger2, Global())
 
-	require.True(t, logger2.Core().Enabled(zapcore.WarnLevel))
+	wait.Wait()
+	require.False(t, failed.Load())
+	require.NotNil(t, Global())
+}
+
+func TestNewFromConfig(t *testing.T) {
+	lg := NewFromConfig(&Config{LogMod: ProductionMod, LogLevel: "error"})
+
+	require.Same(t, lg, Global())
+	require.True(t, lg.Core().Enabled(zapcore.ErrorLevel))
+	require.False(t, lg.Core().Enabled(zapcore.WarnLevel))
+}
+
+func TestParseMode(t *testing.T) {
+	for _, mode := range []string{"development", "production"} {
+		parsed, err := ParseMode(mode)
+		require.NoError(t, err)
+		require.Equal(t, LogMod(mode), parsed)
+	}
+
+	_, err := ParseMode("pretty")
+	require.Error(t, err)
 }
 
 func TestNewStructLogger(t *testing.T) {
-	logger := NewStructLogger("test")
-	require.NotNil(t, logger)
+	lg := NewStructLogger("test")
+	require.NotNil(t, lg)
+}
 
-	require.NotNil(t, logger.Named("test"))
+func TestRedactDSN(t *testing.T) {
+	secrets := []string{"dsn-secret", "db-pass", "query-token", "query-secret", "api-secret"}
+	tests := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{
+			name: "url userinfo and repeated query secrets",
+			dsn: "postgres://user:dsn-secret@host:5432/db?sslmode=require" +
+				"&PASSWORD=db-pass&token=query-token&Token=query-secret" +
+				"&api-key=api-secret&keep=yes",
+			want: "postgres://user:xxxxx@host:5432/db?sslmode=require" +
+				"&PASSWORD=xxxxx&token=xxxxx&Token=xxxxx&api-key=xxxxx&keep=yes",
+		},
+		{
+			name: "mysql no scheme",
+			dsn:  "user:dsn-secret@tcp(host:3306)/db?passwd=db-pass",
+			want: "user:xxxxx@tcp(host:3306)/db?passwd=xxxxx",
+		},
+		{
+			name: "encoded secret key",
+			dsn:  "grpc://host/db?access%54oken=query-token&credentialS=query-secret",
+			want: "grpc://host/db?access%54oken=xxxxx&credentialS=xxxxx",
+		},
+		{
+			name: "malformed URL",
+			dsn:  "postgres://user:dsn-secret@%zz/db?pwd=query-secret",
+			want: "postgres://user:xxxxx@%zz/db?pwd=xxxxx",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := RedactDSN(test.dsn)
+			require.Equal(t, test.want, got)
+
+			for _, secret := range secrets {
+				require.NotContains(t, got, secret)
+			}
+		})
+	}
+
+	require.Equal(t, "postgres://host/db?sslmode=require", RedactDSN("postgres://host/db?sslmode=require"))
+	require.Empty(t, RedactDSN(""))
+}
+
+func TestRedactDSNDoesNotLeakMalformedSecretKeys(t *testing.T) {
+	got := RedactDSN("user:userinfo-secret@host/db?password%zz=malformed-secret&secret=still-secret")
+	require.NotContains(t, got, "userinfo-secret")
+	require.NotContains(t, got, "malformed-secret")
+	require.NotContains(t, got, "still-secret")
+	require.Contains(t, got, "password%zz=xxxxx")
 }

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -1,10 +1,14 @@
 package logger
 
 import (
+	"net/url"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 )
@@ -107,302 +111,152 @@ func TestNewStructLogger(t *testing.T) {
 	require.NotNil(t, lg)
 }
 
-func TestRedactDSN(t *testing.T) {
-	tests := []struct {
-		name      string
-		dsn       string
-		want      string
-		secrets   []string
-		preserved []string
-	}{
-		{
-			name: "userinfo and named query secrets",
-			dsn: "postgres://user:dsn-secret@host:5432/db?sslmode=require" +
-				"&PASSWORD=db-pass&token=query-token&Token=query-secret" +
-				"&api-key=api-secret&keep=yes",
-			want: "postgres://user:xxxxx@host:5432/db?sslmode=require" +
-				"&PASSWORD=xxxxx&token=xxxxx&Token=xxxxx&api-key=xxxxx&keep=yes",
-			secrets:   []string{"dsn-secret", "db-pass", "query-token", "query-secret", "api-secret"},
-			preserved: []string{"sslmode=require", "keep=yes"},
-		},
-		{
-			name: "secret suffix families",
-			dsn: "postgres://host/db?password=password-secret&passwd=passwd-secret&pwd=pwd-secret" +
-				"&dbPassword=db-password&db_password=db-underscore-password" +
-				"&clientSecret=client-secret&client_secret=client-underscore-secret" +
-				"&oauth_client_secret=oauth-secret&credential=credential-secret&credentials=credentials-secret" +
-				"&apiKey=api-key-secret&x-api-key=x-api-secret" +
-				"&access_token=access-secret&refreshToken=refresh-secret&auth-token=auth-secret" +
-				"&application_name=stroppy&sslmode=require",
-			want: "postgres://host/db?password=xxxxx&passwd=xxxxx&pwd=xxxxx" +
-				"&dbPassword=xxxxx&db_password=xxxxx" +
-				"&clientSecret=xxxxx&client_secret=xxxxx" +
-				"&oauth_client_secret=xxxxx&credential=xxxxx&credentials=xxxxx" +
-				"&apiKey=xxxxx&x-api-key=xxxxx" +
-				"&access_token=xxxxx&refreshToken=xxxxx&auth-token=xxxxx" +
-				"&application_name=stroppy&sslmode=require",
-			secrets: []string{
-				"password-secret", "passwd-secret", "pwd-secret", "db-password", "db-underscore-password",
-				"client-secret", "client-underscore-secret", "oauth-secret", "credential-secret", "credentials-secret",
-				"api-key-secret", "x-api-secret", "access-secret", "refresh-secret", "auth-secret",
-			},
-			preserved: []string{"application_name=stroppy", "sslmode=require"},
-		},
-		{
-			name: "encoded separators case variants and repeated values",
-			dsn: "grpc://host/db?CLIENT%5fSECRET=client-secret" +
-				"&oauth%255Fclient%255Fsecret=oauth-secret&refresh%2Dtoken=refresh-secret" +
-				"&x%2Dapi%2Dkey=api-secret&Token=first-token&token=second-token" +
-				"&keep=yes&sslmode=require",
-			want: "grpc://host/db?CLIENT%5fSECRET=xxxxx" +
-				"&oauth%255Fclient%255Fsecret=xxxxx&refresh%2Dtoken=xxxxx" +
-				"&x%2Dapi%2Dkey=xxxxx&Token=xxxxx&token=xxxxx" +
-				"&keep=yes&sslmode=require",
-			secrets: []string{
-				"client-secret", "oauth-secret", "refresh-secret", "api-secret", "first-token", "second-token",
-			},
-			preserved: []string{"keep=yes", "sslmode=require"},
-		},
-		{
-			name: "malformed no scheme",
-			dsn: "user:userinfo-secret@tcp(host:3306)/db?db%5Fpassword%zz=db-password" +
-				"&client%_secret=client-secret&password%zz=password-secret&keep=yes&charset=utf8",
-			want: "user:xxxxx@tcp(host:3306)/db?db%5Fpassword%zz=xxxxx" +
-				"&client%_secret=xxxxx&password%zz=xxxxx&keep=yes&charset=utf8",
-			secrets:   []string{"userinfo-secret", "db-password", "client-secret", "password-secret"},
-			preserved: []string{"keep=yes", "charset=utf8"},
-		},
-		{
-			name:      "userinfo stays inside URL authority",
-			dsn:       "postgres://user:dsn-secret@host:5432/db@name",
-			want:      "postgres://user:xxxxx@host:5432/db@name",
-			secrets:   []string{"dsn-secret"},
-			preserved: []string{"host:5432/db@name"},
-		},
-		{
-			name:      "userinfo does not scan URL fragment",
-			dsn:       "postgres://user:dsn-secret@host:5432/db#note@name",
-			want:      "postgres://user:xxxxx@host:5432/db#note@name",
-			secrets:   []string{"dsn-secret"},
-			preserved: []string{"host:5432/db#note@name"},
-		},
-		{
-			name:      "userinfo does not scan no scheme path",
-			dsn:       "user:dsn-secret@tcp(host:3306)/db@name",
-			want:      "user:xxxxx@tcp(host:3306)/db@name",
-			secrets:   []string{"dsn-secret"},
-			preserved: []string{"tcp(host:3306)/db@name"},
-		},
-		{
-			name: "PostgreSQL keyword secrets",
-			dsn: "host=localhost user=bench password=dsn-secret sslmode=require" +
-				" token=token-secret client_secret=client-secret application_name=worker:one@host",
-			want: "host=localhost user=bench password=xxxxx sslmode=require" +
-				" token=xxxxx client_secret=xxxxx application_name=worker:one@host",
-			secrets:   []string{"dsn-secret", "token-secret", "client-secret"},
-			preserved: []string{"host=localhost", "user=bench", "sslmode=require", "application_name=worker:one@host"},
-		},
-		{
-			name: "quoted and escaped PostgreSQL keyword secrets",
-			dsn: `host=localhost password='quoted secret' token='token\'secret' ` +
-				`client_secret='client\ secret' application_name='bench run'`,
-			want:      `host=localhost password=xxxxx token=xxxxx client_secret=xxxxx application_name='bench run'`,
-			secrets:   []string{"quoted secret", `token\'secret`, `client\ secret`},
-			preserved: []string{"host=localhost", "application_name='bench run'"},
-		},
-		{
-			name:      "unterminated PostgreSQL secret value",
-			dsn:       "host=localhost password='unterminated-secret sslmode=require",
-			want:      "host=localhost password=xxxxx",
-			secrets:   []string{"unterminated-secret"},
-			preserved: []string{"host=localhost"},
-		},
-		{
-			name:      "malformed PostgreSQL key value spacing",
-			dsn:       "host=localhost password = dsn-secret sslmode=require",
-			want:      "host=localhost password = xxxxx sslmode=require",
-			secrets:   []string{"dsn-secret"},
-			preserved: []string{"host=localhost", "sslmode=require"},
-		},
-		{
-			name:      "URI password begins after first colon",
-			dsn:       "postgres://u:pre:secret@host/db",
-			want:      "postgres://u:xxxxx@host/db",
-			secrets:   []string{"pre", "secret"},
-			preserved: []string{"host/db"},
-		},
-		{
-			name:      "PostgreSQL unquoted escaped whitespace",
-			dsn:       `host=db password=top\ secret sslmode=require`,
-			want:      "host=db password=xxxxx sslmode=require",
-			secrets:   []string{`top\ secret`, "secret"},
-			preserved: []string{"host=db", "sslmode=require"},
-		},
-		{
-			name:      "PostgreSQL unquoted escaped backslash",
-			dsn:       `host=db password=top\\secret sslmode=require`,
-			want:      "host=db password=xxxxx sslmode=require",
-			secrets:   []string{`top\\secret`, "secret"},
-			preserved: []string{"host=db", "sslmode=require"},
-		},
-		{
-			name:      "PostgreSQL malformed trailing escape",
-			dsn:       `host=db password=top\`,
-			want:      "host=db password=xxxxx",
-			secrets:   []string{`top\`, "top"},
-			preserved: []string{"host=db"},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := RedactDSN(test.dsn)
-			require.Equal(t, test.want, got)
-
-			for _, secret := range test.secrets {
-				require.NotContains(t, got, secret)
-			}
-
-			for _, option := range test.preserved {
-				require.Contains(t, got, option)
-			}
-		})
-	}
-
-	require.Equal(t, "postgres://host/db?sslmode=require", RedactDSN("postgres://host/db?sslmode=require"))
+func TestRedactDSNEmptyAndFallback(t *testing.T) {
 	require.Empty(t, RedactDSN(""))
+	require.Equal(t, redactedDSN, RedactDSN(redactedDSN))
 }
 
-func TestRedactDSNMySQLPasswordPunctuation(t *testing.T) {
+func TestRedactDSNURI(t *testing.T) {
+	dsn := "postgres://user:uri:secret@host:5432/db@name?sslmode=require" +
+		"&client_secret=query-secret&client%255Fsecret=nested-secret&keep=yes#note@name"
+
+	got := RedactDSN(dsn)
+	require.NotEqual(t, redactedDSN, got)
+	require.NotContains(t, got, "uri:secret")
+	require.NotContains(t, got, "query-secret")
+	require.NotContains(t, got, "nested-secret")
+	require.Equal(t, got, RedactDSN(got))
+
+	parsed, err := url.Parse(got)
+	require.NoError(t, err)
+	require.Equal(t, "host:5432", parsed.Host)
+	require.Equal(t, "/db@name", parsed.Path)
+	require.Equal(t, "note@name", parsed.Fragment)
+	_, passwordPresent := parsed.User.Password()
+	require.True(t, passwordPresent)
+
+	password, _ := parsed.User.Password()
+	require.Equal(t, redactedSecret, password)
+
+	query, err := url.ParseQuery(parsed.RawQuery)
+	require.NoError(t, err)
+	require.Equal(t, "require", query.Get("sslmode"))
+	require.Equal(t, "yes", query.Get("keep"))
+	require.Equal(t, redactedSecret, query.Get("client_secret"))
+	require.Equal(t, redactedSecret, query.Get("client%5Fsecret"))
+}
+
+func TestRedactDSNFallsBackForAmbiguousURI(t *testing.T) {
+	for _, dsn := range []string{
+		"postgres_://user:marker-secret@[2001:db8::1]:5432/db?sslmode=require",
+		"postgres://user:marker-secret@host/db?bad=%zz",
+		"postgres://user:marker-secret@host/db?x=1;y=2",
+	} {
+		got := RedactDSN(dsn)
+		require.Equal(t, redactedDSN, got)
+		require.NotContains(t, got, "marker-secret")
+	}
+}
+
+func TestRedactDSNMySQL(t *testing.T) {
 	tests := []struct {
-		name   string
-		marker string
+		name string
+		dsn  string
 	}{
-		{name: "colon", marker: "marker:colon"},
-		{name: "slash", marker: "marker/slash"},
-		{name: "at sign", marker: "marker@at"},
-		{name: "question mark", marker: "marker?query"},
-		{name: "fragment mark", marker: "marker#fragment"},
+		{
+			name: "equals username and secret params",
+			dsn:  "bench=prod:marker-secret@tcp(db:3306)/bench?charset=utf8&client_secret=query-secret",
+		},
+		{
+			name: "password contains scheme separator",
+			dsn:  "user:marker://secret@tcp(db:3306)/bench?keep=yes",
+		},
+		{
+			name: "password-like username stays MySQL",
+			dsn:  "password=account:marker-secret@tcp(db:3306)/bench?sslmode=require",
+		},
+		{
+			name: "custom network",
+			dsn:  "user:marker-secret@custom-net(db:3306)/bench?keep=yes",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dsn := "user:" + test.marker + "@tcp(db:3306)/bench?charset=utf8"
-			got := RedactDSN(dsn)
+			original, err := mysql.ParseDSN(test.dsn)
+			require.NoError(t, err)
 
-			require.Equal(t, "user:xxxxx@tcp(db:3306)/bench?charset=utf8", got)
-			require.NotContains(t, got, test.marker)
-			require.Contains(t, got, "tcp(db:3306)/bench")
-			require.Contains(t, got, "charset=utf8")
+			got := RedactDSN(test.dsn)
+			require.NotEqual(t, redactedDSN, got)
+			require.NotContains(t, got, "marker-secret")
+			require.Equal(t, got, RedactDSN(got))
+
+			parsed, err := mysql.ParseDSN(got)
+			require.NoError(t, err)
+			require.Equal(t, original.User, parsed.User)
+			require.Equal(t, original.Net, parsed.Net)
+			require.Equal(t, original.Addr, parsed.Addr)
+			require.Equal(t, original.DBName, parsed.DBName)
+			require.Equal(t, redactedSecret, parsed.Passwd)
+
+			for key, value := range original.Params {
+				if isSecretName(key) {
+					require.Equal(t, redactedSecret, parsed.Params[key])
+				} else {
+					require.Equal(t, value, parsed.Params[key])
+				}
+			}
 		})
 	}
 }
 
-func TestRedactDSNMySQLMalformedUserinfo(t *testing.T) {
-	got := RedactDSN("user:marker-secret@tcp(db:3306")
-
-	require.Equal(t, "user:xxxxx@tcp(db:3306", got)
-	require.NotContains(t, got, "marker-secret")
-	require.Contains(t, got, "tcp(db:3306")
+func TestRedactDSNFallsBackForMalformedMySQL(t *testing.T) {
+	for _, dsn := range []string{
+		"user:marker-secret@tcp[db:3306]/bench",
+		"bench=prod:marker-secret@tcp[db:3306]/bench",
+		"user:marker-secret@custom-net(db:3306)",
+	} {
+		got := RedactDSN(dsn)
+		require.Equal(t, redactedDSN, got)
+		require.NotContains(t, got, "marker-secret")
+	}
 }
 
-func TestRedactDSNLayeredGrammarPasses(t *testing.T) {
+func TestRedactDSNConninfo(t *testing.T) {
 	tests := []struct {
-		name      string
-		dsn       string
-		want      string
-		secrets   []string
-		preserved []string
+		name string
+		dsn  string
+		want string
 	}{
 		{
-			name:    "malformed scheme authority with IPv6",
-			dsn:     "postgres_://user:marker-secret@[2001:db8::1]:5432/db?sslmode=require",
-			want:    "postgres_://user:xxxxx@[2001:db8::1]:5432/db?sslmode=require",
-			secrets: []string{"marker-secret"},
-			preserved: []string{
-				"[2001:db8::1]:5432/db", "sslmode=require",
-			},
+			name: "duplicate secrets preserve outside spans",
+			dsn:  "host=db application_name=worker:@/path password=first-secret sslmode=require token=second-secret",
+			want: "host=db application_name=worker:@/path password=xxxxx sslmode=require token=xxxxx",
 		},
 		{
-			name:    "MySQL username with equals",
-			dsn:     "bench=prod:marker-secret@tcp(db:3306)/bench?charset=utf8",
-			want:    "bench=prod:xxxxx@tcp(db:3306)/bench?charset=utf8",
-			secrets: []string{"marker-secret"},
-			preserved: []string{
-				"bench=prod", "tcp(db:3306)/bench", "charset=utf8",
-			},
+			name: "quoted token text is content not query",
+			dsn:  "host=db application_name='?token=not-a-query' password='quoted secret' sslmode=require",
+			want: "host=db application_name='?token=not-a-query' password=xxxxx sslmode=require",
 		},
 		{
-			name:    "custom MySQL protocol",
-			dsn:     "user:custom-secret@custom-net(db:3306)/bench?parseTime=true",
-			want:    "user:xxxxx@custom-net(db:3306)/bench?parseTime=true",
-			secrets: []string{"custom-secret"},
-			preserved: []string{
-				"custom-net(db:3306)/bench", "parseTime=true",
-			},
+			name: "UTF-8 bytes stay inside value",
+			dsn:  "host=db password=pàss-marker sslmode=require",
+			want: "host=db password=xxxxx sslmode=require",
 		},
 		{
-			name:    "tcp4 MySQL protocol",
-			dsn:     "user:tcp4-secret@tcp4(db:3306)/bench",
-			want:    "user:xxxxx@tcp4(db:3306)/bench",
-			secrets: []string{"tcp4-secret"},
-			preserved: []string{
-				"tcp4(db:3306)/bench",
-			},
+			name: "ASCII whitespace only",
+			dsn:  "host=db\tpassword=tab-secret\nsslmode=require",
+			want: "host=db\tpassword=xxxxx\nsslmode=require",
 		},
 		{
-			name:    "tcp6 MySQL protocol",
-			dsn:     "user:tcp6-secret@tcp6([::1]:3306)/bench",
-			want:    "user:xxxxx@tcp6([::1]:3306)/bench",
-			secrets: []string{"tcp6-secret"},
-			preserved: []string{
-				"tcp6([::1]:3306)/bench",
-			},
+			name: "escaped unquoted whitespace",
+			dsn:  `host=db password=top\ secret sslmode=require`,
+			want: "host=db password=xxxxx sslmode=require",
 		},
 		{
-			name:    "custom malformed MySQL protocol",
-			dsn:     "user:custom-malformed-secret@custom-net(db:3306)",
-			want:    "user:xxxxx@custom-net(db:3306)",
-			secrets: []string{"custom-malformed-secret"},
-			preserved: []string{
-				"custom-net(db:3306)",
-			},
-		},
-		{
-			name:    "malformed MySQL protocol with equals username",
-			dsn:     "bench=prod:malformed-secret@tcp[db:3306]/bench",
-			want:    "bench=prod:xxxxx@tcp[db:3306]/bench",
-			secrets: []string{"malformed-secret"},
-			preserved: []string{
-				"bench=prod", "tcp[db:3306]/bench",
-			},
-		},
-		{
-			name:    "malformed MySQL protocol",
-			dsn:     "user:malformed-secret@tcp[db:3306]/bench",
-			want:    "user:xxxxx@tcp[db:3306]/bench",
-			secrets: []string{"malformed-secret"},
-			preserved: []string{
-				"tcp[db:3306]/bench",
-			},
-		},
-		{
-			name:    "leading malformed conninfo token",
-			dsn:     "junk host=db password=marker-secret sslmode=require",
-			want:    "junk host=db password=xxxxx sslmode=require",
-			secrets: []string{"marker-secret"},
-			preserved: []string{
-				"junk", "host=db", "sslmode=require",
-			},
-		},
-		{
-			name:    "interspersed malformed conninfo token",
-			dsn:     "host=db junk password=marker-secret sslmode=require",
-			want:    "host=db junk password=xxxxx sslmode=require",
-			secrets: []string{"marker-secret"},
-			preserved: []string{
-				"host=db", "junk", "sslmode=require",
-			},
+			name: "escaped quoted content",
+			dsn:  `host=db password='top\'secret' sslmode=require`,
+			want: "host=db password=xxxxx sslmode=require",
 		},
 	}
 
@@ -410,14 +264,52 @@ func TestRedactDSNLayeredGrammarPasses(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := RedactDSN(test.dsn)
 			require.Equal(t, test.want, got)
+			require.Equal(t, got, RedactDSN(got))
+			require.NotContains(t, got, "secret")
+			require.NotContains(t, got, "pàss-marker")
+		})
+	}
+}
 
-			for _, secret := range test.secrets {
-				require.NotContains(t, got, secret)
-			}
+func TestRedactDSNFallsBackForMalformedConninfo(t *testing.T) {
+	for _, dsn := range []string{
+		"host=db junk password=marker-secret sslmode=require",
+		"junk host=db password=marker-secret sslmode=require",
+		"host=db password=top\\",
+		"host=db password='unterminated-secret",
+	} {
+		got := RedactDSN(dsn)
+		require.Equal(t, redactedDSN, got)
+		require.NotContains(t, got, "marker-secret")
+		require.NotContains(t, got, "unterminated-secret")
+	}
+}
 
-			for _, value := range test.preserved {
-				require.Contains(t, got, value)
-			}
+func TestRedactDSNInvariants(t *testing.T) {
+	for index := range 32 {
+		marker := "marker" + strconv.Itoa(index)
+		for _, dsn := range []string{
+			"user:" + marker + "@tcp(db:3306)/bench?token=" + marker,
+			"host=db password=" + marker + " token=" + marker + " sslmode=require",
+		} {
+			got := RedactDSN(dsn)
+			require.NotContains(t, got, marker)
+			require.Equal(t, got, RedactDSN(got))
+		}
+	}
+}
+
+func TestRedactDSNNeverPanicsOnArbitraryBytes(t *testing.T) {
+	inputs := []string{
+		string([]byte{0xff, 0xfe, ':', '@', 0x00}),
+		"host=db password=marker\x00secret",
+		"postgres://user:marker-secret@host/\x00",
+		strings.Repeat("!@:/?#%", 4096),
+	}
+
+	for _, input := range inputs {
+		t.Run(strconv.Quote(input[:min(len(input), 16)]), func(t *testing.T) {
+			require.NotPanics(t, func() { _ = RedactDSN(input) })
 		})
 	}
 }

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -118,13 +118,17 @@ func TestRedactDSNEmptyAndFallback(t *testing.T) {
 
 func TestRedactDSNURI(t *testing.T) {
 	dsn := "postgres://user:uri:secret@host:5432/db@name?sslmode=require" +
-		"&client_secret=query-secret&client%255Fsecret=nested-secret&keep=yes#note@name"
+		"&client_secret=query-secret&client%255Fsecret=nested-secret" +
+		"&x%2Dapi%2Dkey=api-secret&token=first-token&token=second-token&keep=yes#note@name"
 
 	got := RedactDSN(dsn)
 	require.NotEqual(t, redactedDSN, got)
 	require.NotContains(t, got, "uri:secret")
 	require.NotContains(t, got, "query-secret")
 	require.NotContains(t, got, "nested-secret")
+	require.NotContains(t, got, "api-secret")
+	require.NotContains(t, got, "first-token")
+	require.NotContains(t, got, "second-token")
 	require.Equal(t, got, RedactDSN(got))
 
 	parsed, err := url.Parse(got)
@@ -144,40 +148,46 @@ func TestRedactDSNURI(t *testing.T) {
 	require.Equal(t, "yes", query.Get("keep"))
 	require.Equal(t, redactedSecret, query.Get("client_secret"))
 	require.Equal(t, redactedSecret, query.Get("client%5Fsecret"))
+	require.Equal(t, redactedSecret, query.Get("x-api-key"))
+	require.Equal(t, []string{redactedSecret, redactedSecret}, query["token"])
 }
 
 func TestRedactDSNFallsBackForAmbiguousURI(t *testing.T) {
 	for _, dsn := range []string{
 		"postgres_://user:marker-secret@[2001:db8::1]:5432/db?sslmode=require",
 		"postgres://user:marker-secret@host/db?bad=%zz",
+		"postgres://user:marker-secret@host/db?client+secret=query-secret",
 		"postgres://user:marker-secret@host/db?x=1;y=2",
 	} {
 		got := RedactDSN(dsn)
 		require.Equal(t, redactedDSN, got)
 		require.NotContains(t, got, "marker-secret")
+		require.NotContains(t, got, "query-secret")
 	}
 }
 
 func TestRedactDSNMySQL(t *testing.T) {
 	tests := []struct {
-		name string
-		dsn  string
+		name          string
+		dsn           string
+		emptyPassword bool
 	}{
-		{
-			name: "equals username and secret params",
-			dsn:  "bench=prod:marker-secret@tcp(db:3306)/bench?charset=utf8&client_secret=query-secret",
-		},
 		{
 			name: "password contains scheme separator",
 			dsn:  "user:marker://secret@tcp(db:3306)/bench?keep=yes",
 		},
 		{
-			name: "password-like username stays MySQL",
-			dsn:  "password=account:marker-secret@tcp(db:3306)/bench?sslmode=require",
-		},
-		{
 			name: "custom network",
 			dsn:  "user:marker-secret@custom-net(db:3306)/bench?keep=yes",
+		},
+		{
+			name: "encoded secret parameter",
+			dsn:  "user:marker-secret@tcp(db:3306)/bench?client%5Fsecret=query-secret&keep=yes&charset=utf8",
+		},
+		{
+			name:          "explicit empty password",
+			dsn:           "user:@tcp(db:3306)/bench?charset=utf8",
+			emptyPassword: true,
 		},
 	}
 
@@ -185,6 +195,10 @@ func TestRedactDSNMySQL(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			original, err := mysql.ParseDSN(test.dsn)
 			require.NoError(t, err)
+
+			if test.emptyPassword {
+				require.Empty(t, original.Passwd)
+			}
 
 			got := RedactDSN(test.dsn)
 			require.NotEqual(t, redactedDSN, got)
@@ -200,7 +214,10 @@ func TestRedactDSNMySQL(t *testing.T) {
 			require.Equal(t, redactedSecret, parsed.Passwd)
 
 			for key, value := range original.Params {
-				if isSecretName(key) {
+				secret, certain := classifyQueryKey(key)
+				require.True(t, certain)
+
+				if secret {
 					require.Equal(t, redactedSecret, parsed.Params[key])
 				} else {
 					require.Equal(t, value, parsed.Params[key])
@@ -219,6 +236,30 @@ func TestRedactDSNFallsBackForMalformedMySQL(t *testing.T) {
 		got := RedactDSN(dsn)
 		require.Equal(t, redactedDSN, got)
 		require.NotContains(t, got, "marker-secret")
+	}
+}
+
+func TestRedactDSNFallsBackForUncertainMySQLParam(t *testing.T) {
+	dsn := "user:marker-secret@tcp(db:3306)/bench?client+secret=query-secret&keep=yes"
+	got := RedactDSN(dsn)
+
+	require.Equal(t, redactedDSN, got)
+	require.NotContains(t, got, "marker-secret")
+	require.NotContains(t, got, "query-secret")
+}
+
+func TestRedactDSNFallsBackForConninfoMySQLAmbiguity(t *testing.T) {
+	for _, dsn := range []string{
+		"password=marker-secret:other-secret@tcp(db:3306)/bench?keep=yes",
+		"bench=prod:marker-secret@tcp(db:3306)/bench?keep=yes",
+		"password=account:marker-secret@tcp(db:3306)/bench?keep=yes",
+	} {
+		got := RedactDSN(dsn)
+
+		require.Equal(t, redactedDSN, got)
+		require.NotContains(t, got, "marker-secret")
+		require.NotContains(t, got, "other-secret")
+		require.Equal(t, got, RedactDSN(got))
 	}
 }
 

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -305,3 +305,119 @@ func TestRedactDSNMySQLMalformedUserinfo(t *testing.T) {
 	require.NotContains(t, got, "marker-secret")
 	require.Contains(t, got, "tcp(db:3306")
 }
+
+func TestRedactDSNLayeredGrammarPasses(t *testing.T) {
+	tests := []struct {
+		name      string
+		dsn       string
+		want      string
+		secrets   []string
+		preserved []string
+	}{
+		{
+			name:    "malformed scheme authority with IPv6",
+			dsn:     "postgres_://user:marker-secret@[2001:db8::1]:5432/db?sslmode=require",
+			want:    "postgres_://user:xxxxx@[2001:db8::1]:5432/db?sslmode=require",
+			secrets: []string{"marker-secret"},
+			preserved: []string{
+				"[2001:db8::1]:5432/db", "sslmode=require",
+			},
+		},
+		{
+			name:    "MySQL username with equals",
+			dsn:     "bench=prod:marker-secret@tcp(db:3306)/bench?charset=utf8",
+			want:    "bench=prod:xxxxx@tcp(db:3306)/bench?charset=utf8",
+			secrets: []string{"marker-secret"},
+			preserved: []string{
+				"bench=prod", "tcp(db:3306)/bench", "charset=utf8",
+			},
+		},
+		{
+			name:    "custom MySQL protocol",
+			dsn:     "user:custom-secret@custom-net(db:3306)/bench?parseTime=true",
+			want:    "user:xxxxx@custom-net(db:3306)/bench?parseTime=true",
+			secrets: []string{"custom-secret"},
+			preserved: []string{
+				"custom-net(db:3306)/bench", "parseTime=true",
+			},
+		},
+		{
+			name:    "tcp4 MySQL protocol",
+			dsn:     "user:tcp4-secret@tcp4(db:3306)/bench",
+			want:    "user:xxxxx@tcp4(db:3306)/bench",
+			secrets: []string{"tcp4-secret"},
+			preserved: []string{
+				"tcp4(db:3306)/bench",
+			},
+		},
+		{
+			name:    "tcp6 MySQL protocol",
+			dsn:     "user:tcp6-secret@tcp6([::1]:3306)/bench",
+			want:    "user:xxxxx@tcp6([::1]:3306)/bench",
+			secrets: []string{"tcp6-secret"},
+			preserved: []string{
+				"tcp6([::1]:3306)/bench",
+			},
+		},
+		{
+			name:    "custom malformed MySQL protocol",
+			dsn:     "user:custom-malformed-secret@custom-net(db:3306)",
+			want:    "user:xxxxx@custom-net(db:3306)",
+			secrets: []string{"custom-malformed-secret"},
+			preserved: []string{
+				"custom-net(db:3306)",
+			},
+		},
+		{
+			name:    "malformed MySQL protocol with equals username",
+			dsn:     "bench=prod:malformed-secret@tcp[db:3306]/bench",
+			want:    "bench=prod:xxxxx@tcp[db:3306]/bench",
+			secrets: []string{"malformed-secret"},
+			preserved: []string{
+				"bench=prod", "tcp[db:3306]/bench",
+			},
+		},
+		{
+			name:    "malformed MySQL protocol",
+			dsn:     "user:malformed-secret@tcp[db:3306]/bench",
+			want:    "user:xxxxx@tcp[db:3306]/bench",
+			secrets: []string{"malformed-secret"},
+			preserved: []string{
+				"tcp[db:3306]/bench",
+			},
+		},
+		{
+			name:    "leading malformed conninfo token",
+			dsn:     "junk host=db password=marker-secret sslmode=require",
+			want:    "junk host=db password=xxxxx sslmode=require",
+			secrets: []string{"marker-secret"},
+			preserved: []string{
+				"junk", "host=db", "sslmode=require",
+			},
+		},
+		{
+			name:    "interspersed malformed conninfo token",
+			dsn:     "host=db junk password=marker-secret sslmode=require",
+			want:    "host=db junk password=xxxxx sslmode=require",
+			secrets: []string{"marker-secret"},
+			preserved: []string{
+				"host=db", "junk", "sslmode=require",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := RedactDSN(test.dsn)
+			require.Equal(t, test.want, got)
+
+			for _, secret := range test.secrets {
+				require.NotContains(t, got, secret)
+			}
+
+			for _, value := range test.preserved {
+				require.Contains(t, got, value)
+			}
+		})
+	}
+}

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -172,6 +172,58 @@ func TestRedactDSN(t *testing.T) {
 			secrets:   []string{"userinfo-secret", "db-password", "client-secret", "password-secret"},
 			preserved: []string{"keep=yes", "charset=utf8"},
 		},
+		{
+			name:      "userinfo stays inside URL authority",
+			dsn:       "postgres://user:dsn-secret@host:5432/db@name",
+			want:      "postgres://user:xxxxx@host:5432/db@name",
+			secrets:   []string{"dsn-secret"},
+			preserved: []string{"host:5432/db@name"},
+		},
+		{
+			name:      "userinfo does not scan URL fragment",
+			dsn:       "postgres://user:dsn-secret@host:5432/db#note@name",
+			want:      "postgres://user:xxxxx@host:5432/db#note@name",
+			secrets:   []string{"dsn-secret"},
+			preserved: []string{"host:5432/db#note@name"},
+		},
+		{
+			name:      "userinfo does not scan no scheme path",
+			dsn:       "user:dsn-secret@tcp(host:3306)/db@name",
+			want:      "user:xxxxx@tcp(host:3306)/db@name",
+			secrets:   []string{"dsn-secret"},
+			preserved: []string{"tcp(host:3306)/db@name"},
+		},
+		{
+			name: "PostgreSQL keyword secrets",
+			dsn: "host=localhost user=bench password=dsn-secret sslmode=require" +
+				" token=token-secret client_secret=client-secret application_name=worker:one@host",
+			want: "host=localhost user=bench password=xxxxx sslmode=require" +
+				" token=xxxxx client_secret=xxxxx application_name=worker:one@host",
+			secrets:   []string{"dsn-secret", "token-secret", "client-secret"},
+			preserved: []string{"host=localhost", "user=bench", "sslmode=require", "application_name=worker:one@host"},
+		},
+		{
+			name: "quoted and escaped PostgreSQL keyword secrets",
+			dsn: `host=localhost password='quoted secret' token='token\'secret' ` +
+				`client_secret='client\ secret' application_name='bench run'`,
+			want:      `host=localhost password=xxxxx token=xxxxx client_secret=xxxxx application_name='bench run'`,
+			secrets:   []string{"quoted secret", `token\'secret`, `client\ secret`},
+			preserved: []string{"host=localhost", "application_name='bench run'"},
+		},
+		{
+			name:      "unterminated PostgreSQL secret value",
+			dsn:       "host=localhost password='unterminated-secret sslmode=require",
+			want:      "host=localhost password=xxxxx",
+			secrets:   []string{"unterminated-secret"},
+			preserved: []string{"host=localhost"},
+		},
+		{
+			name:      "malformed PostgreSQL key value spacing",
+			dsn:       "host=localhost password = dsn-secret sslmode=require",
+			want:      "host=localhost password = xxxxx sslmode=require",
+			secrets:   []string{"dsn-secret"},
+			preserved: []string{"host=localhost", "sslmode=require"},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -189,6 +189,14 @@ func TestRedactDSNMySQL(t *testing.T) {
 			dsn:           "user:@tcp(db:3306)/bench?charset=utf8",
 			emptyPassword: true,
 		},
+		{
+			name: "whitespace password",
+			dsn:  "user:marker secret@tcp(db:3306)/bench?charset=utf8",
+		},
+		{
+			name: "addressless protocol",
+			dsn:  "user:marker-secret@tcp/bench?charset=utf8",
+		},
 	}
 
 	for _, test := range tests {
@@ -202,7 +210,11 @@ func TestRedactDSNMySQL(t *testing.T) {
 
 			got := RedactDSN(test.dsn)
 			require.NotEqual(t, redactedDSN, got)
-			require.NotContains(t, got, "marker-secret")
+
+			for _, marker := range []string{"marker-secret", "marker secret", "query-secret"} {
+				require.NotContains(t, got, marker)
+			}
+
 			require.Equal(t, got, RedactDSN(got))
 
 			parsed, err := mysql.ParseDSN(got)

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -261,17 +261,67 @@ func TestRedactDSNFallsBackForUncertainMySQLParam(t *testing.T) {
 }
 
 func TestRedactDSNFallsBackForConninfoMySQLAmbiguity(t *testing.T) {
-	for _, dsn := range []string{
-		"password=marker-secret:other-secret@tcp(db:3306)/bench?keep=yes",
-		"bench=prod:marker-secret@tcp(db:3306)/bench?keep=yes",
-		"password=account:marker-secret@tcp(db:3306)/bench?keep=yes",
-	} {
-		got := RedactDSN(dsn)
+	tests := []struct {
+		name    string
+		dsn     string
+		secrets []string
+	}{
+		{
+			name: "single-token overlap",
+			dsn:  "password=marker-secret:other-secret@tcp(db:3306)/bench?keep=yes",
+			secrets: []string{
+				"marker-secret", "other-secret",
+			},
+		},
+		{
+			name: "equals username",
+			dsn:  "bench=prod:marker-secret@tcp(db:3306)/bench?keep=yes",
+			secrets: []string{
+				"marker-secret",
+			},
+		},
+		{
+			name: "password-like username",
+			dsn:  "password=account:marker-secret@tcp(db:3306)/bench?keep=yes",
+			secrets: []string{
+				"marker-secret",
+			},
+		},
+		{
+			name: "space-separated dual grammar",
+			dsn:  "bench=prod:first-secret password=second-secret@tcp(db:3306)/bench?keep=yes",
+			secrets: []string{
+				"first-secret", "second-secret",
+			},
+		},
+		{
+			name: "tab-separated dual grammar",
+			dsn:  "bench=prod:first-secret\tpassword=second-secret@tcp(db:3306)/bench?keep=yes",
+			secrets: []string{
+				"first-secret", "second-secret",
+			},
+		},
+		{
+			name: "newline-separated dual grammar",
+			dsn:  "bench=prod:first-secret\npassword=second-secret@tcp(db:3306)/bench?keep=yes",
+			secrets: []string{
+				"first-secret", "second-secret",
+			},
+		},
+	}
 
-		require.Equal(t, redactedDSN, got)
-		require.NotContains(t, got, "marker-secret")
-		require.NotContains(t, got, "other-secret")
-		require.Equal(t, got, RedactDSN(got))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := RedactDSN(test.dsn)
+
+			require.Equal(t, redactedDSN, got)
+
+			for _, secret := range test.secrets {
+				require.NotContains(t, got, secret)
+			}
+
+			require.Equal(t, got, RedactDSN(got))
+		})
 	}
 }
 
@@ -283,8 +333,8 @@ func TestRedactDSNConninfo(t *testing.T) {
 	}{
 		{
 			name: "duplicate secrets preserve outside spans",
-			dsn:  "host=db application_name=worker:@/path password=first-secret sslmode=require token=second-secret",
-			want: "host=db application_name=worker:@/path password=xxxxx sslmode=require token=xxxxx",
+			dsn:  "host=db application_name=worker password=first-secret sslmode=require token=second-secret",
+			want: "host=db application_name=worker password=xxxxx sslmode=require token=xxxxx",
 		},
 		{
 			name: "quoted token text is content not query",

--- a/pkg/common/logger/logger_test.go
+++ b/pkg/common/logger/logger_test.go
@@ -224,6 +224,34 @@ func TestRedactDSN(t *testing.T) {
 			secrets:   []string{"dsn-secret"},
 			preserved: []string{"host=localhost", "sslmode=require"},
 		},
+		{
+			name:      "URI password begins after first colon",
+			dsn:       "postgres://u:pre:secret@host/db",
+			want:      "postgres://u:xxxxx@host/db",
+			secrets:   []string{"pre", "secret"},
+			preserved: []string{"host/db"},
+		},
+		{
+			name:      "PostgreSQL unquoted escaped whitespace",
+			dsn:       `host=db password=top\ secret sslmode=require`,
+			want:      "host=db password=xxxxx sslmode=require",
+			secrets:   []string{`top\ secret`, "secret"},
+			preserved: []string{"host=db", "sslmode=require"},
+		},
+		{
+			name:      "PostgreSQL unquoted escaped backslash",
+			dsn:       `host=db password=top\\secret sslmode=require`,
+			want:      "host=db password=xxxxx sslmode=require",
+			secrets:   []string{`top\\secret`, "secret"},
+			preserved: []string{"host=db", "sslmode=require"},
+		},
+		{
+			name:      "PostgreSQL malformed trailing escape",
+			dsn:       `host=db password=top\`,
+			want:      "host=db password=xxxxx",
+			secrets:   []string{`top\`, "top"},
+			preserved: []string{"host=db"},
+		},
 	}
 
 	for _, test := range tests {
@@ -243,4 +271,37 @@ func TestRedactDSN(t *testing.T) {
 
 	require.Equal(t, "postgres://host/db?sslmode=require", RedactDSN("postgres://host/db?sslmode=require"))
 	require.Empty(t, RedactDSN(""))
+}
+
+func TestRedactDSNMySQLPasswordPunctuation(t *testing.T) {
+	tests := []struct {
+		name   string
+		marker string
+	}{
+		{name: "colon", marker: "marker:colon"},
+		{name: "slash", marker: "marker/slash"},
+		{name: "at sign", marker: "marker@at"},
+		{name: "question mark", marker: "marker?query"},
+		{name: "fragment mark", marker: "marker#fragment"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dsn := "user:" + test.marker + "@tcp(db:3306)/bench?charset=utf8"
+			got := RedactDSN(dsn)
+
+			require.Equal(t, "user:xxxxx@tcp(db:3306)/bench?charset=utf8", got)
+			require.NotContains(t, got, test.marker)
+			require.Contains(t, got, "tcp(db:3306)/bench")
+			require.Contains(t, got, "charset=utf8")
+		})
+	}
+}
+
+func TestRedactDSNMySQLMalformedUserinfo(t *testing.T) {
+	got := RedactDSN("user:marker-secret@tcp(db:3306")
+
+	require.Equal(t, "user:xxxxx@tcp(db:3306", got)
+	require.NotContains(t, got, "marker-secret")
+	require.Contains(t, got, "tcp(db:3306")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 )
 
 // DriverType identifies a database driver implementation.
@@ -168,55 +169,176 @@ func (m LogMode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(int32(m))
 }
 
+func (l LogLevel) Short() string {
+	switch l {
+	case LogLevelDebug:
+		return "debug"
+	case LogLevelInfo:
+		return "info"
+	case LogLevelWarn:
+		return "warn"
+	case LogLevelError:
+		return "error"
+	case LogLevelFatal:
+		return "fatal"
+	default:
+		return ""
+	}
+}
+
+func (m LogMode) Short() string {
+	switch m {
+	case LogModeDevelopment:
+		return "development"
+	case LogModeProduction:
+		return "production"
+	default:
+		return ""
+	}
+}
+
+// ParseLogLevel accepts the short and v5 logging level names, or a valid ordinal.
+func ParseLogLevel(value string) (LogLevel, error) {
+	if level, ok := parseLogLevelName(value); ok {
+		return level, nil
+	}
+
+	ordinal, err := strconv.ParseInt(value, 10, 32)
+	if err == nil {
+		level := LogLevel(ordinal)
+		if _, ok := logLevelNames[level]; ok {
+			return level, nil
+		}
+	}
+
+	return 0, fmt.Errorf("%w: %q", errInvalidLogLevel, value)
+}
+
+// ParseLogMode accepts the short and v5 logging mode names, or a valid ordinal.
+func parseLogLevelName(value string) (LogLevel, bool) {
+	for _, level := range LogLevelValues() {
+		if value == level.Short() || value == level.String() {
+			return level, true
+		}
+	}
+
+	return 0, false
+}
+
+func ParseLogMode(value string) (LogMode, error) {
+	if mode, ok := parseLogModeName(value); ok {
+		return mode, nil
+	}
+
+	ordinal, err := strconv.ParseInt(value, 10, 32)
+	if err == nil {
+		mode := LogMode(ordinal)
+		if _, ok := logModeNames[mode]; ok {
+			return mode, nil
+		}
+	}
+
+	return 0, fmt.Errorf("%w: %q", errInvalidLogMode, value)
+}
+
+func parseLogModeName(value string) (LogMode, bool) {
+	for _, mode := range LogModeValues() {
+		if value == mode.Short() || value == mode.String() {
+			return mode, true
+		}
+	}
+
+	return 0, false
+}
+
 func (l *LogLevel) UnmarshalJSON(data []byte) error {
-	value, err := unmarshalEnum(data, logLevelNames, errInvalidLogLevel)
+	value, err := unmarshalLogLevel(data)
 	if err != nil {
 		return err
 	}
 
-	*l = LogLevel(value)
+	*l = value
 
 	return nil
 }
 
 func (m *LogMode) UnmarshalJSON(data []byte) error {
-	value, err := unmarshalEnum(data, logModeNames, errInvalidLogMode)
+	value, err := unmarshalLogMode(data)
 	if err != nil {
 		return err
 	}
 
-	*m = LogMode(value)
+	*m = value
 
 	return nil
 }
 
-func unmarshalEnum[T ~int32](data []byte, names map[T]string, kind error) (int32, error) {
+func unmarshalLogLevel(data []byte) (LogLevel, error) {
 	if string(data) == "null" {
-		return 0, nil
+		return LogLevelDebug, nil
 	}
 
-	var name string
 	if len(data) > 0 && data[0] == '"' {
+		var name string
 		if err := json.Unmarshal(data, &name); err != nil {
 			return 0, err
 		}
 
-		for value, candidate := range names {
-			if name == candidate {
-				return int32(value), nil
-			}
+		if level, ok := parseLogLevelName(name); ok {
+			return level, nil
 		}
 
-		return 0, fmt.Errorf("%w: %q", kind, name)
+		return 0, fmt.Errorf("%w: %q", errInvalidLogLevel, name)
 	}
 
+	ordinal, err := unmarshalEnumOrdinal(data, errInvalidLogLevel)
+	if err != nil {
+		return 0, err
+	}
+
+	level := LogLevel(ordinal)
+	if _, ok := logLevelNames[level]; !ok {
+		return 0, fmt.Errorf("%w: %d", errInvalidLogLevel, ordinal)
+	}
+
+	return level, nil
+}
+
+func unmarshalLogMode(data []byte) (LogMode, error) {
+	if string(data) == "null" {
+		return LogModeDevelopment, nil
+	}
+
+	if len(data) > 0 && data[0] == '"' {
+		var name string
+		if err := json.Unmarshal(data, &name); err != nil {
+			return 0, err
+		}
+
+		if mode, ok := parseLogModeName(name); ok {
+			return mode, nil
+		}
+
+		return 0, fmt.Errorf("%w: %q", errInvalidLogMode, name)
+	}
+
+	ordinal, err := unmarshalEnumOrdinal(data, errInvalidLogMode)
+	if err != nil {
+		return 0, err
+	}
+
+	mode := LogMode(ordinal)
+	if _, ok := logModeNames[mode]; !ok {
+		return 0, fmt.Errorf("%w: %d", errInvalidLogMode, ordinal)
+	}
+
+	return mode, nil
+}
+
+func unmarshalEnumOrdinal(data []byte, kind error) (int32, error) {
 	var ordinal int32
 	if err := json.Unmarshal(data, &ordinal); err != nil {
 		return 0, fmt.Errorf("%w: %s", kind, data)
-	}
-
-	if _, ok := names[T(ordinal)]; !ok {
-		return 0, fmt.Errorf("%w: %d", kind, ordinal)
 	}
 
 	return ordinal, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -340,6 +340,12 @@ func TestLoggerEnumAcceptedForms(t *testing.T) {
 			mode:  config.LogModeProduction,
 		},
 		{
+			name:  "short names",
+			value: `{"logLevel":"warn","logMode":"development"}`,
+			level: config.LogLevelWarn,
+			mode:  config.LogModeDevelopment,
+		},
+		{
 			name:  "numeric ordinals",
 			value: `{"logLevel":3,"logMode":0}`,
 			level: config.LogLevelError,
@@ -413,6 +419,11 @@ func TestStrictConfigRejectsInvalidJSON(t *testing.T) {
 		},
 		{name: "undeclared enum ordinal", doc: `{"global":{"logger":{"logLevel":9}}}`, path: `$.global.logger.logLevel`},
 		{name: "quoted enum ordinal", doc: `{"global":{"logger":{"logLevel":"1.0"}}}`, path: `$.global.logger.logLevel`},
+		{
+			name: "quoted integral enum ordinal",
+			doc:  `{"global":{"logger":{"logLevel":"0"}}}`,
+			path: `$.global.logger.logLevel`,
+		},
 		{name: "quoted seed", doc: `{"global":{"seed":"7"}}`, path: `$.global.seed`},
 		{name: "exponent seed", doc: `{"global":{"seed":1e2}}`, path: `$.global.seed`},
 		{name: "decimal seed", doc: `{"global":{"seed":1.0}}`, path: `$.global.seed`},

--- a/pkg/config/json.go
+++ b/pkg/config/json.go
@@ -117,11 +117,11 @@ func normalizeValue(
 	}
 
 	if target == logLevelType {
-		return normalizeEnum(token, path, logLevelNames, out)
+		return normalizeLogLevel(token, path, out)
 	}
 
 	if target == logModeType {
-		return normalizeEnum(token, path, logModeNames, out)
+		return normalizeLogMode(token, path, out)
 	}
 
 	switch target.Kind() {
@@ -613,6 +613,30 @@ func normalizeScopeScalar(
 	}
 
 	return nil
+}
+
+func normalizeLogLevel(token json.Token, path string, out *bytes.Buffer) error {
+	if value, ok := token.(string); ok {
+		if level, valid := parseLogLevelName(value); valid {
+			writeJSONString(out, level.String())
+
+			return nil
+		}
+	}
+
+	return normalizeEnum(token, path, logLevelNames, out)
+}
+
+func normalizeLogMode(token json.Token, path string, out *bytes.Buffer) error {
+	if value, ok := token.(string); ok {
+		if mode, valid := parseLogModeName(value); valid {
+			writeJSONString(out, mode.String())
+
+			return nil
+		}
+	}
+
+	return normalizeEnum(token, path, logModeNames, out)
 }
 
 func normalizeEnum[T ~int32](token json.Token, path string, names map[T]string, out *bytes.Buffer) error {

--- a/pkg/driver/csv/driver.go
+++ b/pkg/driver/csv/driver.go
@@ -138,7 +138,7 @@ var _ driver.Driver = (*Driver)(nil)
 func NewDriver(_ context.Context, opts driver.Options) (*Driver, error) {
 	lg := opts.Logger
 	if lg == nil {
-		lg = logger.NewFromEnv().Named("csv")
+		lg = logger.Global().Named("csv")
 	}
 
 	cfg, err := parseConfig(opts.Config.URL)

--- a/pkg/driver/mysql/driver.go
+++ b/pkg/driver/mysql/driver.go
@@ -47,7 +47,7 @@ func NewDriver(
 ) (*Driver, error) {
 	lg := opts.Logger
 	if lg == nil {
-		lg = logger.NewFromEnv().Named("mysql")
+		lg = logger.Global().Named("mysql")
 	}
 
 	cfg := opts.Config
@@ -66,7 +66,7 @@ func NewDriver(
 		return nil, fmt.Errorf("failed to apply SQL config: %w", err)
 	}
 
-	lg.Debug("Checking db connection...", zap.String("url", cfg.URL))
+	lg.Debug("Checking db connection...", zap.String("url", logger.RedactDSN(cfg.URL)))
 
 	if err = sqldriver.WaitForDB(ctx, lg, &sqldriver.DBPinger{DB: db}, 0); err != nil {
 		db.Close()

--- a/pkg/driver/noop/driver.go
+++ b/pkg/driver/noop/driver.go
@@ -51,7 +51,7 @@ var _ driver.Driver = (*Driver)(nil)
 func NewDriver(opts driver.Options) *Driver {
 	lg := opts.Logger
 	if lg == nil {
-		lg = logger.NewFromEnv().Named("noop")
+		lg = logger.Global().Named("noop")
 	}
 
 	bulkSize := defaultBulkSize

--- a/pkg/driver/noop/insert_test.go
+++ b/pkg/driver/noop/insert_test.go
@@ -5,6 +5,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/stroppy-io/stroppy/pkg/common/logger"
 	"github.com/stroppy-io/stroppy/pkg/config"
 	"github.com/stroppy-io/stroppy/pkg/driver"
 	"github.com/stroppy-io/stroppy/pkg/gen"
@@ -40,6 +46,32 @@ func newNoopDriver(t *testing.T) *Driver {
 	t.Helper()
 
 	return NewDriver(driver.Options{Config: &config.DriverConfig{}})
+}
+
+func TestNewDriverPreservesInjectedLogger(t *testing.T) {
+	injected := zap.NewNop()
+
+	d := NewDriver(driver.Options{
+		Config: &config.DriverConfig{},
+		Logger: injected,
+	})
+
+	require.Same(t, injected, d.logger)
+}
+
+func TestNewDriverFallsBackToNamedGlobalLogger(t *testing.T) {
+	core, observed := observer.New(zap.DebugLevel)
+
+	require.NoError(t, logger.Init("debug", "development", zap.WrapCore(func(zapcore.Core) zapcore.Core {
+		return core
+	})))
+
+	d := NewDriver(driver.Options{Config: &config.DriverConfig{}})
+	d.logger.Debug("fallback logger")
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	require.Equal(t, "noop", entries[0].LoggerName)
 }
 
 // TestInsertNilGuards verifies Insert rejects a nil request, nil source,

--- a/pkg/driver/picodata/driver.go
+++ b/pkg/driver/picodata/driver.go
@@ -76,9 +76,7 @@ func NewDriver(
 ) (d *Driver, err error) {
 	lg := opts.Logger
 	if lg == nil {
-		lg = logger.NewFromEnv().
-			Named(LoggerName).
-			WithOptions(zap.AddCallerSkip(0))
+		lg = logger.Global().Named(LoggerName)
 	}
 
 	const defaultBulkSize = 2500
@@ -95,7 +93,7 @@ func NewDriver(
 		d.bulkSize = int(cfg.GetBulkSize())
 	}
 
-	d.logger.Debug("Connecting to Picodata...", zap.String("url", cfg.URL))
+	d.logger.Debug("Connecting to Picodata...", zap.String("url", logger.RedactDSN(cfg.URL)))
 
 	const maxConnPerInstance = 20
 
@@ -130,7 +128,7 @@ func NewDriver(
 
 	d.pool = &PoolX{conn}
 
-	d.logger.Debug("Checking db connection...", zap.String("url", cfg.URL))
+	d.logger.Debug("Checking db connection...", zap.String("url", logger.RedactDSN(cfg.URL)))
 
 	if err := sqldriver.WaitForDB(ctx, d.logger, d.pool, dbConnectionTimeout); err != nil {
 		return nil, err

--- a/pkg/driver/postgres/driver.go
+++ b/pkg/driver/postgres/driver.go
@@ -61,9 +61,7 @@ func NewDriver(
 ) (d *Driver, err error) {
 	lg := opts.Logger
 	if lg == nil {
-		lg = logger.NewFromEnv().
-			Named(pool.DriverLoggerName).
-			WithOptions(zap.AddCallerSkip(0))
+		lg = logger.Global().Named(pool.DriverLoggerName)
 	}
 
 	const defaultBulkSize = 2500
@@ -98,7 +96,7 @@ func NewDriver(
 		}
 	}
 
-	d.logger.Debug("Checking db connection...", zap.String("url", cfg.URL))
+	d.logger.Debug("Checking db connection...", zap.String("url", logger.RedactDSN(cfg.URL)))
 
 	// TODO: make waiting optional
 	err = sqldriver.WaitForDB(ctx, d.logger, d.pool, dbConnectionTimeout)

--- a/pkg/driver/ydb/driver.go
+++ b/pkg/driver/ydb/driver.go
@@ -52,7 +52,7 @@ func NewDriver(
 ) (*Driver, error) {
 	lg := opts.Logger
 	if lg == nil {
-		lg = logger.NewFromEnv().Named("ydb")
+		lg = logger.Global().Named("ydb")
 	}
 
 	cfg := opts.Config
@@ -132,7 +132,7 @@ func tryConnect(
 		return nil, nil, fmt.Errorf("apply SQL config: %w", err)
 	}
 
-	lg.Debug("Checking db connection...", zap.String("url", cfg.URL))
+	lg.Debug("Checking db connection...", zap.String("url", logger.RedactDSN(cfg.URL)))
 
 	if err = sqldriver.WaitForDB(ctx, lg, &sqldriver.DBPinger{DB: db}, pingTimeout); err != nil {
 		db.Close()


### PR DESCRIPTION
Implements #129.

## Summary

Configures one race-safe process logger before run diagnostics begin while preserving explicit logger injection for library callers and tests. Connection diagnostics redact credentials consistently.

## What changed

- **Initialization:** the run command loads configuration silently, resolves logger inputs, atomically initializes `logger.Global()`, then emits config, driver, workload, and benchmark diagnostics.
- **Precedence per field:** `--log-level` / `--log-mode` > process `LOG_LEVEL` / `LOG_MODE` > `-e LOG_LEVEL` / `LOG_MODE` > `global.logger` config > `debug` / `development` defaults.
- **Injection preserved:** `bench.Run(..., logger)` and `driver.Options.Logger` remain supported. Drivers use an injected logger unchanged; nil falls back to a named child of `logger.Global()`.
- **Safe lifecycle:** the global logger remains atomically replaceable. Invalid initialization leaves the previous logger active, and `Global()` never returns nil.
- **API cleanup:** plain-Go `NewFromConfig` remains available; logger environment-construction bridges (`NewFromEnv`, `SetLoggerEnv`, `PrepareLoggerEnvs`) are removed.
- **Config compatibility:** JSON accepts v5 enum names, valid numeric ordinals, and short names (`debug|info|warn|error|fatal`, `development|production`). Omitted values retain `debug` / `development` behavior.
- **Redaction:** passwords, tokens, secrets, credentials, and API-key query variants are masked across regular URLs, encoded keys, repeated values, malformed inputs, and MySQL-style no-scheme DSNs. Config and PostgreSQL/MySQL/Picodata/YDB diagnostics use the shared redactor.

## Tests

- Atomic replacement, concurrent reads, failed initialization, defaults, and retained construction API.
- Logger source precedence and startup ordering.
- Legacy, numeric, and short config values plus invalid forms.
- Explicit injection and nil-driver fallback.
- Userinfo/query credential redaction across URL and no-scheme forms, including encoded, case-varied, repeated, and malformed inputs.
- Full race-enabled repository suite, linter, schema determinism, and build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global logging controls with `--log-level` and `--log-mode`.
  * Supports short names, version 5 names, and numeric logging values.
  * Added clear logging configuration precedence across CLI, environment, overrides, and config files.
* **Bug Fixes**
  * Database connection diagnostics now redact sensitive credentials and secrets.
  * Standardized logger behavior across drivers.
* **Documentation**
  * Updated logging help, defaults, precedence, and redaction details.
  * Added schema support for lowercase logging aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->