### PR TITLE
feat(bench): replace inert errorMode with bounded error reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,14 @@ and unconditional transient facts; unknown facts return errors. Override selecte
 facts per workload with `TxRetryPolicyOptions.Actions`; set `Idempotent` to allow
 conditional transient retries.
 
+Nonfatal terminal transaction errors fail one iteration and the VU continues;
+query-set workloads count the failed query and continue. Both exit 0 but produce
+bounded WARN aggregates and a prominent final completed-with-errors summary.
+Scheduled retries are counted separately and do not mark a run failed when a
+later attempt succeeds. Setup/validation, teardown, fatal, and cancellation
+retain their nonzero or signal-derived semantics; fatal stops the scenario and
+is reported once. The removed `errorMode` driver field and alias are rejected.
+
 ## CLI Usage
 
 ```bash
@@ -102,7 +110,7 @@ conditional transient retries.
 **Driver flags:**
 - `-d <preset>` — driver preset: `pg`, `mysql`, `pico`, `ydb`, `noop`
 - `-d '{"url":"...","bulkSize":20}'` — raw JSON driver config
-- `-D key=value` — override driver field (url, driverType, errorMode, bulkSize, pool.*, postgres.*, sql.*, caCertFile, authToken, authUser, authPassword, tlsInsecureSkipVerify); multiple `-D` accumulate
+- `-D key=value` — override driver field (url, driverType, bulkSize, pool.*, postgres.*, sql.*, caCertFile, authToken, authUser, authPassword, tlsInsecureSkipVerify); multiple `-D` accumulate
 - `-d1 <preset>`, `-D1 key=value` — same for second driver index (multi-driver workloads)
 
 **Workload and run parameters:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,9 +93,10 @@ Nonfatal terminal transaction errors fail one iteration and the VU continues;
 query-set workloads count the failed query and continue. Both exit 0 but produce
 bounded WARN aggregates and a prominent final completed-with-errors summary.
 Scheduled retries are counted separately and do not mark a run failed when a
-later attempt succeeds. Setup/validation, teardown, fatal, and cancellation
-retain their nonzero or signal-derived semantics; fatal stops the scenario and
-is reported once. The removed `errorMode` driver field and alias are rejected.
+later attempt succeeds. Setup, workload teardown, fatal, and cancellation retain
+their nonzero or signal-derived semantics; fatal stops the scenario and is
+reported once. TPC-H/TPC-DS SF=1 answer comparison remains diagnostic-only.
+The removed `errorMode` driver field and alias are rejected.
 
 ## CLI Usage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
-- Nonfatal transaction and query-set errors now keep virtual users running, exit successfully, and appear in bounded warnings, terminal-error metrics, and a prominent final summary; the unused driver `errorMode` option has been removed and is now rejected.
+- Nonfatal transaction and query-set errors now keep virtual users running, exit successfully, and appear in bounded warnings, terminal-error metrics, and a prominent final summary; the unused driver `errorMode` option has been removed and is now rejected. ([#156](https://github.com/stroppy-io/stroppy/pull/156))
 - Logging now uses one safely replaceable process-wide logger, with configurable level and output mode precedence plus redacted database connection diagnostics. ([#154](https://github.com/stroppy-io/stroppy/pull/154))
 - Driver insert-method defaults now fill only load requests that leave their method unset, preserving methods selected by workloads. ([#152](https://github.com/stroppy-io/stroppy/pull/152))
 - SIGINT and SIGTERM now cancel the running workload and trigger graceful teardown; a second signal forces immediate exit. Exit status is 130 (SIGINT) or 143 (SIGTERM) after a graceful cancellation, 2 after a forced exit, and 1 for other errors. ([#148](https://github.com/stroppy-io/stroppy/pull/148))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
+- Nonfatal transaction and query-set errors now keep virtual users running, exit successfully, and appear in bounded warnings, terminal-error metrics, and a prominent final summary; the unused driver `errorMode` option has been removed and is now rejected.
 - Logging now uses one safely replaceable process-wide logger, with configurable level and output mode precedence plus redacted database connection diagnostics. ([#154](https://github.com/stroppy-io/stroppy/pull/154))
 - Driver insert-method defaults now fill only load requests that leave their method unset, preserving methods selected by workloads. ([#152](https://github.com/stroppy-io/stroppy/pull/152))
 - SIGINT and SIGTERM now cancel the running workload and trigger graceful teardown; a second signal forces immediate exit. Exit status is 130 (SIGINT) or 143 (SIGTERM) after a graceful cancellation, 2 after a forced exit, and 1 for other errors. ([#148](https://github.com/stroppy-io/stroppy/pull/148))
@@ -70,7 +71,7 @@ Group lines under `Added` / `Changed` / `Fixed` / `Removed`. Append a PR link
 
 ### Changed
 
-- The `tpcc/tx` and `tpcc/procs` workloads now share their driver setup, load/prepare lifecycle, retry policy, pacing, weighted dispatch, and post-run summary through `tpcc_common.ts` (matching the existing `tpcb` layout), instead of each carrying its own copy. Both variants now run queries with `errorMode=throw` (previously `procs` threw while `tx` logged), so database errors surface as exceptions consistently. ([#114](https://github.com/stroppy-io/stroppy/pull/114))
+- The `tpcc/tx` and `tpcc/procs` workloads now share their driver setup, load/prepare lifecycle, retry policy, pacing, weighted dispatch, and post-run summary through `tpcc_common.ts` (matching the existing `tpcb` layout), instead of each carrying its own copy. Both variants now surface database errors as exceptions consistently (previously `procs` threw while `tx` only logged). ([#114](https://github.com/stroppy-io/stroppy/pull/114))
 
 ## [5.7.2] - 2026-07-27
 

--- a/Makefile
+++ b/Makefile
@@ -147,16 +147,18 @@ endef
 
 # Scenario-branch smoke on the noop driver (NO database). Every workload has
 # two executor archetypes — constant-vus (DURATION set, throughput) and
-# shared-iterations (power test). The noop driver runs the full lifecycle
-# without a DB, so this catches executor/options regressions for ~free. The
-# VUS=2/ITER=1 case also guards the shared-iterations "iterations < VUs" floor.
-# Third field skips each workload's data-validation step (noop has no data to
-# check); "-" means nothing to skip.
+# shared-iterations (power test). Setup still runs against noop, while the
+# database-dependent workload step is excluded: noop cannot return rows required
+# by transactions such as TPC-C new_order. This still exercises each executor,
+# typed options, setup lifecycle, and iteration scheduling without manufacturing
+# expected query failures. The VUS=2/ITER=1 case also guards the
+# shared-iterations "iterations < VUs" floor. Third field names any additional
+# data-validation step to exclude; "-" means no additional step.
 .PHONY: run-scenario-smoke
 run-scenario-smoke: # Tier 0: scenario-branch smoke on noop (no DB), all workloads x both branches
 	@rc=0;                                                                          \
 	for spec in "tpcb/tx 1 -" "tpcc/tx 1 validate_population" "tpcds 0.01 -" "tpch/tx 0.01 validate_answers"; do \
-		set -- $$spec; wl=$$1; sf=$$2; skip=$$3; ns=""; [ "$$skip" = "-" ] || ns="--no-steps $$skip"; \
+		set -- $$spec; wl=$$1; sf=$$2; skip=$$3; ns="--no-steps workload"; [ "$$skip" = "-" ] || ns="--no-steps workload,$$skip"; \
 		$(call smoke_run,noop constant-vus: $$wl,./build/stroppy run $$wl -d noop -e SCALE_FACTOR=$$sf -e DURATION=2s -e VUS=2 $$ns); \
 		$(call smoke_run,noop shared-iters: $$wl,./build/stroppy run $$wl -d noop -e SCALE_FACTOR=$$sf -e VUS=2 -e ITER=1 $$ns); \
 	done;                                                                           \

--- a/Makefile
+++ b/Makefile
@@ -133,15 +133,14 @@ revision: # Recreate git tag with version tag=<semver>
 ## Smoke runs (Go-native workloads)
 ##
 
-# Gate one smoke run: fail on a non-zero exit OR any `level=error` line.
-# stroppy exits 0 even when every iteration errors (e.g. a failed GlobalOnce
-# load), so the exit code alone is not a reliable signal; default error mode
-# logs every error at level=error, which this catches.
+# Gate one smoke run: fail on a non-zero exit, an error log, or the final
+# completed-with-errors marker. Nonfatal iteration/query errors intentionally
+# exit 0, so the summary marker keeps smoke runs strict.
 # $(1)=label, rest=command.
 define smoke_run
 	echo "== $(1) =="; \
 	out=$$($(2) 2>&1); code=$$?; printf '%s\n' "$$out"; \
-	if [ $$code -ne 0 ] || printf '%s' "$$out" | grep -q 'level=error'; then \
+	if [ $$code -ne 0 ] || printf '%s' "$$out" | grep -Eq 'level=error|completed with errors'; then \
 		echo "FAIL ($(1)): exit=$$code"; rc=1; \
 	fi
 endef

--- a/Makefile
+++ b/Makefile
@@ -165,8 +165,9 @@ run-scenario-smoke: # Tier 0: scenario-branch smoke on noop (no DB), all workloa
 	exit $$rc
 
 # Real-Postgres smoke of BOTH scenario branches for the light workloads at tiny
-# scale (default pg preset = localhost:5432). Complements run-scenario-smoke by
-# exercising the actual DB path (load + run) in throughput and power modes.
+# scale (default pg preset = localhost:5432). Constant-vus uses one VU so this
+# scenario-shape gate does not become a contention/retry test; shared-iterations
+# keeps VUS=2/ITER=1 to guard the iterations-below-VUs floor.
 # tpch's validate_answers golden set is SF=1 only, so it is skipped at smoke
 # scale; validate_population stays on for tpcc since it passes at SF=1.
 # tpcds is intentionally NOT here: its fixed-cardinality dimensions do not
@@ -178,7 +179,7 @@ run-workload-branches: # Tier 1: real-Postgres smoke of both branches (tpcb/tpcc
 	@rc=0;                                                                          \
 	for spec in "tpcb/tx 1 -" "tpcc/tx 1 -" "tpch/tx 0.01 validate_answers"; do \
 		set -- $$spec; wl=$$1; sf=$$2; skip=$$3; ns=""; [ "$$skip" = "-" ] || ns="--no-steps $$skip"; \
-		$(call smoke_run,pg constant-vus: $$wl,./build/stroppy run $$wl -e SCALE_FACTOR=$$sf -e DURATION=2s -e VUS=2 $$ns); \
+		$(call smoke_run,pg constant-vus: $$wl,./build/stroppy run $$wl -e SCALE_FACTOR=$$sf -e DURATION=2s -e VUS=1 $$ns); \
 		$(call smoke_run,pg shared-iters: $$wl,./build/stroppy run $$wl -e SCALE_FACTOR=$$sf -e VUS=2 -e ITER=1 $$ns); \
 	done;                                                                           \
 	exit $$rc

--- a/cmd/stroppy/commands/help/topic_config_file.go
+++ b/cmd/stroppy/commands/help/topic_config_file.go
@@ -95,8 +95,13 @@ Example stroppy-config.json:
     (default 10000). With no endpoint, metrics still appear in the local summary.
 
   Driver types: postgres, mysql, picodata, ydb, noop, csv
-  Error modes:  silent, log, throw, fail, abort
   Insert methods: native, plain_bulk, plain_query (selected by workload InsertRequest)
+
+  The unused driver errorMode field has been removed. Delete it from migrated
+  config files and raw driver JSON; stroppy now rejects both errorMode and its
+  error_mode alias as unknown fields. Error behavior is workload-owned; see
+  'stroppy help drivers' for transaction, query-set, retry, fatal, cancellation,
+  summary, and exit-status behavior.
 
 PRECEDENCE (highest to lowest)
 

--- a/cmd/stroppy/commands/help/topic_drivers.go
+++ b/cmd/stroppy/commands/help/topic_drivers.go
@@ -137,11 +137,13 @@ ERROR AND EXIT BEHAVIOR
   iterations, failed queries, retries, and representative groups. Nonfatal
   errors leave the process exit status at 0.
 
-  Setup and validation failures, teardown failures, and fatal workload actions
-  return a nonzero status. A fatal action stops the whole scenario and is
-  reported once. SIGINT/SIGTERM cancellation stops the scenario, runs teardown,
-  and keeps its signal-derived exit status (130/143; a forced second signal is
-  2). Cancellation is not reported as a nonfatal benchmark error.
+  Setup failures, workload teardown failures, and fatal workload actions return
+  a nonzero status. TPC-H and TPC-DS SF=1 answer comparison remains diagnostic:
+  query errors and answer differences are logged but do not change exit status.
+  A fatal action stops the whole scenario and is reported once. SIGINT/SIGTERM
+  cancellation stops the scenario, runs teardown, and keeps its signal-derived
+  exit status (130/143; a forced second signal is 2). Cancellation is not
+  reported as a nonfatal benchmark error.
 
   To inspect the driver insert methods each driver supports:
 

--- a/cmd/stroppy/commands/help/topic_drivers.go
+++ b/cmd/stroppy/commands/help/topic_drivers.go
@@ -75,7 +75,6 @@ DRIVER OPTIONS (-D / --driver-opt)
     url                    string    Database connection URL
     driverType             string    postgres | mysql | picodata | ydb |
                                      noop | csv
-    errorMode              string    silent | log | throw | fail | abort
     bulkSize               int       Rows per bulk INSERT (default: 2500)
     insertProgress.enabled bool      Enable load progress watcher
     insertProgress.interval duration Progress log/metric cadence (default: 10s)
@@ -115,6 +114,35 @@ HOW IT WORKS
   2. Each DriverConfig is passed directly to the Go-native bench engine,
      which dispatches to the registered driver implementation.
 
+  Drivers classify backend errors into bounded, database-independent facts.
+  Workloads—not driver configuration—choose whether each transaction fact is
+  retried, returned as an error, ignored, or made fatal. The former errorMode
+  driver field has been removed; config files, raw driver JSON, and -D reject it.
+
+ERROR AND EXIT BEHAVIOR
+
+  Transaction errors follow the workload's retry policy. A retry attempt is
+  counted separately; if a later attempt succeeds, the iteration succeeds and
+  the run is not marked as completed with errors. A terminal nonfatal error
+  fails that iteration, increments terminal/failed-iteration metrics, and the
+  VU continues with its next iteration.
+
+  Query-set workloads (TPC-H, TPC-DS, and execute_sql) continue with the next
+  query after a nonfatal query error. They increment terminal/failed-query
+  metrics without logging every duplicate event.
+
+  The first occurrence of each bounded operation/error-class group is logged
+  at WARN, recurring events are reported periodically as aggregates, and the
+  final summary prints "completed with errors" with terminal errors, failed
+  iterations, failed queries, retries, and representative groups. Nonfatal
+  errors leave the process exit status at 0.
+
+  Setup and validation failures, teardown failures, and fatal workload actions
+  return a nonzero status. A fatal action stops the whole scenario and is
+  reported once. SIGINT/SIGTERM cancellation stops the scenario, runs teardown,
+  and keeps its signal-derived exit status (130/143; a forced second signal is
+  2). Cancellation is not reported as a nonfatal benchmark error.
+
   To inspect the driver insert methods each driver supports:
 
     stroppy probe
@@ -130,9 +158,6 @@ EXAMPLES
   # Two drivers: PostgreSQL and MySQL
   stroppy run tpcc/tx -d pg -d1 mysql
 
-  # Override a field without specifying a preset
-  stroppy run tpcc/tx -D errorMode=throw
-
   # Dump generated TPC-B data to CSV and stop before the workload phase
   stroppy run tpcb/tx -D driverType=csv \
     -D url='/tmp/tpcb-csv?merge=true&workload=tpcb' \
@@ -146,7 +171,7 @@ EXAMPLES
     -D insertProgress.stallAfter=2m
 
   # Full JSON config instead of preset
-  stroppy run tpcc/tx -d '{"url":"postgres://prod:5432","driverType":"postgres","errorMode":"throw"}'
+  stroppy run tpcc/tx -d '{"url":"postgres://prod:5432","driverType":"postgres"}'
 
   # YDB with TLS and token auth (grpc:// or grpcs:// scheme)
   stroppy run tpcc/tx -d ydb -D url=grpcs://host:2135/db \

--- a/cmd/stroppy/commands/root_test.go
+++ b/cmd/stroppy/commands/root_test.go
@@ -83,16 +83,42 @@ func executeTestCommand(t *testing.T, args []string) (int, string) {
 		rootCmd.SetArgs(nil)
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
+		clearCommandContexts(rootCmd)
 	})
 
 	return execute(), output.String()
 }
 
 func clearCommandContexts(cmd *cobra.Command) {
-	cmd.SetContext(context.TODO())
+	cmd.SetContext(nil) //nolint:staticcheck // nil lets ExecuteContext propagate its context to child commands.
 
 	for _, child := range cmd.Commands() {
 		clearCommandContexts(child)
+	}
+}
+
+func TestClearCommandContextsAllowsExecuteContextPropagation(t *testing.T) {
+	t.Parallel()
+
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		Run: func(cmd *cobra.Command, _ []string) {
+			if err := cmd.Context().Err(); !errors.Is(err, context.Canceled) {
+				t.Errorf("child context error = %v, want context.Canceled", err)
+			}
+		},
+	}
+	root.AddCommand(child)
+	root.SetArgs([]string{"child"})
+	child.SetContext(context.TODO())
+	clearCommandContexts(root)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := root.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
 	}
 }
 

--- a/cmd/stroppy/commands/root_test.go
+++ b/cmd/stroppy/commands/root_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -44,16 +45,7 @@ func TestExitCodeFor(t *testing.T) {
 }
 
 func TestCommandErrorExitAndDiagnosticContract(t *testing.T) {
-	var ordinary *commandErrorWorkload
-
-	bench.Register(func() bench.Workload {
-		ordinary = &commandErrorWorkload{name: "test/command-ordinary-error"}
-
-		return ordinary
-	})
-	bench.Register(func() bench.Workload {
-		return &commandErrorWorkload{name: "test/command-fatal-error", fatal: true}
-	})
+	registerCommandErrorWorkloads()
 
 	ordinaryCode, ordinaryOutput := executeTestCommand(t, []string{
 		"run", "test/command-ordinary-error", "-d", "noop", "--iterations", "3", "--vus", "1",
@@ -62,8 +54,8 @@ func TestCommandErrorExitAndDiagnosticContract(t *testing.T) {
 		t.Fatalf("ordinary-error exit code = %d, output = %q, want 0", ordinaryCode, ordinaryOutput)
 	}
 
-	if ordinary.calls.Load() != 3 {
-		t.Fatalf("ordinary-error iterations = %d, want 3", ordinary.calls.Load())
+	if commandOrdinaryErrorWorkload.calls.Load() != 3 {
+		t.Fatalf("ordinary-error iterations = %d, want 3", commandOrdinaryErrorWorkload.calls.Load())
 	}
 
 	fatalCode, fatalOutput := executeTestCommand(t, []string{
@@ -102,6 +94,24 @@ func clearCommandContexts(cmd *cobra.Command) {
 	for _, child := range cmd.Commands() {
 		clearCommandContexts(child)
 	}
+}
+
+var (
+	registerCommandErrorWorkloadsOnce sync.Once
+	commandOrdinaryErrorWorkload      *commandErrorWorkload
+)
+
+func registerCommandErrorWorkloads() {
+	registerCommandErrorWorkloadsOnce.Do(func() {
+		bench.Register(func() bench.Workload {
+			commandOrdinaryErrorWorkload = &commandErrorWorkload{name: "test/command-ordinary-error"}
+
+			return commandOrdinaryErrorWorkload
+		})
+		bench.Register(func() bench.Workload {
+			return &commandErrorWorkload{name: "test/command-fatal-error", fatal: true}
+		})
+	})
 }
 
 type commandErrorWorkload struct {

--- a/cmd/stroppy/commands/root_test.go
+++ b/cmd/stroppy/commands/root_test.go
@@ -45,6 +45,7 @@ func TestExitCodeFor(t *testing.T) {
 
 func TestCommandErrorExitAndDiagnosticContract(t *testing.T) {
 	var ordinary *commandErrorWorkload
+
 	bench.Register(func() bench.Workload {
 		ordinary = &commandErrorWorkload{name: "test/command-ordinary-error"}
 
@@ -60,6 +61,7 @@ func TestCommandErrorExitAndDiagnosticContract(t *testing.T) {
 	if ordinaryCode != 0 {
 		t.Fatalf("ordinary-error exit code = %d, output = %q, want 0", ordinaryCode, ordinaryOutput)
 	}
+
 	if ordinary.calls.Load() != 3 {
 		t.Fatalf("ordinary-error iterations = %d, want 3", ordinary.calls.Load())
 	}
@@ -70,6 +72,7 @@ func TestCommandErrorExitAndDiagnosticContract(t *testing.T) {
 	if fatalCode != 1 {
 		t.Fatalf("fatal exit code = %d, output = %q, want 1", fatalCode, fatalOutput)
 	}
+
 	if got := strings.Count(fatalOutput, "fatal command sentinel"); got != 1 {
 		t.Fatalf("fatal diagnostic occurrences = %d, output = %q, want 1", got, fatalOutput)
 	}
@@ -79,6 +82,7 @@ func executeTestCommand(t *testing.T, args []string) (int, string) {
 	t.Helper()
 
 	var output bytes.Buffer
+
 	clearCommandContexts(rootCmd)
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(&output)
@@ -93,7 +97,8 @@ func executeTestCommand(t *testing.T, args []string) (int, string) {
 }
 
 func clearCommandContexts(cmd *cobra.Command) {
-	cmd.SetContext(nil)
+	cmd.SetContext(context.TODO())
+
 	for _, child := range cmd.Commands() {
 		clearCommandContexts(child)
 	}
@@ -110,6 +115,7 @@ func (*commandErrorWorkload) Define(*bench.Def) error                   { return
 func (*commandErrorWorkload) Setup(context.Context, *bench.Bench) error { return nil }
 func (w *commandErrorWorkload) Iterate(ctx context.Context, b *bench.Bench) error {
 	w.calls.Add(1)
+
 	if !w.fatal {
 		return errors.New("ordinary command failure")
 	}
@@ -123,4 +129,5 @@ func (w *commandErrorWorkload) Iterate(ctx context.Context, b *bench.Bench) erro
 
 	return bench.Retry0(ctx, policy, func() error { return errors.New("fatal command sentinel") })
 }
+
 func (*commandErrorWorkload) Teardown(context.Context, *bench.Bench) error { return nil }

--- a/cmd/stroppy/commands/root_test.go
+++ b/cmd/stroppy/commands/root_test.go
@@ -1,10 +1,19 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stroppy-io/stroppy/pkg/bench"
+	"github.com/stroppy-io/stroppy/pkg/driver"
+	_ "github.com/stroppy-io/stroppy/pkg/driver/noop"
 )
 
 func TestExitCodeFor(t *testing.T) {
@@ -33,3 +42,85 @@ func TestExitCodeFor(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandErrorExitAndDiagnosticContract(t *testing.T) {
+	var ordinary *commandErrorWorkload
+	bench.Register(func() bench.Workload {
+		ordinary = &commandErrorWorkload{name: "test/command-ordinary-error"}
+
+		return ordinary
+	})
+	bench.Register(func() bench.Workload {
+		return &commandErrorWorkload{name: "test/command-fatal-error", fatal: true}
+	})
+
+	ordinaryCode, ordinaryOutput := executeTestCommand(t, []string{
+		"run", "test/command-ordinary-error", "-d", "noop", "--iterations", "3", "--vus", "1",
+	})
+	if ordinaryCode != 0 {
+		t.Fatalf("ordinary-error exit code = %d, output = %q, want 0", ordinaryCode, ordinaryOutput)
+	}
+	if ordinary.calls.Load() != 3 {
+		t.Fatalf("ordinary-error iterations = %d, want 3", ordinary.calls.Load())
+	}
+
+	fatalCode, fatalOutput := executeTestCommand(t, []string{
+		"run", "test/command-fatal-error", "-d", "noop", "--iterations", "10", "--vus", "2",
+	})
+	if fatalCode != 1 {
+		t.Fatalf("fatal exit code = %d, output = %q, want 1", fatalCode, fatalOutput)
+	}
+	if got := strings.Count(fatalOutput, "fatal command sentinel"); got != 1 {
+		t.Fatalf("fatal diagnostic occurrences = %d, output = %q, want 1", got, fatalOutput)
+	}
+}
+
+func executeTestCommand(t *testing.T, args []string) (int, string) {
+	t.Helper()
+
+	var output bytes.Buffer
+	clearCommandContexts(rootCmd)
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(&output)
+	rootCmd.SetErr(&output)
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	return execute(), output.String()
+}
+
+func clearCommandContexts(cmd *cobra.Command) {
+	cmd.SetContext(nil)
+	for _, child := range cmd.Commands() {
+		clearCommandContexts(child)
+	}
+}
+
+type commandErrorWorkload struct {
+	name  string
+	fatal bool
+	calls atomic.Int64
+}
+
+func (w *commandErrorWorkload) Name() string                            { return w.name }
+func (*commandErrorWorkload) Define(*bench.Def) error                   { return nil }
+func (*commandErrorWorkload) Setup(context.Context, *bench.Bench) error { return nil }
+func (w *commandErrorWorkload) Iterate(ctx context.Context, b *bench.Bench) error {
+	w.calls.Add(1)
+	if !w.fatal {
+		return errors.New("ordinary command failure")
+	}
+
+	policy := b.TxRetryPolicy(bench.TxRetryPolicyOptions{
+		MaxAttempts: 1,
+		Actions: bench.ErrorActionMap{ //nolint:exhaustive // test overrides one kind
+			driver.ErrorKindUnknown: bench.ErrorActionFatal,
+		},
+	})
+
+	return bench.Retry0(ctx, policy, func() error { return errors.New("fatal command sentinel") })
+}
+func (*commandErrorWorkload) Teardown(context.Context, *bench.Bench) error { return nil }

--- a/cmd/stroppy/commands/run/run.go
+++ b/cmd/stroppy/commands/run/run.go
@@ -105,8 +105,9 @@ Config file flags:
 Signals:
   SIGINT and SIGTERM cancel the running workload and trigger graceful teardown.
   A second signal forces immediate exit.
-  Exit statuses: 130 (SIGINT) or 143 (SIGTERM) after a graceful cancellation,
-  2 after a forced exit, 1 for other errors.
+  Exit statuses: nonfatal iteration/query errors are summarized and exit 0;
+  130 (SIGINT) or 143 (SIGTERM) after a graceful cancellation, 2 after a forced
+  exit, and 1 for setup, validation, teardown, fatal, or other command errors.
 `,
 	DisableFlagParsing: true,
 	SilenceErrors:      false,
@@ -773,15 +774,6 @@ func applyDriverRunConfigExtras(
 ) error {
 	if fileConfig == nil {
 		return nil
-	}
-
-	if fileConfig.ErrorMode != nil {
-		parsed, err := bench.ParseErrorMode(fileConfig.GetErrorMode())
-		if err != nil {
-			return fmt.Errorf("driver %d errorMode: %w", idx, err)
-		}
-
-		driverConfig.ErrorMode = parsed
 	}
 
 	pool := applicableDriverPool(idx, driverConfig.DriverType, fileConfig)

--- a/cmd/stroppy/commands/run/run_test.go
+++ b/cmd/stroppy/commands/run/run_test.go
@@ -647,7 +647,6 @@ func TestParseRunArgs(t *testing.T) {
 func TestConfigDriversMergeBelowCLI(t *testing.T) {
 	driverType := "postgres"
 	fileURL := "postgres://file"
-	errorMode := "throw"
 	bulkSize := int32(20)
 	maxConns := int32(7)
 	specificMaxConns := int32(5)
@@ -657,7 +656,6 @@ func TestConfigDriversMergeBelowCLI(t *testing.T) {
 		0: {
 			DriverType: &driverType,
 			URL:        &fileURL,
-			ErrorMode:  &errorMode,
 			BulkSize:   &bulkSize,
 			Pool:       &config.PoolConfig{MaxConns: &maxConns},
 			Postgres: &config.PostgresConfig{
@@ -689,7 +687,6 @@ func TestConfigDriversMergeBelowCLI(t *testing.T) {
 
 	if runtimeConfig.URL != "postgres://cli" ||
 		runtimeConfig.GetBulkSize() != 20 ||
-		runtimeConfig.ErrorMode != config.ErrorModeThrow ||
 		runtimeConfig.Postgres.GetMaxConns() != 10 ||
 		runtimeConfig.Postgres.GetStatementCacheCapacity() != 13 {
 		t.Fatalf("runtime driver config = %#v, extra = %#v", runtimeConfig, configs[0].Extra)
@@ -1191,7 +1188,7 @@ func TestApplyDriverPresetJSON(t *testing.T) {
 
 	configs := runner.DriverCLIConfigs{}
 
-	err := applyDriverPreset(configs, 0, `{"url":"postgres://prod:5432","driverType":"postgres","errorMode":"throw"}`)
+	err := applyDriverPreset(configs, 0, `{"url":"postgres://prod:5432","driverType":"postgres"}`)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1204,9 +1201,20 @@ func TestApplyDriverPresetJSON(t *testing.T) {
 	if cfg.DriverType != "postgres" {
 		t.Errorf("DriverType: got %q, want %q", cfg.DriverType, "postgres")
 	}
+}
 
-	if cfg.Extra["errorMode"] != "throw" {
-		t.Errorf("Extra[errorMode]: got %v, want %q", cfg.Extra["errorMode"], "throw")
+func TestRemovedErrorModeOverrideRejected(t *testing.T) {
+	configs := runner.DriverCLIConfigs{}
+	if err := applyDriverPreset(configs, 0, "noop"); err != nil {
+		t.Fatalf("applyDriverPreset() error = %v", err)
+	}
+	if err := applyDriverOpt(configs, 0, "errorMode", "throw"); err != nil {
+		t.Fatalf("applyDriverOpt() error = %v", err)
+	}
+
+	_, err := buildDriverConfig(0, configs[0])
+	if err == nil || !contains(err.Error(), `unknown field "errorMode"`) {
+		t.Fatalf("buildDriverConfig() error = %v, want removed errorMode rejection", err)
 	}
 }
 
@@ -1230,6 +1238,7 @@ func TestApplyDriverPresetStrictJSON(t *testing.T) {
 		{name: "exact duplicate", doc: `{"url":"a","url":"b"}`, path: `$.url`},
 		{name: "alias collision", doc: `{"bulkSize":1,"bulk_size":2}`, path: `$.bulkSize`},
 		{name: "wrong case", doc: `{"DriverType":"postgres"}`, path: `$["DriverType"]`},
+		{name: "removed error mode", doc: `{"errorMode":"throw"}`, path: `$.errorMode`},
 		{name: "unknown nested field", doc: `{"pool":{"MaxConns":1}}`, path: `$.pool["MaxConns"]`},
 		{name: "fractional int32", doc: `{"bulkSize":1.5}`, path: `$.bulkSize`},
 		{name: "trailing JSON", doc: `{} {}`, path: `$`},

--- a/cmd/stroppy/commands/run/run_test.go
+++ b/cmd/stroppy/commands/run/run_test.go
@@ -1208,6 +1208,7 @@ func TestRemovedErrorModeOverrideRejected(t *testing.T) {
 	if err := applyDriverPreset(configs, 0, "noop"); err != nil {
 		t.Fatalf("applyDriverPreset() error = %v", err)
 	}
+
 	if err := applyDriverOpt(configs, 0, "errorMode", "throw"); err != nil {
 		t.Fatalf("applyDriverOpt() error = %v", err)
 	}

--- a/docs/jsonschema/run.schema.json
+++ b/docs/jsonschema/run.schema.json
@@ -14,14 +14,6 @@
         {
           "not": {
             "required": [
-              "errorMode",
-              "error_mode"
-            ]
-          }
-        },
-        {
-          "not": {
-            "required": [
               "bulkSize",
               "bulk_size"
             ]
@@ -242,26 +234,6 @@
           ]
         },
         "driver_type": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "errorMode": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "error_mode": {
           "anyOf": [
             {
               "type": "string"

--- a/internal/workloads/execute_sql/execute_sql.go
+++ b/internal/workloads/execute_sql/execute_sql.go
@@ -116,7 +116,11 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 
 			ms := time.Since(start).Milliseconds()
 			if err != nil {
-				lg.Infof("[execute_sql] %s: error in %dms %v", name, ms, err)
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
+				b.RecordQueryError(name, err)
 
 				continue
 			}

--- a/internal/workloads/execute_sql/execute_sql.go
+++ b/internal/workloads/execute_sql/execute_sql.go
@@ -115,6 +115,7 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 			err := b.Exec(ctx, body, nil)
 
 			ms := time.Since(start).Milliseconds()
+
 			if err != nil {
 				if ctx.Err() != nil {
 					return ctx.Err()

--- a/internal/workloads/execute_sql/execute_sql_test.go
+++ b/internal/workloads/execute_sql/execute_sql_test.go
@@ -175,6 +175,7 @@ func TestCancellationStopsRemainingQueries(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	canceling := &cancelingDriver{cancel: cancel}
+
 	driver.RegisterDriver(driverType, func(context.Context, driver.Options) (driver.Driver, error) {
 		return canceling, nil
 	})

--- a/internal/workloads/execute_sql/execute_sql_test.go
+++ b/internal/workloads/execute_sql/execute_sql_test.go
@@ -3,8 +3,10 @@ package execute_sql
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,7 +14,9 @@ import (
 
 	"github.com/stroppy-io/stroppy/pkg/bench"
 	"github.com/stroppy-io/stroppy/pkg/config"
+	"github.com/stroppy-io/stroppy/pkg/driver"
 	_ "github.com/stroppy-io/stroppy/pkg/driver/noop"
+	"github.com/stroppy-io/stroppy/pkg/driver/stats"
 )
 
 func TestSQLSourcePrecedence(t *testing.T) {
@@ -165,6 +169,57 @@ func TestSQLSourceDoesNotLeakBetweenRuns(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, errNoSQLSource, err)
 }
+
+func TestCancellationStopsRemainingQueries(t *testing.T) {
+	const driverType config.DriverType = 1000
+
+	ctx, cancel := context.WithCancel(context.Background())
+	canceling := &cancelingDriver{cancel: cancel}
+	driver.RegisterDriver(driverType, func(context.Context, driver.Options) (driver.Driver, error) {
+		return canceling, nil
+	})
+
+	err := bench.Run(
+		ctx,
+		"execute_sql",
+		map[int]*config.DriverConfig{0: {DriverType: driverType}},
+		bench.ParamInputs{CLI: map[string]string{
+			"sql-body": "--= first\nSELECT 1;\n--= second\nSELECT 2;\n",
+		}},
+		nil,
+		nil,
+		zap.NewNop(),
+		&bench.MetricsConfig{},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, int64(1), canceling.queries.Load())
+}
+
+type cancelingDriver struct {
+	cancel  context.CancelFunc
+	queries atomic.Int64
+}
+
+func (*cancelingDriver) Insert(context.Context, *driver.InsertRequest) (*stats.Query, error) {
+	return nil, errors.New("unexpected insert")
+}
+
+func (d *cancelingDriver) RunQuery(ctx context.Context, _ string, _ map[string]any) (*driver.QueryResult, error) {
+	d.queries.Add(1)
+	d.cancel()
+
+	return nil, ctx.Err()
+}
+
+func (*cancelingDriver) Begin(context.Context, config.TxIsolationLevel) (driver.Tx, error) {
+	return nil, errors.New("unexpected transaction")
+}
+
+func (*cancelingDriver) ClassifyError(err error) driver.ErrorFacts {
+	return driver.DefaultErrorFacts(err)
+}
+
+func (*cancelingDriver) Teardown(context.Context) error { return nil }
 
 func runExecuteSQL(inputs bench.ParamInputs) error {
 	return bench.Run(

--- a/internal/workloads/tpcds/tpcds.go
+++ b/internal/workloads/tpcds/tpcds.go
@@ -191,6 +191,7 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 			err := b.Exec(ctx, q.sql, nil)
 
 			ms := time.Since(start).Milliseconds()
+
 			if err != nil {
 				if ctx.Err() != nil {
 					return ctx.Err()

--- a/internal/workloads/tpcds/tpcds.go
+++ b/internal/workloads/tpcds/tpcds.go
@@ -192,7 +192,11 @@ func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 
 			ms := time.Since(start).Milliseconds()
 			if err != nil {
-				lg.Infof("[tpcds] %s: error in %dms %v", q.name, ms, err)
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
+				b.RecordQueryError(q.name, err)
 
 				continue
 			}

--- a/internal/workloads/tpch/tpch.go
+++ b/internal/workloads/tpch/tpch.go
@@ -182,15 +182,13 @@ func (w *workload) buildParams() map[string]map[string]any {
 
 func (w *workload) Iterate(ctx context.Context, b *bench.Bench) error {
 	return b.StepSilent("workload", func() error {
-		w.runQueries(ctx, b)
-
-		return nil
+		return w.runQueries(ctx, b)
 	})
 }
 
 // runQueries executes q1..q22 once each with pinned defaults, draining rows and
 // recording per-query timing/error metrics. Rows are discarded (throughput pass).
-func (w *workload) runQueries(ctx context.Context, b *bench.Bench) {
+func (w *workload) runQueries(ctx context.Context, b *bench.Bench) error {
 	lg := b.Logger().Sugar()
 
 	for _, name := range queryNames {
@@ -207,13 +205,19 @@ func (w *workload) runQueries(ctx context.Context, b *bench.Bench) {
 		w.recordAttempt(name, float64(elapsed), err != nil)
 
 		if err != nil {
-			lg.Infof("[tpch] %s: error in %dms %v", name, elapsed, err)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			b.RecordQueryError(name, err)
 
 			continue
 		}
 
 		lg.Infof("[tpch] %s: ok in %dms", name, elapsed)
 	}
+
+	return nil
 }
 
 func (w *workload) recordAttempt(name string, elapsedMs float64, failed bool) {

--- a/pkg/bench/cancel_test.go
+++ b/pkg/bench/cancel_test.go
@@ -77,7 +77,7 @@ func TestRunScenarioConstantVUsCancellation(t *testing.T) {
 			<-vu.Context().Done()
 
 			return vu.Context().Err()
-		})
+		}, nil)
 	}()
 
 	select {

--- a/pkg/bench/enums.go
+++ b/pkg/bench/enums.go
@@ -9,7 +9,6 @@ import (
 
 var (
 	errUnknownDriverType  = errors.New("unknown driver type")
-	errUnknownErrorMode   = errors.New("unknown error mode")
 	errUnknownTxIsolation = errors.New("unknown tx isolation")
 )
 
@@ -63,33 +62,6 @@ func DriverTypeNameOf(t config.DriverType) DriverTypeName {
 		return DriverCSV
 	default:
 		return ""
-	}
-}
-
-type ErrorModeName string
-
-const (
-	ErrorSilent ErrorModeName = "silent"
-	ErrorLog    ErrorModeName = "log"
-	ErrorThrow  ErrorModeName = "throw"
-	ErrorFail   ErrorModeName = "fail"
-	ErrorAbort  ErrorModeName = "abort"
-)
-
-func ParseErrorMode(s string) (config.ErrorMode, error) {
-	switch s {
-	case "", "silent":
-		return config.ErrorModeSilent, nil
-	case "log":
-		return config.ErrorModeLog, nil
-	case "throw":
-		return config.ErrorModeThrow, nil
-	case "fail":
-		return config.ErrorModeFail, nil
-	case "abort":
-		return config.ErrorModeAbort, nil
-	default:
-		return 0, fmt.Errorf("%w %q", errUnknownErrorMode, s)
 	}
 }
 

--- a/pkg/bench/error_reporter.go
+++ b/pkg/bench/error_reporter.go
@@ -1,0 +1,333 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+const (
+	maxErrorGroups         = 32
+	maxErrorOperationBytes = 64
+	errorReportInterval    = 30 * time.Second
+)
+
+type terminalErrorScope uint8
+
+const (
+	terminalErrorIteration terminalErrorScope = iota
+	terminalErrorQuery
+)
+
+type errorGroup struct {
+	operation string
+	kind      driver.ErrorKind
+}
+
+type errorGroupSummary struct {
+	errorGroup
+	count uint64
+}
+
+type errorSummary struct {
+	terminalErrors   uint64
+	failedIterations uint64
+	failedQueries    uint64
+	retryAttempts    uint64
+	groups           []errorGroupSummary
+}
+
+type errorGroupState struct {
+	count atomic.Uint64
+}
+
+type errorReporter struct {
+	lg       *zap.Logger
+	interval time.Duration
+	stop     chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
+
+	mu     sync.RWMutex
+	groups map[errorGroup]*errorGroupState
+
+	failedIterations atomic.Uint64
+	failedQueries    atomic.Uint64
+	retryAttempts    atomic.Uint64
+	lastPeriodic     uint64
+}
+
+func newErrorReporter(lg *zap.Logger, interval time.Duration) *errorReporter {
+	if lg == nil {
+		lg = zap.NewNop()
+	}
+	if interval <= 0 {
+		interval = errorReportInterval
+	}
+
+	r := &errorReporter{
+		lg:       lg,
+		interval: interval,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+		groups:   make(map[errorGroup]*errorGroupState, maxErrorGroups+1),
+	}
+	go r.run()
+
+	return r
+}
+
+func (r *errorReporter) run() {
+	ticker := time.NewTicker(r.interval)
+	defer func() {
+		ticker.Stop()
+		close(r.done)
+	}()
+
+	for {
+		select {
+		case <-ticker.C:
+			r.reportPeriodic()
+		case <-r.stop:
+			return
+		}
+	}
+}
+
+func (r *errorReporter) stopAndWait() {
+	if r == nil {
+		return
+	}
+
+	r.stopOnce.Do(func() { close(r.stop) })
+	<-r.done
+}
+
+func (r *errorReporter) record(
+	vu *VU,
+	scope terminalErrorScope,
+	operation string,
+	err error,
+	classify func(error) driver.ErrorFacts,
+) {
+	if r == nil || err == nil {
+		return
+	}
+
+	kind := classifyError(err, classify).Kind
+	group := errorGroup{operation: boundErrorOperation(operation), kind: normalizeErrorKind(kind)}
+	group, state := r.groupState(group)
+	count := state.count.Add(1)
+
+	switch scope {
+	case terminalErrorIteration:
+		r.failedIterations.Add(1)
+	case terminalErrorQuery:
+		r.failedQueries.Add(1)
+	}
+
+	first := count == 1
+
+	if vu != nil && vu.root != nil && vu.root.txMetrics != nil {
+		vu.root.txMetrics.recordTerminalError(vu, scope, group)
+	}
+
+	if first {
+		r.lg.Warn(
+			"nonfatal error; continuing",
+			zap.String("operation", group.operation),
+			zap.String("error_class", string(group.kind)),
+			zap.Error(err),
+		)
+	}
+}
+
+func (r *errorReporter) groupState(group errorGroup) (errorGroup, *errorGroupState) {
+	r.mu.RLock()
+	state := r.groups[group]
+	r.mu.RUnlock()
+	if state != nil {
+		return group, state
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if state = r.groups[group]; state != nil {
+		return group, state
+	}
+	if len(r.groups) >= maxErrorGroups {
+		group = errorGroup{operation: "other", kind: driver.ErrorKindUnknown}
+		if state = r.groups[group]; state != nil {
+			return group, state
+		}
+	} else {
+		group.operation = strings.Clone(group.operation)
+	}
+
+	state = &errorGroupState{}
+	r.groups[group] = state
+
+	return group, state
+}
+
+func (r *errorReporter) recordRetry(vu *VU) {
+	if r == nil {
+		return
+	}
+
+	r.retryAttempts.Add(1)
+
+	if vu != nil && vu.root != nil && vu.root.txMetrics != nil {
+		vu.root.txMetrics.recordRetry(vu)
+	}
+}
+
+func (r *errorReporter) reportPeriodic() {
+	failedIterations := r.failedIterations.Load()
+	failedQueries := r.failedQueries.Load()
+	total := failedIterations + failedQueries
+	if total == r.lastPeriodic {
+		return
+	}
+
+	newErrors := total - r.lastPeriodic
+	r.lastPeriodic = total
+	retryAttempts := r.retryAttempts.Load()
+
+	r.mu.RLock()
+	groupCount := uint64(len(r.groups))
+	r.mu.RUnlock()
+
+	var suppressed uint64
+	if total > groupCount {
+		suppressed = total - groupCount
+	}
+
+	r.lg.Warn(
+		"nonfatal errors continue",
+		zap.Uint64("new_errors", newErrors),
+		zap.Uint64("terminal_errors", total),
+		zap.Uint64("suppressed_events", suppressed),
+		zap.Uint64("failed_iterations", failedIterations),
+		zap.Uint64("failed_queries", failedQueries),
+		zap.Uint64("retry_attempts", retryAttempts),
+	)
+}
+
+func (r *errorReporter) snapshot() errorSummary {
+	if r == nil {
+		return errorSummary{}
+	}
+
+	failedIterations := r.failedIterations.Load()
+	failedQueries := r.failedQueries.Load()
+	summary := errorSummary{
+		terminalErrors:   failedIterations + failedQueries,
+		failedIterations: failedIterations,
+		failedQueries:    failedQueries,
+		retryAttempts:    r.retryAttempts.Load(),
+	}
+
+	r.mu.RLock()
+	summary.groups = make([]errorGroupSummary, 0, len(r.groups))
+	for group, state := range r.groups {
+		summary.groups = append(summary.groups, errorGroupSummary{errorGroup: group, count: state.count.Load()})
+	}
+	r.mu.RUnlock()
+
+	slices.SortFunc(summary.groups, func(a, b errorGroupSummary) int {
+		if byOperation := strings.Compare(a.operation, b.operation); byOperation != 0 {
+			return byOperation
+		}
+
+		return strings.Compare(string(a.kind), string(b.kind))
+	})
+
+	return summary
+}
+
+func (r *errorReporter) writeSummary(w io.Writer) {
+	summary := r.snapshot()
+	if summary.terminalErrors == 0 {
+		return
+	}
+
+	fmt.Fprintln(w, "\n=== bench completed with errors ===")
+	fmt.Fprintf(w, "  %-40s %d\n", "terminal_errors_total", summary.terminalErrors)
+	fmt.Fprintf(w, "  %-40s %d\n", "failed_iterations_total", summary.failedIterations)
+	fmt.Fprintf(w, "  %-40s %d\n", "failed_queries_total", summary.failedQueries)
+	fmt.Fprintf(w, "  %-40s %d\n", "retry_attempts_total", summary.retryAttempts)
+	fmt.Fprintln(w, "  representative error groups:")
+
+	for _, group := range summary.groups {
+		fmt.Fprintf(
+			w,
+			"    operation=%-20s class=%-14s count=%d\n",
+			group.operation,
+			group.kind,
+			group.count,
+		)
+	}
+}
+
+func boundErrorOperation(operation string) string {
+	if len(operation) > maxErrorOperationBytes {
+		operation = operation[:maxErrorOperationBytes]
+	}
+
+	operation = strings.TrimSpace(strings.ToValidUTF8(operation, "?"))
+	if operation == "" {
+		return "unknown"
+	}
+
+	return operation
+}
+
+func normalizeErrorKind(kind driver.ErrorKind) driver.ErrorKind {
+	switch kind {
+	case driver.ErrorKindUnknown,
+		driver.ErrorKindSerialization,
+		driver.ErrorKindDeadlock,
+		driver.ErrorKindLockTimeout,
+		driver.ErrorKindTransient,
+		driver.ErrorKindUnsupported,
+		driver.ErrorKindCanceled,
+		driver.ErrorKindTimeout:
+		return kind
+	default:
+		return driver.ErrorKindUnknown
+	}
+}
+
+func canceledError(ctx context.Context, err error) bool {
+	return ctx != nil && ctx.Err() != nil && errors.Is(err, ctx.Err())
+}
+
+// RecordQueryError records a query-set error after the workload has decided not
+// to retry it. The query set may continue and the run remains successful.
+func (b *Bench) RecordQueryError(operation string, err error) {
+	if b == nil || b.root == nil || b.root.errorReporter == nil || b.vu == nil || err == nil {
+		return
+	}
+	if canceledError(b.vu.Context(), err) {
+		return
+	}
+
+	var classify func(error) driver.ErrorFacts
+	if b.drv != nil {
+		classify = b.drv.ClassifyError
+	}
+
+	b.root.errorReporter.record(b.vu, terminalErrorQuery, operation, err, classify)
+}

--- a/pkg/bench/error_reporter.go
+++ b/pkg/bench/error_reporter.go
@@ -71,6 +71,7 @@ func newErrorReporter(lg *zap.Logger, interval time.Duration) *errorReporter {
 	if lg == nil {
 		lg = zap.NewNop()
 	}
+
 	if interval <= 0 {
 		interval = errorReportInterval
 	}
@@ -156,6 +157,7 @@ func (r *errorReporter) groupState(group errorGroup) (errorGroup, *errorGroupSta
 	r.mu.RLock()
 	state := r.groups[group]
 	r.mu.RUnlock()
+
 	if state != nil {
 		return group, state
 	}
@@ -163,13 +165,15 @@ func (r *errorReporter) groupState(group errorGroup) (errorGroup, *errorGroupSta
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if state = r.groups[group]; state != nil {
-		return group, state
+	if existing := r.groups[group]; existing != nil {
+		return group, existing
 	}
+
 	if len(r.groups) >= maxErrorGroups {
 		group = errorGroup{operation: "other", kind: driver.ErrorKindUnknown}
-		if state = r.groups[group]; state != nil {
-			return group, state
+
+		if existing := r.groups[group]; existing != nil {
+			return group, existing
 		}
 	} else {
 		group.operation = strings.Clone(group.operation)
@@ -197,6 +201,7 @@ func (r *errorReporter) reportPeriodic() {
 	failedIterations := r.failedIterations.Load()
 	failedQueries := r.failedQueries.Load()
 	total := failedIterations + failedQueries
+
 	if total == r.lastPeriodic {
 		return
 	}
@@ -241,9 +246,11 @@ func (r *errorReporter) snapshot() errorSummary {
 
 	r.mu.RLock()
 	summary.groups = make([]errorGroupSummary, 0, len(r.groups))
+
 	for group, state := range r.groups {
 		summary.groups = append(summary.groups, errorGroupSummary{errorGroup: group, count: state.count.Load()})
 	}
+
 	r.mu.RUnlock()
 
 	slices.SortFunc(summary.groups, func(a, b errorGroupSummary) int {
@@ -320,6 +327,7 @@ func (b *Bench) RecordQueryError(operation string, err error) {
 	if b == nil || b.root == nil || b.root.errorReporter == nil || b.vu == nil || err == nil {
 		return
 	}
+
 	if canceledError(b.vu.Context(), err) {
 		return
 	}

--- a/pkg/bench/error_reporter.go
+++ b/pkg/bench/error_reporter.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"go.uber.org/zap"
 
@@ -289,13 +291,28 @@ func (r *errorReporter) writeSummary(w io.Writer) {
 }
 
 func boundErrorOperation(operation string) string {
-	if len(operation) > maxErrorOperationBytes {
-		operation = operation[:maxErrorOperationBytes]
-	}
+	operation = strings.ToValidUTF8(operation, "?")
+	operation = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || unicode.In(r, unicode.Cf) {
+			return '?'
+		}
 
-	operation = strings.TrimSpace(strings.ToValidUTF8(operation, "?"))
+		return r
+	}, operation)
+	operation = strings.TrimSpace(operation)
+
 	if operation == "" {
 		return "unknown"
+	}
+
+	if len(operation) <= maxErrorOperationBytes {
+		return operation
+	}
+
+	operation = operation[:maxErrorOperationBytes]
+
+	for !utf8.ValidString(operation) {
+		operation = operation[:len(operation)-1]
 	}
 
 	return operation

--- a/pkg/bench/error_reporter_test.go
+++ b/pkg/bench/error_reporter_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -113,6 +114,22 @@ func TestErrorReporterBoundsGroupsAndPeriodicNotices(t *testing.T) {
 	}, time.Second, time.Millisecond)
 	time.Sleep(15 * time.Millisecond)
 	require.Len(t, logs.FilterMessage("nonfatal errors continue").All(), 1)
+}
+
+func TestBoundErrorOperationSanitizesAndPreservesRuneBoundaries(t *testing.T) {
+	t.Parallel()
+
+	bidi := string(rune(0x202e))
+	format := bidi + string(rune(0x200d))
+	require.Equal(t, "safe???[31m??end", boundErrorOperation("safe\r\n\x1b[31m\x00"+bidi+"end"))
+	require.Equal(t, "left??right", boundErrorOperation("left"+format+"right"))
+	require.Equal(t, "a?b", boundErrorOperation(string([]byte{'a', 0xff, 'b'})))
+
+	prefix := strings.Repeat("a", maxErrorOperationBytes-1)
+	got := boundErrorOperation(prefix + "é")
+	require.Equal(t, prefix, got)
+	require.True(t, utf8.ValidString(got))
+	require.LessOrEqual(t, len(got), maxErrorOperationBytes)
 }
 
 func TestRecordQueryErrorExcludesRunCancellation(t *testing.T) {

--- a/pkg/bench/error_reporter_test.go
+++ b/pkg/bench/error_reporter_test.go
@@ -1,0 +1,165 @@
+package bench
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/stroppy-io/stroppy/pkg/driver"
+)
+
+func TestErrorReporterSuppressesDuplicatesAndRecordsMetrics(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	rootState, err := newRootState(zap.New(core), context.Background(), nil, nil, &MetricsConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		rootState.errorReporter.stopAndWait()
+		rootState.shutdownMetrics()
+	})
+
+	vu := &VU{root: rootState, vuid: 1, ctx: context.Background()}
+	classifyDeadlock := func(error) driver.ErrorFacts {
+		return driver.ErrorFacts{Kind: driver.ErrorKindDeadlock}
+	}
+	classifyCustom := func(error) driver.ErrorFacts {
+		return driver.ErrorFacts{Kind: driver.ErrorKind("backend-private")}
+	}
+
+	for range 3 {
+		rootState.errorReporter.record(
+			vu, terminalErrorQuery, "q1", errors.New("same backend failure"), classifyDeadlock,
+		)
+	}
+	rootState.errorReporter.record(
+		vu, terminalErrorIteration, "iteration", errors.New("different failure"), classifyCustom,
+	)
+	rootState.errorReporter.recordRetry(vu)
+
+	require.Len(t, logs.FilterMessage("nonfatal error; continuing").All(), 2)
+	require.NotContains(t, fmt.Sprint(logs.All()[0].Context), "backend-private")
+
+	snapshot := rootState.errorReporter.snapshot()
+	require.Equal(t, uint64(4), snapshot.terminalErrors)
+	require.Equal(t, uint64(1), snapshot.failedIterations)
+	require.Equal(t, uint64(3), snapshot.failedQueries)
+	require.Equal(t, uint64(1), snapshot.retryAttempts)
+	require.Len(t, snapshot.groups, 2)
+	require.Equal(t, driver.ErrorKindUnknown, snapshot.groups[0].kind)
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, rootState.manualReader.Collect(context.Background(), &data))
+	require.InDelta(t, 4, findSum(t, data, rootState.metricsPrefix+"terminal_errors_total"), 0)
+	require.InDelta(t, 1, findSum(t, data, rootState.metricsPrefix+"failed_iterations_total"), 0)
+	require.InDelta(t, 3, findSum(t, data, rootState.metricsPrefix+"failed_queries_total"), 0)
+	require.InDelta(t, 1, findSum(t, data, rootState.metricsPrefix+"retry_attempts_total"), 0)
+
+	for _, scope := range data.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != rootState.metricsPrefix+"terminal_errors_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[float64])
+			require.True(t, ok)
+			for _, point := range sum.DataPoints {
+				attrs := point.Attributes.ToSlice()
+				for _, attr := range attrs {
+					require.NotContains(t, attr.Value.AsString(), "failure")
+				}
+			}
+		}
+	}
+}
+
+func TestErrorReporterBoundsGroupsAndPeriodicNotices(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	reporter := newErrorReporter(zap.New(core), 5*time.Millisecond)
+	t.Cleanup(reporter.stopAndWait)
+
+	for i := range maxErrorGroups + 10 {
+		reporter.record(
+			nil,
+			terminalErrorQuery,
+			fmt.Sprintf("query-%d-%s", i, strings.Repeat("x", maxErrorOperationBytes)),
+			errors.New("query failed"),
+			nil,
+		)
+	}
+
+	snapshot := reporter.snapshot()
+	require.Equal(t, uint64(maxErrorGroups+10), snapshot.terminalErrors)
+	require.Len(t, snapshot.groups, maxErrorGroups+1)
+	require.Len(t, logs.FilterMessage("nonfatal error; continuing").All(), maxErrorGroups+1)
+	for _, group := range snapshot.groups {
+		require.LessOrEqual(t, len(group.operation), maxErrorOperationBytes)
+	}
+
+	require.Eventually(t, func() bool {
+		return logs.FilterMessage("nonfatal errors continue").Len() == 1
+	}, time.Second, time.Millisecond)
+	time.Sleep(15 * time.Millisecond)
+	require.Len(t, logs.FilterMessage("nonfatal errors continue").All(), 1)
+}
+
+func TestRecordQueryErrorExcludesRunCancellation(t *testing.T) {
+	reporter := newErrorReporter(zap.NewNop(), time.Hour)
+	t.Cleanup(reporter.stopAndWait)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rootState := &RootState{errorReporter: reporter, txMetrics: &txMetrics{}}
+	b := &Bench{root: rootState, vu: &VU{root: rootState, ctx: ctx}}
+	b.RecordQueryError("query", errors.Join(errors.New("backend detail"), context.Canceled))
+
+	snapshot := reporter.snapshot()
+	require.Zero(t, snapshot.terminalErrors)
+	require.Empty(t, snapshot.groups)
+}
+
+func TestErrorSummaryIsProminentAndDeterministic(t *testing.T) {
+	rootState, err := newRootState(zap.NewNop(), context.Background(), nil, nil, &MetricsConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		rootState.errorReporter.stopAndWait()
+		rootState.shutdownMetrics()
+	})
+	reporter := rootState.errorReporter
+
+	reporter.record(
+		nil,
+		terminalErrorQuery,
+		"q2",
+		errors.New("second"),
+		func(error) driver.ErrorFacts { return driver.ErrorFacts{Kind: driver.ErrorKindTimeout} },
+	)
+	reporter.record(
+		nil,
+		terminalErrorIteration,
+		"iteration",
+		errors.New("first"),
+		func(error) driver.ErrorFacts { return driver.ErrorFacts{Kind: driver.ErrorKindDeadlock} },
+	)
+	reporter.recordRetry(nil)
+
+	var output bytes.Buffer
+	newSummary(rootState).printTo(&output)
+
+	text := output.String()
+	require.Contains(t, text, "=== bench completed with errors ===")
+	require.Contains(t, text, "terminal_errors_total")
+	require.Contains(t, text, "failed_iterations_total")
+	require.Contains(t, text, "failed_queries_total")
+	require.Contains(t, text, "retry_attempts_total")
+	require.Less(t, strings.Index(text, "operation=iteration"), strings.Index(text, "operation=q2"))
+	require.NotContains(t, text, "first")
+	require.NotContains(t, text, "second")
+}

--- a/pkg/bench/error_reporter_test.go
+++ b/pkg/bench/error_reporter_test.go
@@ -87,7 +87,7 @@ func TestErrorReporterSuppressesDuplicatesAndRecordsMetrics(t *testing.T) {
 
 func TestErrorReporterBoundsGroupsAndPeriodicNotices(t *testing.T) {
 	core, logs := observer.New(zapcore.WarnLevel)
-	reporter := newErrorReporter(zap.New(core), 5*time.Millisecond)
+	reporter := newErrorReporter(zap.New(core), time.Hour)
 	t.Cleanup(reporter.stopAndWait)
 
 	for i := range maxErrorGroups + 10 {
@@ -109,10 +109,10 @@ func TestErrorReporterBoundsGroupsAndPeriodicNotices(t *testing.T) {
 		require.LessOrEqual(t, len(group.operation), maxErrorOperationBytes)
 	}
 
-	require.Eventually(t, func() bool {
-		return logs.FilterMessage("nonfatal errors continue").Len() == 1
-	}, time.Second, time.Millisecond)
-	time.Sleep(15 * time.Millisecond)
+	reporter.reportPeriodic()
+	require.Len(t, logs.FilterMessage("nonfatal errors continue").All(), 1)
+
+	reporter.reportPeriodic()
 	require.Len(t, logs.FilterMessage("nonfatal errors continue").All(), 1)
 }
 

--- a/pkg/bench/error_reporter_test.go
+++ b/pkg/bench/error_reporter_test.go
@@ -40,6 +40,7 @@ func TestErrorReporterSuppressesDuplicatesAndRecordsMetrics(t *testing.T) {
 			vu, terminalErrorQuery, "q1", errors.New("same backend failure"), classifyDeadlock,
 		)
 	}
+
 	rootState.errorReporter.record(
 		vu, terminalErrorIteration, "iteration", errors.New("different failure"), classifyCustom,
 	)
@@ -68,10 +69,13 @@ func TestErrorReporterSuppressesDuplicatesAndRecordsMetrics(t *testing.T) {
 			if m.Name != rootState.metricsPrefix+"terminal_errors_total" {
 				continue
 			}
+
 			sum, ok := m.Data.(metricdata.Sum[float64])
 			require.True(t, ok)
+
 			for _, point := range sum.DataPoints {
 				attrs := point.Attributes.ToSlice()
+
 				for _, attr := range attrs {
 					require.NotContains(t, attr.Value.AsString(), "failure")
 				}
@@ -99,6 +103,7 @@ func TestErrorReporterBoundsGroupsAndPeriodicNotices(t *testing.T) {
 	require.Equal(t, uint64(maxErrorGroups+10), snapshot.terminalErrors)
 	require.Len(t, snapshot.groups, maxErrorGroups+1)
 	require.Len(t, logs.FilterMessage("nonfatal error; continuing").All(), maxErrorGroups+1)
+
 	for _, group := range snapshot.groups {
 		require.LessOrEqual(t, len(group.operation), maxErrorOperationBytes)
 	}
@@ -116,6 +121,7 @@ func TestRecordQueryErrorExcludesRunCancellation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+
 	rootState := &RootState{errorReporter: reporter, txMetrics: &txMetrics{}}
 	b := &Bench{root: rootState, vu: &VU{root: rootState, ctx: ctx}}
 	b.RecordQueryError("query", errors.Join(errors.New("backend detail"), context.Canceled))
@@ -132,6 +138,7 @@ func TestErrorSummaryIsProminentAndDeterministic(t *testing.T) {
 		rootState.errorReporter.stopAndWait()
 		rootState.shutdownMetrics()
 	})
+
 	reporter := rootState.errorReporter
 
 	reporter.record(

--- a/pkg/bench/metrics.go
+++ b/pkg/bench/metrics.go
@@ -36,6 +36,10 @@ type txMetrics struct {
 	insertDuration   *metric
 	iterationDur     *metric
 	iterations       *metric
+	terminalErrors   *metric
+	failedIterations *metric
+	failedQueries    *metric
+	retryAttempts    *metric
 	txTotalDuration  *metric
 	txCommits        *metric
 	txErrors         *metric
@@ -43,6 +47,7 @@ type txMetrics struct {
 	stepAttrs        attributeCache
 	tableAttrs       attributeCache
 	txAttrs          attributeCache
+	errorAttrs       attributeCache
 	progressAttrs    attributeCache
 }
 
@@ -102,6 +107,10 @@ func (m *txMetrics) ensureRegistered(vu *VU, lg *zap.Logger) {
 	m.insertDuration = newMetric("insert_duration", Trend)
 	m.iterationDur = newMetric("iteration_duration", Trend)
 	m.iterations = newMetric("iterations_total", Counter)
+	m.terminalErrors = newMetric("terminal_errors_total", Counter)
+	m.failedIterations = newMetric("failed_iterations_total", Counter)
+	m.failedQueries = newMetric("failed_queries_total", Counter)
+	m.retryAttempts = newMetric("retry_attempts_total", Counter)
 	m.txTotalDuration = newMetric("tx_total_duration", Trend)
 	m.txCommits = newMetric("tx_commits_total", Counter)
 	m.txErrors = newMetric("tx_errors_total", Counter)
@@ -186,6 +195,15 @@ func (m *txMetrics) txAttributes(step, action, name, isolation string) metricAtt
 	)
 }
 
+func (m *txMetrics) errorAttributes(group errorGroup) metricAttributes {
+	return cachedAttributes(
+		&m.errorAttrs,
+		group,
+		"operation", group.operation,
+		"error_class", string(group.kind),
+	)
+}
+
 func (m *txMetrics) progressAttributes(snapshot *insertprogress.Snapshot, step string) metricAttributes {
 	key := progressAttributeKey{
 		step: step, table: snapshot.Table, method: snapshot.Method,
@@ -203,7 +221,7 @@ func (m *txMetrics) progressAttributes(snapshot *insertprogress.Snapshot, step s
 }
 
 func (m *txMetrics) recordQueryResult(vu *VU, elapsed time.Duration, queryErr error) {
-	m.ensureRegistered(vu, root.lg)
+	m.ensureRegistered(vu, vu.root.lg)
 	attrs := m.stepAttributes(vu.stepTag)
 	m.emit(vu, m.queryOperations, 1, attrs)
 
@@ -217,7 +235,7 @@ func (m *txMetrics) recordQueryResult(vu *VU, elapsed time.Duration, queryErr er
 }
 
 func (m *txMetrics) recordInsertResult(vu *VU, table string, elapsed time.Duration, insertErr error) {
-	m.ensureRegistered(vu, root.lg)
+	m.ensureRegistered(vu, vu.root.lg)
 
 	if table == "" {
 		table = "unknown"
@@ -236,10 +254,28 @@ func (m *txMetrics) recordInsertResult(vu *VU, table string, elapsed time.Durati
 }
 
 func (m *txMetrics) recordIteration(vu *VU, elapsed time.Duration) {
-	m.ensureRegistered(vu, root.lg)
+	m.ensureRegistered(vu, vu.root.lg)
 	attrs := m.stepAttributes(vu.stepTag)
 	m.emit(vu, m.iterationDur, elapsed.Seconds()*millisPerSecond, attrs)
 	m.emit(vu, m.iterations, 1, attrs)
+}
+
+func (m *txMetrics) recordTerminalError(vu *VU, scope terminalErrorScope, group errorGroup) {
+	m.ensureRegistered(vu, vu.root.lg)
+	attrs := m.errorAttributes(group)
+	m.emit(vu, m.terminalErrors, 1, attrs)
+
+	switch scope {
+	case terminalErrorIteration:
+		m.emit(vu, m.failedIterations, 1, attrs)
+	case terminalErrorQuery:
+		m.emit(vu, m.failedQueries, 1, attrs)
+	}
+}
+
+func (m *txMetrics) recordRetry(vu *VU) {
+	m.ensureRegistered(vu, vu.root.lg)
+	m.emit(vu, m.retryAttempts, 1, metricAttributes{})
 }
 
 func (m *txMetrics) recordTxEnd(
@@ -250,7 +286,7 @@ func (m *txMetrics) recordTxEnd(
 	queries int,
 	committed bool,
 ) {
-	m.ensureRegistered(vu, root.lg)
+	m.ensureRegistered(vu, vu.root.lg)
 
 	attrs := m.txAttributes(vu.stepTag, action, name, txIsolationName(isolation))
 	if committed {
@@ -264,7 +300,7 @@ func (m *txMetrics) recordTxEnd(
 }
 
 func (m *txMetrics) recordInsertProgress(vu *VU, snapshot *insertprogress.Snapshot) {
-	m.ensureRegistered(vu, root.lg)
+	m.ensureRegistered(vu, vu.root.lg)
 
 	attrs := m.progressAttributes(snapshot, vu.stepTag)
 	if snapshot.DeltaRows > 0 {
@@ -275,7 +311,7 @@ func (m *txMetrics) recordInsertProgress(vu *VU, snapshot *insertprogress.Snapsh
 }
 
 func (m *txMetrics) recordInsert(vu *VU, table string, rows int64) {
-	m.ensureRegistered(vu, root.lg)
+	m.ensureRegistered(vu, vu.root.lg)
 
 	if table == "" {
 		table = "unknown"
@@ -289,7 +325,7 @@ func (m *txMetrics) recordInsert(vu *VU, table string, rows int64) {
 }
 
 func (m *txMetrics) record(vu *VU, action, name string, isolation config.TxIsolationLevel) {
-	m.ensureRegistered(vu, root.lg)
+	m.ensureRegistered(vu, vu.root.lg)
 	m.emit(vu, m.transactions, 1, m.txAttributes(vu.stepTag, action, name, txIsolationName(isolation)))
 }
 

--- a/pkg/bench/retry.go
+++ b/pkg/bench/retry.go
@@ -148,10 +148,7 @@ func applyRetryDecision(
 }
 
 func (p RetryPolicy) decision(err error) RetryDecision {
-	facts := driver.DefaultErrorFacts(err)
-	if p.Classify != nil {
-		facts = p.Classify(err)
-	}
+	facts := classifyError(err, p.Classify)
 
 	action := p.Actions.action(facts.Kind)
 	if action == ErrorActionRetry && facts.RequiresIdempotency && !p.idempotent {
@@ -159,6 +156,14 @@ func (p RetryPolicy) decision(err error) RetryDecision {
 	}
 
 	return RetryDecision{Action: action, Facts: facts}
+}
+
+func classifyError(err error, classify func(error) driver.ErrorFacts) driver.ErrorFacts {
+	if classify != nil {
+		return classify(err)
+	}
+
+	return driver.DefaultErrorFacts(err)
 }
 
 // TxRetryPolicyOptions configures Bench.TxRetryPolicy.
@@ -174,6 +179,16 @@ type TxRetryPolicyOptions struct {
 // TxRetryPolicy builds a policy from this bench's driver classifier and
 // workload overrides.
 func (b *Bench) TxRetryPolicy(opts TxRetryPolicyOptions) RetryPolicy {
+	workloadOnRetry := opts.OnRetry
+	opts.OnRetry = func(attempt int, err error, decision RetryDecision) {
+		if b.root != nil && b.root.errorReporter != nil {
+			b.root.errorReporter.recordRetry(b.vu)
+		}
+		if workloadOnRetry != nil {
+			workloadOnRetry(attempt, err, decision)
+		}
+	}
+
 	return newTxRetryPolicy(b.drv.ClassifyError, opts)
 }
 

--- a/pkg/bench/retry.go
+++ b/pkg/bench/retry.go
@@ -184,6 +184,7 @@ func (b *Bench) TxRetryPolicy(opts TxRetryPolicyOptions) RetryPolicy {
 		if b.root != nil && b.root.errorReporter != nil {
 			b.root.errorReporter.recordRetry(b.vu)
 		}
+
 		if workloadOnRetry != nil {
 			workloadOnRetry(attempt, err, decision)
 		}

--- a/pkg/bench/retry_test.go
+++ b/pkg/bench/retry_test.go
@@ -5,7 +5,11 @@ import (
 	"errors"
 	"testing"
 
+	"go.uber.org/zap"
+
+	"github.com/stroppy-io/stroppy/pkg/config"
 	"github.com/stroppy-io/stroppy/pkg/driver"
+	_ "github.com/stroppy-io/stroppy/pkg/driver/noop"
 )
 
 func TestDefaultErrorActions(t *testing.T) {
@@ -101,6 +105,63 @@ func TestRetryWithPolicyRetriesClassifiedError(t *testing.T) {
 
 	if len(retried) != 2 || retried[0] != 2 || retried[1] != 3 {
 		t.Fatalf("retry attempts = %v, want [2 3]", retried)
+	}
+}
+
+func TestBenchRetryPolicyCountsOnlyScheduledRetries(t *testing.T) {
+	rootState, err := newRootState(zap.NewNop(), context.Background(), nil, nil, &MetricsConfig{})
+	if err != nil {
+		t.Fatalf("newRootState() error = %v", err)
+	}
+	t.Cleanup(func() {
+		rootState.errorReporter.stopAndWait()
+		rootState.shutdownMetrics()
+	})
+
+	drv, err := driver.Dispatch(context.Background(), driver.Options{
+		Config: &config.DriverConfig{DriverType: config.DriverTypeNoop},
+		Logger: zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("driver.Dispatch() error = %v", err)
+	}
+
+	vu := &VU{root: rootState, vuid: 1, ctx: context.Background()}
+	b := &Bench{root: rootState, vu: vu, drv: drv}
+	attempts := 0
+
+	var callbacks []int
+	policy := b.TxRetryPolicy(TxRetryPolicyOptions{
+		MaxAttempts: 3,
+		Actions: ErrorActionMap{ //nolint:exhaustive // test overrides one kind
+			driver.ErrorKindUnknown: ErrorActionRetry,
+		},
+		OnRetry: func(attempt int, _ error, _ RetryDecision) {
+			callbacks = append(callbacks, attempt)
+		},
+	})
+
+	err = Retry0(context.Background(), policy, func() error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("retry")
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Retry0() error = %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	if len(callbacks) != 2 || callbacks[0] != 2 || callbacks[1] != 3 {
+		t.Fatalf("workload callbacks = %v, want [2 3]", callbacks)
+	}
+
+	snapshot := rootState.errorReporter.snapshot()
+	if snapshot.retryAttempts != 2 || snapshot.terminalErrors != 0 {
+		t.Fatalf("retry summary = %#v, want two retries and no terminal errors", snapshot)
 	}
 }
 

--- a/pkg/bench/retry_test.go
+++ b/pkg/bench/retry_test.go
@@ -113,6 +113,7 @@ func TestBenchRetryPolicyCountsOnlyScheduledRetries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newRootState() error = %v", err)
 	}
+
 	t.Cleanup(func() {
 		rootState.errorReporter.stopAndWait()
 		rootState.shutdownMetrics()
@@ -131,6 +132,7 @@ func TestBenchRetryPolicyCountsOnlyScheduledRetries(t *testing.T) {
 	attempts := 0
 
 	var callbacks []int
+
 	policy := b.TxRetryPolicy(TxRetryPolicyOptions{
 		MaxAttempts: 3,
 		Actions: ErrorActionMap{ //nolint:exhaustive // test overrides one kind
@@ -152,9 +154,11 @@ func TestBenchRetryPolicyCountsOnlyScheduledRetries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Retry0() error = %v", err)
 	}
+
 	if attempts != 3 {
 		t.Fatalf("attempts = %d, want 3", attempts)
 	}
+
 	if len(callbacks) != 2 || callbacks[0] != 2 || callbacks[1] != 3 {
 		t.Fatalf("workload callbacks = %v, want [2 3]", callbacks)
 	}

--- a/pkg/bench/root.go
+++ b/pkg/bench/root.go
@@ -30,7 +30,8 @@ type RootState struct {
 	manualReader  *sdkmetric.ManualReader
 	metricsPrefix string
 
-	txMetrics *txMetrics
+	txMetrics     *txMetrics
+	errorReporter *errorReporter
 
 	sharedMu    sync.Mutex
 	sharedSlots map[uint64]*sharedDriverSlot
@@ -53,7 +54,7 @@ func newRootState(
 		return nil, err
 	}
 
-	return &RootState{
+	state := &RootState{
 		lg:            lg,
 		ctx:           ctx,
 		dialer:        &net.Dialer{},
@@ -64,7 +65,10 @@ func newRootState(
 		txMetrics:     &txMetrics{},
 		sharedSlots:   make(map[uint64]*sharedDriverSlot),
 		stepFilter:    newStepFilter(steps, noSteps),
-	}, nil
+	}
+	state.errorReporter = newErrorReporter(lg, errorReportInterval)
+
+	return state, nil
 }
 
 // NotifyStep is a no-op at the floor (cloud notification deferred).

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"slices"
@@ -220,6 +221,7 @@ func Run(
 
 	defer root.shutdownMetrics()
 	defer sum.print()
+	defer root.errorReporter.stopAndWait()
 	defer func() { _ = root.Teardown() }()
 
 	cfg := drivers[0]
@@ -273,6 +275,8 @@ func Run(
 		}
 
 		return wl.Iterate(vu.Context(), b)
+	}, func(vu *VU, err error) {
+		root.errorReporter.record(vu, terminalErrorIteration, "iteration", err, drv.ClassifyError)
 	}); err != nil {
 		return fmt.Errorf("scenario %q: %w", sc.name, err)
 	}
@@ -414,7 +418,12 @@ func (params *scenarioParams) spec(lg *zap.Logger) (scenarioSpec, error) {
 
 // --- executor (shared-iterations + constant-vus) ---
 
-func runScenario(ctx context.Context, sc scenarioSpec, iterate func(*VU) error) error {
+func runScenario(
+	ctx context.Context,
+	sc scenarioSpec,
+	iterate func(*VU) error,
+	onIterationError func(*VU, error),
+) error {
 	scenarioCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -424,7 +433,7 @@ func runScenario(ctx context.Context, sc scenarioSpec, iterate func(*VU) error) 
 
 	startWorker := func(vuid int, keep func() bool) {
 		wg.Go(func() {
-			if err := runWorker(scenarioCtx, vuid, iterate, keep); IsFatalError(err) {
+			if err := runWorker(scenarioCtx, vuid, iterate, keep, onIterationError); IsFatalError(err) {
 				select {
 				case fatalErrors <- err:
 					cancel()
@@ -464,7 +473,13 @@ func runScenario(ctx context.Context, sc scenarioSpec, iterate func(*VU) error) 
 	return ctx.Err()
 }
 
-func runWorker(ctx context.Context, vuid int, iterate func(*VU) error, keep func() bool) error {
+func runWorker(
+	ctx context.Context,
+	vuid int,
+	iterate func(*VU) error,
+	keep func() bool,
+	onIterationError func(*VU, error),
+) error {
 	vu := &VU{root: root, vuid: uint64(vuid), ctx: ctx} //nolint:gosec // G115: scale-bound, no overflow
 	for keep() {
 		if err := ctx.Err(); err != nil {
@@ -478,18 +493,17 @@ func runWorker(ctx context.Context, vuid int, iterate func(*VU) error, keep func
 		err := iterate(vu)
 		root.txMetrics.recordIteration(vu, time.Since(start))
 
-		if err != nil {
-			if IsFatalError(err) {
-				return err
-			}
-
-			if ctx.Err() != nil && errors.Is(err, ctx.Err()) {
-				return ctx.Err()
-			}
-
-			root.lg.Error("iteration failed", zap.Int("vu", vuid), zap.Error(err))
-
-			return nil
+		if err == nil {
+			continue
+		}
+		if IsFatalError(err) {
+			return err
+		}
+		if canceledError(ctx, err) {
+			return ctx.Err()
+		}
+		if onIterationError != nil {
+			onIterationError(vu, err)
 		}
 	}
 
@@ -530,9 +544,17 @@ type summary struct {
 func newSummary(root *RootState) *summary { return &summary{root: root} }
 
 func (s *summary) print() {
+	s.printTo(os.Stderr)
+}
+
+func (s *summary) printTo(out io.Writer) {
+	if s.root.errorReporter != nil {
+		defer s.root.errorReporter.writeSummary(out)
+	}
+
 	var data metricdata.ResourceMetrics
 	if err := s.root.manualReader.Collect(context.Background(), &data); err != nil {
-		fmt.Fprintf(os.Stderr, "bench: collect metrics: %v\n", err)
+		fmt.Fprintf(out, "bench: collect metrics: %v\n", err)
 
 		return
 	}
@@ -559,15 +581,15 @@ func (s *summary) print() {
 	}
 
 	if len(lines) == 0 {
-		fmt.Fprintln(os.Stderr, "bench: no metrics recorded")
+		fmt.Fprintln(out, "bench: no metrics recorded")
 
 		return
 	}
 
-	fmt.Fprintln(os.Stderr, "\n=== bench summary ===")
+	fmt.Fprintln(out, "\n=== bench summary ===")
 
 	for _, line := range lines {
-		fmt.Fprintln(os.Stderr, line)
+		fmt.Fprintln(out, line)
 	}
 }
 

--- a/pkg/bench/runtime.go
+++ b/pkg/bench/runtime.go
@@ -496,12 +496,15 @@ func runWorker(
 		if err == nil {
 			continue
 		}
+
 		if IsFatalError(err) {
 			return err
 		}
+
 		if canceledError(ctx, err) {
 			return ctx.Err()
 		}
+
 		if onIterationError != nil {
 			onIterationError(vu, err)
 		}

--- a/pkg/bench/runtime_test.go
+++ b/pkg/bench/runtime_test.go
@@ -68,6 +68,7 @@ func TestRunScenarioContinuesAfterOrdinaryErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runScenario() error = %v, want nil", err)
 	}
+
 	if calls.Load() != 5 || failures.Load() != 5 {
 		t.Fatalf("calls = %d, failures = %d, want 5 each", calls.Load(), failures.Load())
 	}
@@ -75,6 +76,7 @@ func TestRunScenarioContinuesAfterOrdinaryErrors(t *testing.T) {
 
 func TestRunContinuesAndSummarizesOrdinaryErrors(t *testing.T) {
 	var workload *ordinaryErrorWorkload
+
 	Register(func() Workload {
 		workload = &ordinaryErrorWorkload{}
 
@@ -82,6 +84,7 @@ func TestRunContinuesAndSummarizesOrdinaryErrors(t *testing.T) {
 	})
 
 	core, logs := observer.New(zapcore.WarnLevel)
+
 	err := Run(
 		context.Background(),
 		"test/ordinary-errors-continue",
@@ -95,6 +98,7 @@ func TestRunContinuesAndSummarizesOrdinaryErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
+
 	if workload.calls.Load() != 6 {
 		t.Fatalf("iteration calls = %d, want 6", workload.calls.Load())
 	}
@@ -103,9 +107,11 @@ func TestRunContinuesAndSummarizesOrdinaryErrors(t *testing.T) {
 	if snapshot.terminalErrors != 6 || snapshot.failedIterations != 6 || snapshot.failedQueries != 0 {
 		t.Fatalf("error summary = %#v, want six failed iterations", snapshot)
 	}
+
 	if got := logs.FilterMessage("nonfatal error; continuing").Len(); got != 1 {
 		t.Fatalf("initial nonfatal warnings = %d, want 1", got)
 	}
+
 	if got := logs.FilterLevelExact(zapcore.ErrorLevel).Len(); got != 0 {
 		t.Fatalf("error-level logs = %d, want 0", got)
 	}

--- a/pkg/bench/runtime_test.go
+++ b/pkg/bench/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -75,13 +76,7 @@ func TestRunScenarioContinuesAfterOrdinaryErrors(t *testing.T) {
 }
 
 func TestRunContinuesAndSummarizesOrdinaryErrors(t *testing.T) {
-	var workload *ordinaryErrorWorkload
-
-	Register(func() Workload {
-		workload = &ordinaryErrorWorkload{}
-
-		return workload
-	})
+	registerOrdinaryErrorWorkload()
 
 	core, logs := observer.New(zapcore.WarnLevel)
 
@@ -99,8 +94,8 @@ func TestRunContinuesAndSummarizesOrdinaryErrors(t *testing.T) {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
 
-	if workload.calls.Load() != 6 {
-		t.Fatalf("iteration calls = %d, want 6", workload.calls.Load())
+	if ordinaryErrorWorkloadRun.calls.Load() != 6 {
+		t.Fatalf("iteration calls = %d, want 6", ordinaryErrorWorkloadRun.calls.Load())
 	}
 
 	snapshot := root.errorReporter.snapshot()
@@ -115,6 +110,21 @@ func TestRunContinuesAndSummarizesOrdinaryErrors(t *testing.T) {
 	if got := logs.FilterLevelExact(zapcore.ErrorLevel).Len(); got != 0 {
 		t.Fatalf("error-level logs = %d, want 0", got)
 	}
+}
+
+var (
+	registerOrdinaryErrorWorkloadOnce sync.Once
+	ordinaryErrorWorkloadRun          *ordinaryErrorWorkload
+)
+
+func registerOrdinaryErrorWorkload() {
+	registerOrdinaryErrorWorkloadOnce.Do(func() {
+		Register(func() Workload {
+			ordinaryErrorWorkloadRun = &ordinaryErrorWorkload{}
+
+			return ordinaryErrorWorkloadRun
+		})
+	})
 }
 
 type ordinaryErrorWorkload struct {

--- a/pkg/bench/runtime_test.go
+++ b/pkg/bench/runtime_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stroppy-io/stroppy/pkg/config"
 	_ "github.com/stroppy-io/stroppy/pkg/driver/noop"
@@ -33,7 +35,7 @@ func TestRunScenarioReturnsFatalErrorAndCancelsWorkers(t *testing.T) {
 		<-vu.Context().Done()
 
 		return vu.Context().Err()
-	})
+	}, nil)
 
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("runScenario() error = %v, want sentinel", err)
@@ -44,20 +46,84 @@ func TestRunScenarioReturnsFatalErrorAndCancelsWorkers(t *testing.T) {
 	}
 }
 
-func TestRunScenarioKeepsOrdinaryErrorsPerWorker(t *testing.T) {
+func TestRunScenarioContinuesAfterOrdinaryErrors(t *testing.T) {
 	installRuntimeTestRoot(t)
+
+	var (
+		calls    atomic.Int64
+		failures atomic.Int64
+	)
 
 	err := runScenario(context.Background(), scenarioSpec{
 		executor:   "shared-iterations",
 		vus:        1,
-		iterations: 1,
+		iterations: 5,
 	}, func(*VU) error {
+		calls.Add(1)
+
 		return errors.New("iteration")
+	}, func(*VU, error) {
+		failures.Add(1)
 	})
 	if err != nil {
 		t.Fatalf("runScenario() error = %v, want nil", err)
 	}
+	if calls.Load() != 5 || failures.Load() != 5 {
+		t.Fatalf("calls = %d, failures = %d, want 5 each", calls.Load(), failures.Load())
+	}
 }
+
+func TestRunContinuesAndSummarizesOrdinaryErrors(t *testing.T) {
+	var workload *ordinaryErrorWorkload
+	Register(func() Workload {
+		workload = &ordinaryErrorWorkload{}
+
+		return workload
+	})
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	err := Run(
+		context.Background(),
+		"test/ordinary-errors-continue",
+		map[int]*config.DriverConfig{0: {DriverType: config.DriverTypeNoop}},
+		ParamInputs{CLI: map[string]string{"iterations": "6", "vus": "2"}},
+		nil,
+		nil,
+		zap.New(core),
+		&MetricsConfig{},
+	)
+	if err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if workload.calls.Load() != 6 {
+		t.Fatalf("iteration calls = %d, want 6", workload.calls.Load())
+	}
+
+	snapshot := root.errorReporter.snapshot()
+	if snapshot.terminalErrors != 6 || snapshot.failedIterations != 6 || snapshot.failedQueries != 0 {
+		t.Fatalf("error summary = %#v, want six failed iterations", snapshot)
+	}
+	if got := logs.FilterMessage("nonfatal error; continuing").Len(); got != 1 {
+		t.Fatalf("initial nonfatal warnings = %d, want 1", got)
+	}
+	if got := logs.FilterLevelExact(zapcore.ErrorLevel).Len(); got != 0 {
+		t.Fatalf("error-level logs = %d, want 0", got)
+	}
+}
+
+type ordinaryErrorWorkload struct {
+	calls atomic.Int64
+}
+
+func (*ordinaryErrorWorkload) Name() string                        { return "test/ordinary-errors-continue" }
+func (*ordinaryErrorWorkload) Define(*Def) error                   { return nil }
+func (*ordinaryErrorWorkload) Setup(context.Context, *Bench) error { return nil }
+func (w *ordinaryErrorWorkload) Iterate(context.Context, *Bench) error {
+	w.calls.Add(1)
+
+	return errors.New("ordinary iteration failure")
+}
+func (*ordinaryErrorWorkload) Teardown(context.Context, *Bench) error { return nil }
 
 func TestRunRejectsNegativeQueryTimeout(t *testing.T) {
 	installRuntimeTestRoot(t)
@@ -89,7 +155,7 @@ func TestRunScenarioReturnsParentCancellation(t *testing.T) {
 		executor:   "shared-iterations",
 		vus:        1,
 		iterations: 1,
-	}, func(*VU) error { return nil })
+	}, func(*VU) error { return nil }, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("runScenario() error = %v, want context.Canceled", err)
 	}
@@ -174,6 +240,7 @@ func installRuntimeTestRoot(t *testing.T) {
 	root = testRoot
 
 	t.Cleanup(func() {
+		testRoot.errorReporter.stopAndWait()
 		testRoot.shutdownMetrics()
 
 		root = oldRoot

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,18 +59,6 @@ func DriverTypeValues() []DriverType {
 	}
 }
 
-// ErrorMode selects how query and insert errors are handled.
-type ErrorMode int32
-
-const (
-	ErrorModeUnspecified ErrorMode = 0
-	ErrorModeSilent      ErrorMode = 1
-	ErrorModeLog         ErrorMode = 2
-	ErrorModeThrow       ErrorMode = 3
-	ErrorModeFail        ErrorMode = 4
-	ErrorModeAbort       ErrorMode = 5
-)
-
 // TxIsolationLevel is the isolation level of a database transaction.
 type TxIsolationLevel int32
 
@@ -379,7 +367,6 @@ type DriverRunConfig struct {
 	DriverType            *string               `json:"driverType,omitempty"`
 	URL                   *string               `json:"url,omitempty"`
 	Pool                  *PoolConfig           `json:"pool,omitempty"`
-	ErrorMode             *string               `json:"errorMode,omitempty"`
 	BulkSize              *int32                `json:"bulkSize,omitempty"`
 	CaCertFile            *string               `json:"caCertFile,omitempty"`
 	AuthToken             *string               `json:"authToken,omitempty"`
@@ -403,14 +390,6 @@ func (c *DriverRunConfig) GetDriverType() string {
 func (c *DriverRunConfig) GetURL() string {
 	if c != nil && c.URL != nil {
 		return *c.URL
-	}
-
-	return ""
-}
-
-func (c *DriverRunConfig) GetErrorMode() string {
-	if c != nil && c.ErrorMode != nil {
-		return *c.ErrorMode
 	}
 
 	return ""
@@ -603,7 +582,6 @@ type DriverConfig struct {
 	// InsertRequest.Method unset.
 	DefaultInsertMethod   string                `json:"defaultInsertMethod,omitempty"`
 	BulkSize              *int32                `json:"bulkSize,omitempty"`
-	ErrorMode             ErrorMode             `json:"errorMode,omitempty"`
 	Postgres              *PostgresConfig       `json:"postgres,omitempty"`
 	SQL                   *SQLConfig            `json:"sql,omitempty"`
 	CaCertFile            *string               `json:"caCertFile,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -160,6 +160,7 @@ func TestRemovedFieldsAreAbsentFromPublicConfigTypes(t *testing.T) {
 	_, hasErrorMode := driverConfig.FieldByName("ErrorMode")
 	runtimeDriverConfig := reflect.TypeFor[config.DriverConfig]()
 	_, runtimeHasErrorMode := runtimeDriverConfig.FieldByName("ErrorMode")
+
 	require.False(t, hasDefaultTxIsolation)
 	require.False(t, hasErrorMode)
 	require.False(t, runtimeHasErrorMode)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -77,6 +77,8 @@ func TestRunConfigJSONRejects(t *testing.T) {
 		"unknown top-level field": `{"unknownField": 1}`,
 		"removed k6Args":          `{"k6Args": ["--vus", "10"]}`,
 		"removed k6Config":        `{"k6Config": "k6.json"}`,
+		"removed driver errorMode": `{"drivers":{"0":{
+			"driverType":"postgres","errorMode":"throw"}}}`,
 		"removed driver defaultTxIsolation": `{"drivers":{"0":{
 			"driverType":"postgres","defaultTxIsolation":"repeatable_read"}}}`,
 		"unknown driver field": `{"drivers":{"0":{"driverType":"postgres","unknown":true}}}`,
@@ -107,6 +109,18 @@ func TestRemovedFieldsUseOrdinaryUnknownFieldErrors(t *testing.T) {
 		{name: "k6 args alias", doc: `{"k6_args":[]}`, path: `$["k6_args"]`, field: "k6_args"},
 		{name: "k6 config", doc: `{"k6Config":"k6.json"}`, path: `$.k6Config`, field: "k6Config"},
 		{name: "k6 config alias", doc: `{"k6_config":"k6.json"}`, path: `$["k6_config"]`, field: "k6_config"},
+		{
+			name:  "driver error mode",
+			doc:   `{"drivers":{"0":{"errorMode":"throw"}}}`,
+			path:  `$.drivers["0"].errorMode`,
+			field: "errorMode",
+		},
+		{
+			name:  "driver error mode alias",
+			doc:   `{"drivers":{"0":{"error_mode":"throw"}}}`,
+			path:  `$.drivers["0"]["error_mode"]`,
+			field: "error_mode",
+		},
 		{
 			name:  "driver isolation",
 			doc:   `{"drivers":{"0":{"defaultTxIsolation":"serializable"}}}`,
@@ -143,14 +157,18 @@ func TestRemovedFieldsAreAbsentFromPublicConfigTypes(t *testing.T) {
 
 	driverConfig := reflect.TypeFor[config.DriverRunConfig]()
 	_, hasDefaultTxIsolation := driverConfig.FieldByName("DefaultTxIsolation")
+	_, hasErrorMode := driverConfig.FieldByName("ErrorMode")
+	runtimeDriverConfig := reflect.TypeFor[config.DriverConfig]()
+	_, runtimeHasErrorMode := runtimeDriverConfig.FieldByName("ErrorMode")
 	require.False(t, hasDefaultTxIsolation)
+	require.False(t, hasErrorMode)
+	require.False(t, runtimeHasErrorMode)
 }
 
 func TestJSONFieldNamesPreserved(t *testing.T) {
 	driver := config.DriverRunConfig{
 		DriverType:   ptr("postgres"),
 		URL:          ptr("postgres://x"),
-		ErrorMode:    ptr("throw"),
 		BulkSize:     ptr[int32](20),
 		CaCertFile:   ptr("/tls/ca.pem"),
 		AuthToken:    ptr("token"),
@@ -163,7 +181,6 @@ func TestJSONFieldNamesPreserved(t *testing.T) {
 	require.JSONEq(t, `{
 		"driverType": "postgres",
 		"url": "postgres://x",
-		"errorMode": "throw",
 		"bulkSize": 20,
 		"caCertFile": "/tls/ca.pem",
 		"authToken": "token",


### PR DESCRIPTION
## Summary

- remove the accepted-but-unused driver `errorMode` option from config, CLI overrides, schema, help, and active docs
- keep VUs running after nonfatal iteration errors while counting terminal iteration/query failures and retry attempts separately
- bound runtime warnings and final error-group summaries without raw-error metric cardinality
- preserve fatal, setup, validation, teardown, and signal-derived exit behavior

## Validation

- `make tests`
- `go test -race ./pkg/bench ./cmd/stroppy/commands/...`
- pinned `golangci-lint v2.12.2` under Go 1.26
- repeated registry/error reporter regressions with `-race -count=5`
- `make build` plus real noop and removed-option CLI runs

Closes #134


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nonfatal transaction and query errors now include failure and retry metrics.
  * Benchmark runs continue after nonfatal iteration errors with bounded warnings and a final summary.
  * Query cancellations stop remaining work and propagate correctly.
  * Exit status and error reporting now distinguish nonfatal failures from fatal, setup, teardown, and cancellation errors.

* **Bug Fixes**
  * Improved error handling across SQL, TPC-DS, and TPC-H workloads.

* **Breaking Changes**
  * The deprecated driver `errorMode` and `error_mode` settings are rejected as unknown fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->